### PR TITLE
Allowing for relative paths in the pipeline

### DIFF
--- a/bin/compress-mesa
+++ b/bin/compress-mesa
@@ -44,12 +44,12 @@ def set_up_test(args):
                         shutil.copytree(track_dirs[ind], os.path.join(
                             args.test_dir,
                             folder,
-                            track_dirs[ind].split("/")[-1]))
+                            os.path.split(track_dirs[ind])[1]))
                     else:
                         shutil.copy(track_dirs[ind], os.path.join(
                             args.test_dir,
                             folder,
-                            track_dirs[ind].split("/")[-1]))
+                            os.path.split(track_dirs[ind])[1]))
 
     print(f"Created Test Directory at {args.test_dir}.")
 

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -156,7 +156,7 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
                 for line in f.readlines():
                     if 'zams_filename' in line:
                         print("ZAMS_FILENAME detected, setting mesa_inlists['zams_filename']")
-                        zams_filename = line.split("'")[1].split("/")[1]
+                        zams_filename = os.path.split(line.split("'")[1])[1]
                         zams_file_path = os.path.join(inlists_dir, 'r11701', "ZAMS_models", zams_filename)
                         if os.path.isfile(zams_file_path):
                             print("Verified locations of ZAMS data file, {0}".format(zams_file_path))

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -83,14 +83,6 @@ def create_grid_slice(i, path_to_csv_file, STOP_BEFORE_CARBON_DEPLETION=True, ve
     grid_path = df.loc[i,'path_to_grid']
     compression = df.loc[i,'compression']
 
-#    grid_name = grid_path.split('/')[-1]
-#    otuput_path = os.path.join('/', os.path.join(*grid_path.split('/')[:-1]),
-#                               compression)
-#    grid_output = os.path.join(otuput_path, grid_name+'.h5')
-#
-#    # check that LITE/ or ORIGINAL/ directory exists
-#    if not os.path.isdir(otuput_path):
-#        os.makedirs(otuput_path)
     grid_output = get_new_grid_name(grid_path, compression,
                                     create_missing_directories=True)
 
@@ -160,7 +152,7 @@ def plot_grid(i, path_to_csv_file, verbose=False):
         print(f'plotting {grid_path}')
 
     # check that plots/ directories exist
-    plot_path = os.path.join('/', os.path.join(*plot_dir.split('/')[:-1]))
+    plot_path = os.path.split(os.path.normpath(plot_dir))[0]
     check_dirs = [plot_path, plot_dir]
 
     sub_dirs = ['TF12/', 'TF1/', 'TF2/', 'TF3/', 'TF4/', 'debug_mt/',
@@ -430,7 +422,7 @@ def train_interpolators(i, path_to_csv_file, verbose=False):
         print(f'train interpolators {grid_path} with method {method}')
 
     # check interpolation_objects directory exists
-    interp_path = os.path.join('/', os.path.join(*interpolator_path.split('/')[:-1]))
+    interp_path = os.path.split(interpolator_path)[0]
     if not os.path.isdir(interp_path):
         os.makedirs(interp_path)
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -202,14 +202,14 @@ class MesaGridStep:
             # Set the interpolation path
             if interpolation_path is None:
                 interpolation_path = (
-                    self.path + grid_name.split('/')[0]
+                    self.path + os.path.split(grid_name)[0]
                     + '/interpolators/%s/' % self.interpolation_method)
 
             # Set the interpolation filename
             if interpolation_filename is None:
                 interpolation_filename = (
                     interpolation_path
-                    + grid_name.split('/')[1].replace('h5', 'pkl'))
+                    + os.path.split(grid_name)[1].replace('h5', 'pkl'))
             else:
                 interpolation_filename = (interpolation_path
                                           + interpolation_filename)

--- a/posydon/utils/gridutils.py
+++ b/posydon/utils/gridutils.py
@@ -545,8 +545,14 @@ def get_new_grid_name(path, compression, create_missing_directories=False):
 
     """
     grid_name = path.split('/')[-1]
-    output_path = os.path.join('/', os.path.join(*path.split('/')[:-1]),
-                               compression)
+    if path[0]=='/':
+        #path is an absolute path
+        output_path = os.path.join('/', os.path.join(*path.split('/')[:-1]),
+                                   compression)
+    else:
+        #path is a relative path
+        output_path = os.path.join(os.path.join(*path.split('/')[:-1]),
+                                   compression)
     grid_output = os.path.join(output_path, grid_name+'.h5')
     if create_missing_directories:
         # check that LITE/ or ORIGINAL/ directory exists

--- a/posydon/utils/gridutils.py
+++ b/posydon/utils/gridutils.py
@@ -544,15 +544,8 @@ def get_new_grid_name(path, compression, create_missing_directories=False):
         File name for the new grid slice.
 
     """
-    grid_name = path.split('/')[-1]
-    if path[0]=='/':
-        #path is an absolute path
-        output_path = os.path.join('/', os.path.join(*path.split('/')[:-1]),
-                                   compression)
-    else:
-        #path is a relative path
-        output_path = os.path.join(os.path.join(*path.split('/')[:-1]),
-                                   compression)
+    grid_path, grid_name = os.path.split(os.path.normpath(path))
+    output_path = os.path.join(grid_path, compression)
     grid_output = os.path.join(output_path, grid_name+'.h5')
     if create_missing_directories:
         # check that LITE/ or ORIGINAL/ directory exists


### PR DESCRIPTION
So far, the code was always adding a `/` in front, hence assuming, that only absolute paths are given in the ini file of the pipeline. Now it checks, whether the path is absolute or relative and deals with it accordingly.