### PR TITLE
Changes on IF interpolator

### DIFF
--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -460,9 +460,9 @@ def train_interpolators(i, path_to_csv_file, verbose=False):
     if 'CO-HMS_RLO' in grid_path:
         interp_method = [method, method]
         interp_classes = ["stable_MT", "unstable_MT"]
-    else:
-        interp_method = [method, method, method]
-        interp_classes = ["no_MT", "stable_MT", "unstable_MT"]
+    elif 'HMS-HMS' in grid_path:
+        interp_method = [method, method, method, method, method]
+        interp_classes = ["no_MT", "stable_MT","stable_reverse_MT" "unstable_MT","DoubleCE"]
 
     # TODO: train CC2 quantities coming from reverse MT systems
     interp = IFInterpolator(grid=grid, interpolators = [

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -462,7 +462,10 @@ def train_interpolators(i, path_to_csv_file, verbose=False):
         interp_classes = ["stable_MT", "unstable_MT"]
     elif 'HMS-HMS' in grid_path:
         interp_method = [method, method, method, method, method]
-        interp_classes = ["no_MT", "stable_MT","stable_reverse_MT" "unstable_MT","DoubleCE"]
+        interp_classes = ["no_MT", "stable_MT","stable_reverse_MT", "unstable_MT","DoubleCE"]
+    else:
+        interp_method = [method, method, method]
+        interp_classes = ["no_MT", "stable_MT", "unstable_MT"]
 
     # TODO: train CC2 quantities coming from reverse MT systems
     interp = IFInterpolator(grid=grid, interpolators = [

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -499,40 +499,40 @@ def train_interpolators(i, path_to_csv_file, verbose=False):
             "c_key": "interpolation_class"
         },
         {
-            "interp_method": [method, method, method],
-            "interp_classes": ["BH", "WD", "NS"],
+            "interp_method": [method, method, method, method],
+            "interp_classes": ["BH", "WD", "NS", "BH_reverse"],
             "out_keys": second,
             "class_method": "kNN",
             "c_keys": ['S1_direct_state'],
             "c_key": 'S1_direct_state'
         },
         {
-            "interp_method": [method, method, method],
-            "interp_classes": ["BH", "WD", "NS"],
+            "interp_method": [method, method, method, method],
+            "interp_classes": ["BH", "WD", "NS", "BH_reverse"],
             "out_keys": third,
             "class_method": "kNN",
             "c_keys": ['S1_Fryer+12-rapid_state'],
             "c_key": 'S1_Fryer+12-rapid_state'
         },
         {
-            "interp_method": [method, method, method],
-            "interp_classes": ["BH", "WD", "NS"],
+            "interp_method": [method, method, method, method],
+            "interp_classes": ["BH", "WD", "NS", "BH_reverse"],
             "out_keys": fourth,
             "class_method": "kNN",
             "c_keys": ['S1_Fryer+12-delayed_state'],
             "c_key": 'S1_Fryer+12-delayed_state'
         },
         {
-            "interp_method": [method, method, method],
-            "interp_classes": ["BH", "WD", "NS"],
+            "interp_method": [method, method, method, method],
+            "interp_classes": ["BH", "WD", "NS", "BH_reverse"],
             "out_keys": fifth,
             "class_method": "kNN",
             "c_keys": ['S1_Sukhbold+16-engineN20_state'],
             "c_key": 'S1_Sukhbold+16-engineN20_state'
         },
         {
-            "interp_method": [method, method, method],
-            "interp_classes": ["BH", "WD", "NS"],
+            "interp_method": [method, method, method, method],
+            "interp_classes": ["BH", "WD", "NS", "BH_reverse"],
             "out_keys": sixth,
             "class_method": "kNN",
             "c_keys": ['S1_Patton&Sukhbold20-engineN20_state'],

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -545,7 +545,7 @@ class StepSN(object):
                     CC_properites)
                 if star.state not in self.use_interp_values_classes:
                     for key in STARPROPERTIES:
-                        if key in [“state”, “SN_type”, “f_fb”, “mass”, “spin”]:
+                        if key in ["state", "SN_type", "f_fb", "mass", "spin"]:
                             setattr(star, key, None)
                 else:
                     for key in STARPROPERTIES:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -243,7 +243,7 @@ class StepSN(object):
                  sigma_kick_ECSN=MODEL['sigma_kick_ECSN'],
                  max_NS_mass=MODEL['max_NS_mass'],
                  use_interp_values=MODEL['use_interp_values'],
-                 use_interp_values_classes=MODEL['use_interp_values_classes']
+                 use_interp_values_classes=MODEL['use_interp_values_classes'],
                  use_profiles=MODEL['use_profiles'],
                  use_core_masses=MODEL['use_core_masses'],
                  approx_at_he_depletion=MODEL['approx_at_he_depletion'],

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -543,6 +543,8 @@ class StepSN(object):
                 CC_properites = getattr(star, key)
                 star.state, star.SN_type, star.f_fb, star.mass, star.spin = (
                     CC_properites)
+                if star.state == 'BH_reverse':
+                    star.state = 'BH'
                 if star.state not in self.use_interp_values_classes:
                     for key in STARPROPERTIES:
                         if key in ["state", "SN_type", "f_fb", "mass", "spin"]:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -78,6 +78,7 @@ MODEL = {
     "sigma_kick_ECSN": 20.0,
     "max_NS_mass": 2.5,
     "use_interp_values": True,
+    "use_interp_values_classes": ['BH'],
     "use_profiles": True,
     "use_core_masses": True,
     "approx_at_he_depletion": False,
@@ -242,6 +243,7 @@ class StepSN(object):
                  sigma_kick_ECSN=MODEL['sigma_kick_ECSN'],
                  max_NS_mass=MODEL['max_NS_mass'],
                  use_interp_values=MODEL['use_interp_values'],
+                 use_interp_values_classes=MODEL['use_interp_values_classes']
                  use_profiles=MODEL['use_profiles'],
                  use_core_masses=MODEL['use_core_masses'],
                  approx_at_he_depletion=MODEL['approx_at_he_depletion'],
@@ -269,6 +271,7 @@ class StepSN(object):
             self.sigma_kick_ECSN = sigma_kick_ECSN
             self.max_NS_mass = max_NS_mass
             self.use_interp_values = use_interp_values
+            self.use_interp_values_classes = use_interp_values_classes
             self.use_profiles = use_profiles
             self.use_core_masses = use_core_masses
             self.approx_at_he_depletion = approx_at_he_depletion
@@ -540,11 +543,15 @@ class StepSN(object):
                 CC_properites = getattr(star, key)
                 star.state, star.SN_type, star.f_fb, star.mass, star.spin = (
                     CC_properites)
-
-                for key in STARPROPERTIES:
-                    if key not in ["state", "mass", "spin"]:
-                        setattr(star, key, None)
-                return
+                if star.state not in self.use_interp_values_classes:
+                    for key in STARPROPERTIES:
+                        if key in [“state”, “SN_type”, “f_fb”, “mass”, “spin”]:
+                            setattr(star, key, None)
+                else:
+                    for key in STARPROPERTIES:
+                        if key not in ["state", "mass", "spin"]:
+                            setattr(star, key, None)
+                    return
 
             # Verifies the selection of core-collapse mechnism to perform
             # the collapse

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -549,6 +549,7 @@ class StepSN(object):
                     for key in STARPROPERTIES:
                         if key in ["state", "SN_type", "f_fb", "mass", "spin"]:
                             setattr(star, key, None)
+                    star.state = state
                 else:
                     for key in STARPROPERTIES:
                         if key not in ["state", "mass", "spin"]:

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -320,6 +320,11 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODEL=MODEL,
                     try:
                         star_copy = copy.copy(star)
                         SN.collapse_star(star_copy)
+                        if (star_copy.state =='BH' and
+                           interpolation_class == 'stable_reverse_MT'):
+                           EXTRA_COLUMNS[s+m[0]+m[1]].append(
+                               ['BH_reverse', star_copy.SN_type,
+                                star_copy.f_fb, star_copy.mass, star_copy.spin])
                         EXTRA_COLUMNS[s+m[0]+m[1]].append(
                             [star_copy.state, star_copy.SN_type,
                              star_copy.f_fb, star_copy.mass, star_copy.spin])

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -181,7 +181,7 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODEL=MODEL,
 
         # He depeltion and CE quantities
         for j, star in enumerate(stars):
-            if not stars_CO[j] and IC in ['no_MT', 'stable_MT', 'unstable_MT']:
+            if not stars_CO[j] and IC in ['no_MT', 'stable_MT', 'unstable_MT','stable_reverse_MT', 'DoubleCE']:
                 EXTRA_COLUMNS['S%s_state' % (j+1)].append(check_state_of_star(
                     star, star_CO=False))
                 with warnings.catch_warnings(record=True) as w:
@@ -257,7 +257,7 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODEL=MODEL,
 
         if not single_star:
             # core collpase quantities
-            if interpolation_class in ['no_MT', 'stable_MT']:
+            if interpolation_class in ['no_MT', 'stable_MT','stable_reverse_MT']:
                 if star_2_CO or TF1 == 'Primary has depleted central carbon':
                     star = binary.star_1
                     s = 'S1_'

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -325,9 +325,10 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODEL=MODEL,
                            EXTRA_COLUMNS[s+m[0]+m[1]].append(
                                ['BH_reverse', star_copy.SN_type,
                                 star_copy.f_fb, star_copy.mass, star_copy.spin])
-                        EXTRA_COLUMNS[s+m[0]+m[1]].append(
-                            [star_copy.state, star_copy.SN_type,
-                             star_copy.f_fb, star_copy.mass, star_copy.spin])
+                        else:
+                            EXTRA_COLUMNS[s+m[0]+m[1]].append(
+                                [star_copy.state, star_copy.SN_type,
+                                 star_copy.f_fb, star_copy.mass, star_copy.spin])
                         if verbose:
                             print(
                                 "{:<30} {:<33} {:10} {:6.2f} {:11.2f} {:14.2f}"

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1233,6 +1233,7 @@ class PSyGrid:
         configuration_string = hdf5.attrs["config"]
         config = ast.literal_eval(ast.literal_eval(configuration_string))
         self.config = ConfigFile()
+        self.config['accept_missing_profile'] = False
         self.config.update(config)
 
         # enumerate the runs included, and ensure that:

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -979,7 +979,8 @@ class PSyGrid:
 
                 if binary_grid:
                     self.final_values[i]["interpolation_class"] = \
-                        infer_interpolation_class(*termination_flags[:2])
+                        infer_interpolation_class(*termination_flags[:2], 
+                             binary_history,history1,history2)
 
             if ignore_data:
                 # if not fix requested and failed run, do not include it

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -28,7 +28,8 @@ import numpy as np
 
 from posydon.utils.common_functions import (
     infer_star_state, cumulative_mass_transfer_flag, infer_mass_transfer_case,
-    RL_RELATIVE_OVERFLOW_THRESHOLD, LG_MTRANSFER_RATE_THRESHOLD)
+    RL_RELATIVE_OVERFLOW_THRESHOLD,THRESHOLD_CENTRAL_ABUNDANCE, 
+    LG_MTRANSFER_RATE_THRESHOLD)
 from posydon.visualization.combine_TF import (
     TF1_POOL_STABLE, TF1_POOL_UNSTABLE,
     TF1_POOL_INITIAL_RLO, TF1_POOL_ERROR, TF2_POOL_NO_RLO
@@ -239,9 +240,9 @@ def infer_interpolation_class(tf1, tf2, binary_history, history1,history2):
                                      rl_overflow2<RL_RELATIVE_OVERFLOW_THRESHOLD)
             reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD,
                                      rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
-            reverse_postMS = np.logical_and(reverse, &
+            reverse_postMS = np.logical_and(reverse,
                                            center_h1<THRESHOLD_CENTRAL_ABUNDANCE)
-            if (np.max(forward) == True and np.max(reverse_postMT) == True):
+            if (np.max(forward) == True and np.max(reverse_postMS) == True):
                 return "stable_reverse_MT"
             else:
                 return "stable_MT"

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -235,12 +235,12 @@ def infer_interpolation_class(tf1, tf2, binary_history, history1,history2):
             rl_overflow1 = binary_history['rl_relative_overflow_1']
             rl_overflow2 = binary_history['rl_relative_overflow_2']
             center_h1 = history1['center_h1']
-            forward = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD, &
+            forward = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD,
                                      rl_overflow2<RL_RELATIVE_OVERFLOW_THRESHOLD)
-            reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD, &
+            reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD,
                                      rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
             reverse_postMS = np.logical_and(reverse, &
-                                            center_h1<THRESHOLD_CENTRAL_ABUNDANCE)
+                                           center_h1<THRESHOLD_CENTRAL_ABUNDANCE)
             if (np.max(forward) == True and np.max(reverse_postMT) == True):
                 return "stable_reverse_MT"
             else:
@@ -250,16 +250,16 @@ def infer_interpolation_class(tf1, tf2, binary_history, history1,history2):
         if (binary_history is not None and history1 is not None):
             rl_overflow1 = binary_history['rl_relative_overflow_1'][-1]
             rl_overflow2 = binary_history['rl_relative_overflow_2'][-1]
-            forward = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD, &
+            forward = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD,
                                      rl_overflow2<RL_RELATIVE_OVERFLOW_THRESHOLD)
-            reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD, &
+            reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD,
                                      rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
-            contact = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD, &
+            contact = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD,
                                      rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
             final_state_1 = check_state_from_history(history1,
-                                                     binary_history["star_1_mass"])
+                                                   binary_history["star_1_mass"])
             final_state_2 = check_state_from_history(history2,
-                                                     binary_history["star_2_mass"])
+                                                   binary_history["star_2_mass"])
             if (forward or contact):
                 if final_state_2 not in [
                         "H-rich_Core_H_burning",

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -222,7 +222,7 @@ def get_flags_from_MESA_run(MESA_log_path, binary_history=None,
     return flag_out, flag_mass_transfer, final_state_1, final_state_2
 
 
-def infer_interpolation_class(tf1, tf2):
+def infer_interpolation_class(tf1, tf2, binary_history, history1,history2):
     """Use the first two termination flags to infer the interpolation class."""
     if tf1 in TF1_POOL_INITIAL_RLO:
         return "initial_MT"
@@ -231,8 +231,52 @@ def infer_interpolation_class(tf1, tf2):
     if tf2 in TF2_POOL_NO_RLO:
         return "no_MT"
     if tf1 in TF1_POOL_STABLE:
+        if (binary_history is not None and history1 is not None):
+            rl_overflow1 = binary_history['rl_relative_overflow_1']
+            rl_overflow2 = binary_history['rl_relative_overflow_2']
+            center_h1 = history1['center_h1']
+            forward = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD, &
+                                     rl_overflow2<RL_RELATIVE_OVERFLOW_THRESHOLD)
+            reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD, &
+                                     rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
+            reverse_postMS = np.logical_and(reverse, &
+                                            center_h1<THRESHOLD_CENTRAL_ABUNDANCE)
+            if (np.max(forward) == True and np.max(reverse_postMT) == True):
+                return "stable_reverse_MT"
+            else:
+                return "stable_MT"
         return "stable_MT"
     if tf1 in TF1_POOL_UNSTABLE:
+        if (binary_history is not None and history1 is not None):
+            rl_overflow1 = binary_history['rl_relative_overflow_1'][-1]
+            rl_overflow2 = binary_history['rl_relative_overflow_2'][-1]
+            forward = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD, &
+                                     rl_overflow2<RL_RELATIVE_OVERFLOW_THRESHOLD)
+            reverse = np.logical_and(rl_overflow1<RL_RELATIVE_OVERFLOW_THRESHOLD, &
+                                     rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
+            contact = np.logical_and(rl_overflow1>RL_RELATIVE_OVERFLOW_THRESHOLD, &
+                                     rl_overflow2>RL_RELATIVE_OVERFLOW_THRESHOLD)
+            final_state_1 = check_state_from_history(history1,
+                                                     binary_history["star_1_mass"])
+            final_state_2 = check_state_from_history(history2,
+                                                     binary_history["star_2_mass"])
+            if (forward or contact):
+                if final_state_2 not in [
+                        "H-rich_Core_H_burning",
+                        "stripped_He_Core_He_burning", "WD", "NS", "BH"]:
+                    return "DoubleCE"
+                else:
+                    return "unstable_MT"
+
+            elif reverse:
+                if final_state_1 not in [
+                        "H-rich_Core_H_burning",
+                        "stripped_He_Core_He_burning", "WD", "NS", "BH"]:
+                    return "DoubleCE"
+                else:
+                    return "unstable_MT"
+            else:
+                return "unstable_MT"
         return "unstable_MT"
     return "unknown"
 

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -558,7 +558,24 @@ class BaseIFInterpolator:
 
         """
         XTn = self.X_scaler.normalize(self.XT[self.valid > 0, :])
-        YTn = self.Y_scaler.normalize(self.YT[self.valid > 0, :])
+        YT = self.YT[self.valid > 0, :]
+        YT_sort = np.insert(YT, 0, np.linspace(0,len(YT)-1,len(YT)), axis=1)
+        YT_list=[]
+        for classes in self.interp_classes:
+            YT_class = YT_sort[ic[self.valid > 0] == classes]
+            index = YT_class[:,0]
+            data = np.hsplit(YT_class,np.array([1]))[1]
+            self.Y_scaler = MatrixScaler(self.out_scaling,
+                                                     data)
+            YT_class_norm = self.Y_scaler.normalize(data)
+            YT_list.append(np.insert(YT_class_norm,0,index,axis=1))
+        for i in range(len(YT_list)):
+            if i ==0:
+                YT_sort_norm = YT_list[i]
+            else:
+                YT_sort_norm = np.concatenate((YT_sort_norm, YT_list[i]), axis=0)
+            YTn = YT_sort_norm[YT_sort_norm[:, 0].argsort()]
+        YTn = np.hsplit(YTn,np.array([1]))[1]
 
         if self.interp_method == "linear":
             self.interpolator = LinInterpolator()

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -567,7 +567,9 @@ class BaseIFInterpolator:
             index = YT_class[:,0]
             data = np.hsplit(YT_class,np.array([1]))[1]
             if classes == 'unstable_MT':
+                data[:,65][data[:,66]>=1e99] = 1e-5
                 data[:,66][data[:,66]>=1e99] = 1e-5
+                data[:,67][data[:,66]>=1e99] = 1e-5
             self.Y_scaler_norm.append(MatrixScaler(self.out_scaling,
                                                              data))
             YT_class_norm = self.Y_scaler_norm[i].normalize(data)

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -558,29 +558,7 @@ class BaseIFInterpolator:
 
         """
         XTn = self.X_scaler.normalize(self.XT[self.valid > 0, :])
-        YT = self.YT[self.valid > 0, :]
-        YT_sort = np.insert(YT, 0, np.linspace(0,len(YT)-1,len(YT)), axis=1)
-        YT_list=[]
-        self.Y_scaler_norm = []
-        for i, classes in enumerate(self.interp_classes):
-            YT_class = YT_sort[ic[self.valid > 0] == classes]
-            index = YT_class[:,0]
-            data = np.hsplit(YT_class,np.array([1]))[1]
-            if classes == 'unstable_MT':
-                data[:,65][data[:,66]>=1e99] = 1e-5
-                data[:,66][data[:,66]>=1e99] = 1e-5
-                data[:,67][data[:,66]>=1e99] = 1e-5
-            self.Y_scaler_norm.append(MatrixScaler(self.out_scaling,
-                                                             data))
-            YT_class_norm = self.Y_scaler_norm[i].normalize(data)
-            YT_list.append(np.insert(YT_class_norm,0,index,axis=1))
-        for i in range(len(YT_list)):
-            if i ==0:
-                YT_sort_norm = YT_list[i]
-            else:
-                YT_sort_norm = np.concatenate((YT_sort_norm, YT_list[i]), axis=0)
-            YTn = YT_sort_norm[YT_sort_norm[:, 0].argsort()]
-        YTn = np.hsplit(YTn,np.array([1]))[1]
+        YTn = self.Y_scaler.normalize(self.YT[self.valid > 0, :])
         
         if self.interp_method == "linear":
             self.interpolator = LinInterpolator()
@@ -609,22 +587,12 @@ class BaseIFInterpolator:
 
         """
         Xtn = self.X_scaler.normalize(Xt)
-        Ypredn = self.interpolator.predict(Xtn)
-        k = self.interp_classes.index(classes)
-        if classes in self.interp_classes and self.interp_in_q:
-            Ypredn = np.array([
-                list(sanitize_interpolated_quantities(
-                    dict(zip(self.out_keys, track)),
-                    self.constraints, verbose=False).values())
-                for track in self.Y_scaler_norm[k].denormalize(Ypredn)
-            ])
-        else:
-            Ypredn = np.array([
-                list(sanitize_interpolated_quantities(
-                    dict(zip(self.out_keys, track)),
-                    self.constraints, verbose=False).values())
-                for track in self.Y_scaler.denormalize(Ypredn)
-            ])
+        Ypredn = np.array([
+             list(sanitize_interpolated_quantities(
+                 dict(zip(self.out_keys, track)),
+                 self.constraints, verbose=False).values())
+             for track in self.Y_scaler.denormalize(Ypredn)
+         ])
         return Ypredn
 
     def train_classifiers(self, grid, method='kNN', **options):
@@ -751,8 +719,8 @@ class BaseIFInterpolator:
             raise Exception("Wrong dimensions. Xt should have as many "
                             "columns as it was trained with.")
         # if binary classified as 'initial_MT', set numerical quantities to nan
-        ycat = self.test_classifiers(Xt)
-        ynum= self.test_interpolator(Xt,ycat[self.c_key])
+        ynum, ycat = self.test_interpolator(Xt), self.test_classifiers(Xt)
+        
         if self.class_method != '1NN':
             ynum[ycat[self.c_key] == 'initial_MT', :] = np.nan
         if self.interp_method == '1NN':

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -566,6 +566,8 @@ class BaseIFInterpolator:
             YT_class = YT_sort[ic[self.valid > 0] == classes]
             index = YT_class[:,0]
             data = np.hsplit(YT_class,np.array([1]))[1]
+            if classes == 'unstable_MT':
+                data[:,66][data[:,66]>=1e99] = 1e-5
             self.Y_scaler_norm.append(MatrixScaler(self.out_scaling,
                                                              data))
             YT_class_norm = self.Y_scaler_norm[i].normalize(data)

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -1323,7 +1323,10 @@ class MatrixScaler:
         assert X.shape[1] == self.N
         Xn = np.empty_like(X)
         for i in range(self.N):
-            Xn[:, i] = self.scalers[i].transform(X[:, i])
+            if np.max(X[:, i]) == np.min(X[:, i]):
+                Xn[:, i] = X[:, i]
+            else:
+                Xn[:, i] = self.scalers[i].transform(X[:, i])
 
         return Xn
 
@@ -1332,7 +1335,10 @@ class MatrixScaler:
         assert Xn.shape[1] == self.N
         X = np.empty_like(Xn)
         for i in range(self.N):
-            X[:, i] = self.scalers[i].inv_transform(Xn[:, i])
+            if np.max(Xn[:, i]) == np.min(Xn[:, i]):
+                X[:, i] = Xn[:, i]
+            else:
+                X[:, i] = self.scalers[i].inv_transform(Xn[:, i])
         return X
 
 

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -1326,10 +1326,7 @@ class MatrixScaler:
         assert X.shape[1] == self.N
         Xn = np.empty_like(X)
         for i in range(self.N):
-            if (len(X[:, i])>1 and np.max(X[:, i]) == np.min(X[:, i])):
-                Xn[:, i] = X[:, i]
-            else:
-                Xn[:, i] = self.scalers[i].transform(X[:, i])
+            Xn[:, i] = self.scalers[i].transform(X[:, i])
 
         return Xn
 
@@ -1338,10 +1335,7 @@ class MatrixScaler:
         assert Xn.shape[1] == self.N
         X = np.empty_like(Xn)
         for i in range(self.N):
-            if (len(Xn[:, i])>1 and np.max(Xn[:, i]) == np.min(Xn[:, i])):
-                X[:, i] = Xn[:, i]
-            else:
-                X[:, i] = self.scalers[i].inv_transform(Xn[:, i])
+            X[:, i] = self.scalers[i].inv_transform(Xn[:, i])
         return X
 
 

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -607,14 +607,20 @@ class BaseIFInterpolator:
         Xtn = self.X_scaler.normalize(Xt)
         Ypredn = self.interpolator.predict(Xtn)
         k = self.interp_classes.index(classes)
-        
-        Ypredn = np.array([
-            list(sanitize_interpolated_quantities(
-                dict(zip(self.out_keys, track)),
-                self.constraints, verbose=False).values())
-            for track in self.Y_scaler_norm[k].denormalize(Ypredn)
-        ])
-
+        if classes in self.interp_classes and self.interp_in_q:
+            Ypredn = np.array([
+                list(sanitize_interpolated_quantities(
+                    dict(zip(self.out_keys, track)),
+                    self.constraints, verbose=False).values())
+                for track in self.Y_scaler_norm[k].denormalize(Ypredn)
+            ])
+        else:
+            Ypredn = np.array([
+                list(sanitize_interpolated_quantities(
+                    dict(zip(self.out_keys, track)),
+                    self.constraints, verbose=False).values())
+                for track in self.Y_scaler.denormalize(Ypredn)
+            ])
         return Ypredn
 
     def train_classifiers(self, grid, method='kNN', **options):

--- a/posydon/interpolation/data_scaling.py
+++ b/posydon/interpolation/data_scaling.py
@@ -121,25 +121,16 @@ class DataScaler:
                 "You have to fit a scaling object to a feature vector first")
 
         if self.method == 'min_max':
-            if self.params[1] == self.params[0]:
-                x_t = self.upper
-            else:
-                x_t = ((x - self.params[0]) / (self.params[1] - self.params[0])
-                       * (self.upper - self.lower) + self.lower)
+            x_t = ((x - self.params[0]) / (self.params[1] - self.params[0])
+                    * (self.upper - self.lower) + self.lower)
         elif self.method == 'log_min_max':
-            if self.params[1] == self.params[0]:
-                x_t = self.upper
-            else:
-                x_t = ((np.log10(x) - self.params[0])
-                       / (self.params[1] - self.params[0])
-                       * (self.upper - self.lower) + self.lower)
+            x_t = ((np.log10(x) - self.params[0])
+                    / (self.params[1] - self.params[0])
+                    * (self.upper - self.lower) + self.lower)
         elif self.method == 'neg_log_min_max':
-            if self.params[1] == self.params[0]:
-                x_t = self.upper
-            else:
-                x_t = ((np.log10(-x) - self.params[0])
-                       / (self.params[1] - self.params[0])
-                       * (self.upper - self.lower) + self.lower)
+            x_t = ((np.log10(-x) - self.params[0])
+                    / (self.params[1] - self.params[0])
+                    * (self.upper - self.lower) + self.lower)
         elif self.method == 'max_abs':
             x_t = x / self.params[0]
         elif self.method == 'log_max_abs':

--- a/posydon/interpolation/data_scaling.py
+++ b/posydon/interpolation/data_scaling.py
@@ -121,16 +121,25 @@ class DataScaler:
                 "You have to fit a scaling object to a feature vector first")
 
         if self.method == 'min_max':
-            x_t = ((x - self.params[0]) / (self.params[1] - self.params[0])
-                   * (self.upper - self.lower) + self.lower)
+            if self.params[1] == self.params[0]:
+                x_t = self.upper
+            else:
+                x_t = ((x - self.params[0]) / (self.params[1] - self.params[0])
+                       * (self.upper - self.lower) + self.lower)
         elif self.method == 'log_min_max':
-            x_t = ((np.log10(x) - self.params[0])
-                   / (self.params[1] - self.params[0])
-                   * (self.upper - self.lower) + self.lower)
+            if self.params[1] == self.params[0]:
+                x_t = self.upper
+            else:
+                x_t = ((np.log10(x) - self.params[0])
+                       / (self.params[1] - self.params[0])
+                       * (self.upper - self.lower) + self.lower)
         elif self.method == 'neg_log_min_max':
-            x_t = ((np.log10(-x) - self.params[0])
-                   / (self.params[1] - self.params[0])
-                   * (self.upper - self.lower) + self.lower)
+            if self.params[1] == self.params[0]:
+                x_t = self.upper
+            else:
+                x_t = ((np.log10(-x) - self.params[0])
+                       / (self.params[1] - self.params[0])
+                       * (self.upper - self.lower) + self.lower)
         elif self.method == 'max_abs':
             x_t = x / self.params[0]
         elif self.method == 'log_max_abs':

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1116,19 +1116,19 @@ def get_binary_state_and_event_and_mt_case(binary, interpolation_class=None,
 
     if rlof1 and rlof2:                             # contact condition
         result = ['contact', None, 'None']
-        if interpolation_class == 'unstable_MT':
+        if interpolation_class == 'unstable_MT' or 'DoubleCE':
             result = ['contact', 'oCE1', 'None']
     elif no_rlof:                                   # no MT in any star
         result = ['detached', None, 'None']
     elif rlof1 and not rlof2:                       # only in star 1
         result = ['RLO1', None, mt_flag_1_str]
-        if interpolation_class == 'unstable_MT':
+        if interpolation_class == 'unstable_MT' or 'DoubleCE':
             return ['RLO1', 'oCE1', mt_flag_1_str]
         # if prev_state not in ALL_RLO_CASES:
         #    return ['RLO1', 'oRLO1', mt_flag_1_str]
     elif rlof2 and not rlof1:                       # only in star 2
         result = ['RLO2', None, mt_flag_2_str]
-        if interpolation_class == 'unstable_MT':
+        if interpolation_class == 'unstable_MT' or 'DoubleCE':
             return ['RLO2', 'oCE2', mt_flag_2_str]
     else:                                           # undetermined in any star
         result = ["undefined", None, 'None']

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1116,19 +1116,19 @@ def get_binary_state_and_event_and_mt_case(binary, interpolation_class=None,
 
     if rlof1 and rlof2:                             # contact condition
         result = ['contact', None, 'None']
-        if interpolation_class == 'unstable_MT' or 'DoubleCE':
+        if (interpolation_class == 'unstable_MT' or interpolation_class == 'DoubleCE'):
             result = ['contact', 'oCE1', 'None']
     elif no_rlof:                                   # no MT in any star
         result = ['detached', None, 'None']
     elif rlof1 and not rlof2:                       # only in star 1
         result = ['RLO1', None, mt_flag_1_str]
-        if interpolation_class == 'unstable_MT' or 'DoubleCE':
+        if (interpolation_class == 'unstable_MT' or interpolation_class == 'DoubleCE'):
             return ['RLO1', 'oCE1', mt_flag_1_str]
         # if prev_state not in ALL_RLO_CASES:
         #    return ['RLO1', 'oRLO1', mt_flag_1_str]
     elif rlof2 and not rlof1:                       # only in star 2
         result = ['RLO2', None, mt_flag_2_str]
-        if interpolation_class == 'unstable_MT' or 'DoubleCE':
+        if (interpolation_class == 'unstable_MT' or interpolation_class == 'DoubleCE'):
             return ['RLO2', 'oCE2', mt_flag_2_str]
     else:                                           # undetermined in any star
         result = ["undefined", None, 'None']


### PR DESCRIPTION
Changes to improve IF interpolation:

- [ ] Add sub interpolation classes. This PR adds 'stable_reverse_MT', 'DoubleCE' as new grid classes and 'BH_reverse' as a new CC state class. Need to be more general to allow new classes. The way of reverting BH_reverse to BH in step_SN needs improvement.
- [ ] Implement class-wise normalization and de-normalization for final values. Now it only support HMS-HMS grid. 1e99 are not removed as the KNeighborsRegressor cannot do fit with None in the data.
- [x] Calculate NS properties using core_mass instead of interpolated values. 
- [x] Let normalization functions handle equal numbers.