### PR TITLE
Adding option to set q_max to a user specified value

### DIFF
--- a/posydon/popsyn/independent_sample.py
+++ b/posydon/popsyn/independent_sample.py
@@ -305,7 +305,8 @@ def generate_primary_masses(number_of_binaries=1,
 
 
 def generate_secondary_masses(primary_masses,
-                              number_of_binaries=1,
+                              q_min = 0.05,
+                              q_max = 1.0,
                               secondary_mass_min=0.35,
                               secondary_mass_max=120,
                               secondary_mass_scheme='flat_mass_ratio',
@@ -318,8 +319,10 @@ def generate_secondary_masses(primary_masses,
     ----------
     primary_masses : ndarray of floats
         Previously drawn primary masses
-    number_of_binaries : int
-        Number of binaries that require randomly sampled orbital separations
+    q_min : float
+        Minimum secondary mass ratio
+    q_max : float
+        Maximum secondary mass ratio
     secondary_mass_min : float
         Minimum secondary mass
     secondary_mass_max : float
@@ -344,12 +347,18 @@ def generate_secondary_masses(primary_masses,
     if np.min(primary_masses) < secondary_mass_min:
         raise ValueError("`secondary_mass_min` is "
                          "larger than some primary masses")
+    
+    # Get the number of binaries
+    number_of_binaries = len(primary_masses)
 
     # Generate secondary masses
     if secondary_mass_scheme == 'flat_mass_ratio':
-        mass_ratio_min = np.max([secondary_mass_min / primary_masses,np.ones(len(primary_masses))*0.05], axis=0)
-        mass_ratio_max = np.min([secondary_mass_max / primary_masses,
-                                 np.ones(len(primary_masses))], axis=0)
+
+        mass_ratio_min = np.max([secondary_mass_min / primary_masses, np.ones(number_of_binaries)*q_min], 
+                                axis=0)
+        mass_ratio_max = np.min([secondary_mass_max / primary_masses, np.ones(number_of_binaries)*q_max], 
+                                axis=0)
+
         secondary_masses = (
             (mass_ratio_max - mass_ratio_min) * RNG.uniform(
                 size=number_of_binaries) + mass_ratio_min) * primary_masses


### PR DESCRIPTION
This update allows for a user to change the default initial minimum and maximum mass ratio of the two stars in the binary. Note that both the mass ratio limits and the secondary mass limits are simultaneously satisfied. This has been tested and is ready to go. 

Defaults are: 
`q_min = 0.05`
`q_max = 1.0`
`secondary_mass_min=0.35`
`secondary_mass_max=120`


An isolated test of the function:
```
In [22]: M1 = generate_primary_masses(number_of_binaries=1000)

In [23]: M2 = generate_secondary_masses(M1)

In [24]: q = M2/M1

In [25]: print(np.min(q), np.max(q), np.min(M2), np.max(M2))
0.055159202746417196 0.9978797254217177 0.4031951085983805 92.65663979838298

In [26]: M2 = generate_secondary_masses(M1, q_min=0.01, q_max=0.5)

In [27]: q = M2/M1

In [28]: print(np.min(q), np.max(q), np.min(M2), np.max(M2))
0.011247410652580144 0.49886272923081393 0.3504552319194787 54.75864549435622

In [29]: 

```