### PR TITLE
replace isnan

### DIFF
--- a/posydon/active_learning/psy_cris/classify.py
+++ b/posydon/active_learning/psy_cris/classify.py
@@ -376,7 +376,7 @@ class Classifier:
         which is useful for finding good or bad values.
 
         """
-        bool_row_index_where_nan = np.isnan(trans_probs.T[0])
+        bool_row_index_where_nan = pd.isna(trans_probs.T[0])
         # where_nan = np.where(bool_row_index_where_nan)[0]
         where_not_nan = np.where(~bool_row_index_where_nan)[0]
         # how_many_rows = len(trans_probs.T[0])

--- a/posydon/active_learning/psy_cris/data.py
+++ b/posydon/active_learning/psy_cris/data.py
@@ -393,7 +393,7 @@ class TableData:
                     converted_val = float(
                         val
                     )  # if fails -> straight to except (skips next line)
-                    if math.isnan(converted_val):
+                    if pd.isna(converted_val):
                         bad_cols.append(col_num)
                     else:
                         cols_with_float.append(col_num)

--- a/posydon/active_learning/psy_cris/regress.py
+++ b/posydon/active_learning/psy_cris/regress.py
@@ -243,9 +243,9 @@ class Regressor:
             Cleaned output data free of undefined values.
 
         """
-        if np.sum(np.isnan(training_y)) > 0:
-            where_undef = np.where(np.isnan(training_y))[0]
-            where_def = np.where(~np.isnan(training_y))[0]
+        if np.sum(pd.isna(training_y)) > 0:
+            where_undef = np.where(pd.isna(training_y))[0]
+            where_def = np.where(pd.notna(training_y))[0]
             need_to_clean = True
         elif self._undefined_p_change_val_ in training_y:
             where_undef = np.where(self._undefined_p_change_val_
@@ -770,7 +770,7 @@ class Regressor:
                 predicted_values_rbf = self._predict(
                     "RBF", class_key, col_key, cross_val_test_input
                 )
-                where_nan = np.where(np.isnan(predicted_values_linear))[0]
+                where_nan = np.where(pd.isna(predicted_values_linear))[0]
                 if len(where_nan) > 0:
                     print("{0}: {1} nan points out of {2}. Used rbf instead.".
                           format(regressor_key, len(where_nan),
@@ -886,7 +886,7 @@ class Regressor:
             p_diffs, diffs = self.cross_validate(
                 regressor_name, class_key, col_key, alpha, verbose=verbose
             )
-            where_not_nan = np.where(np.invert(np.isnan(p_diffs)))[0]
+            where_not_nan = np.where(pd.notna(p_diffs))[0]
 
             p_diffs_holder.append(p_diffs[where_not_nan])
 

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -511,7 +511,7 @@ class StepCEE(object):
             ebind_i = (-const.standard_cgrav / lambda1_CE
                        * (m1_i * const.Msun * (m1_i - mc1_i) * const.Msun)
                        / (radius1 * const.Rsun))
-        if (double_CE and (not pd.isna(lambda2_CE))):
+        if (double_CE and pd.notna(lambda2_CE)):
             ebind_i += (-const.standard_cgrav / lambda2_CE
                         * (m2_i * const.Msun * (m2_i - mc2_i) * const.Msun)
                         / (radius2 * const.Rsun))

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -828,7 +828,7 @@ class detached_step:
                 initials = sol.x
 
         if self.verbose:
-            if not np.isnan(initials[0]):
+            if pd.notna(initials[0]):
                 print(
                     "Matching completed for", star.state, "star!\n"
                     f"Matched to track with intial mass m0 = {initials[0]:.3f} [Msun]"
@@ -1136,8 +1136,8 @@ class detached_step:
 
             if (star.log_total_angular_momentum is not None
                     and star.total_moment_of_inertia is not None
-                    and not np.isnan(star.log_total_angular_momentum)
-                    and not np.isnan(star.total_moment_of_inertia)):
+                    and pd.notna(star.log_total_angular_momentum)
+                    and pd.notna(star.total_moment_of_inertia)):
                 
                 # the last factor converts rad/s to rad/yr
                 omega_in_rad_per_year = (
@@ -1151,17 +1151,16 @@ class detached_step:
                 # (although the critical rotation should be improved to
                 # take into account radiation pressure)
 
-                if (star.surf_avg_omega is not None and not np.isnan(star.surf_avg_omega)):
+                if pd.notna(star.surf_avg_omega):
 
                     if self.verbose:
                         print("calculating initial omega using surf_avg_omega")
 
                     omega_in_rad_per_year = star.surf_avg_omega * const.secyer                    
                         
-                elif (star.surf_avg_omega_div_omega_crit is not None
-                        and not np.isnan(star.surf_avg_omega_div_omega_crit)):
+                elif pd.notna(star.surf_avg_omega_div_omega_crit):
                     
-                    if (star.log_R is not None and not np.isnan(star.log_R)):
+                    if pd.notna(star.log_R):
                         omega_in_rad_per_year = (
                             star.surf_avg_omega_div_omega_crit * np.sqrt(
                                 const.standard_cgrav * star.mass * const.msol
@@ -2091,9 +2090,9 @@ def diffeq(
         f5 = 1 + 3 * e ** 2 + (3 / 8) * e ** 4
 
         # equilibrium timecale
-        if ((M_env_sec != 0.0 and not np.isnan(M_env_sec))
-                and (DR_env_sec != 0.0 and not np.isnan(DR_env_sec)) and (
-                    Renv_middle_sec != 0.0 and not np.isnan(Renv_middle_sec))):
+        if ((pd.notna(M_env_sec) and M_env_sec != 0.0)
+                and (pd.notna(DR_env_sec) and DR_env_sec != 0.0)
+                and (pd.notna(Renv_middle_sec) and Renv_middle_sec != 0.0)):
             # eq. (31) of Hurley et al. 2002, generalized for convective layers
             # not on surface too
             tau_conv_sec = 0.431 * ((M_env_sec * DR_env_sec * Renv_middle_sec
@@ -2103,9 +2102,9 @@ def diffeq(
                 print("something wrong with M_env/DR_env/Renv_middle",
                       M_env_sec, DR_env_sec, Renv_middle_sec)
             tau_conv_sec = 1.0e99
-        if ((M_env_pri != 0.0 and not np.isnan(M_env_pri))
-                and (DR_env_pri != 0.0 and not np.isnan(DR_env_pri)) and (
-                    Renv_middle_pri != 0.0 and not np.isnan(Renv_middle_pri))):
+        if ((pd.notna(M_env_pri) and M_env_pri != 0.0)
+                and (pd.notna(DR_env_pri) and DR_env_pri != 0.0)
+                and (pd.notna(Renv_middle_pri) and Renv_middle_pri != 0.0)):
             # eq. (31) of Hurley et al. 2002, generalized for convective layers
             # not on surface too
             tau_conv_pri = 0.431 * ((M_env_pri * DR_env_pri * Renv_middle_pri

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1123,7 +1123,7 @@ class PSyGrid:
                 for colname, value in grid_point.items():
                     if colname in self.initial_values.dtype.names:
                         self.initial_values[i][colname] = value
-                if np.isnan(self.initial_values[i]["Z"]):
+                if pd.isna(self.initial_values[i]["Z"]):
                     # try to get metallicity from directory name
                     params_from_path = initial_values_from_dirname(run.path)
                     if (len(params_from_path)==4) or\
@@ -1940,8 +1940,8 @@ class PSyGrid:
                         format(colname, tablename))
                 if np.any(data1 != data2):
                     for val1, val2 in zip(data1, data2):
-                        if ((val1 == val2) or (val1 is None and val2 is None)
-                                or (np.isnan(val1) and np.isnan(val2))):
+                        if ((val1 == val2) or (pd.isna(val1)
+                                               and pd.isna(val2))):
                             continue
                         say("Column `{}` in `{}` is not the same ({} != {}).".
                             format(colname, tablename, val1, val2))

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -180,6 +180,7 @@ from posydon.interpolation.data_scaling import DataScaler
 from posydon.utils.posydonwarning import Pwarn
 # Maths
 import numpy as np
+import pandas as pd
 # Machine Learning
 from scipy.interpolate import LinearNDInterpolator
 from sklearn.neighbors import KNeighborsRegressor
@@ -458,13 +459,13 @@ class BaseIFInterpolator:
                     key for key in grid.final_values.dtype.names
                     if key != "model_number"
                     and (type(grid.final_values[key][0]) != np.str_)
-                    and any(~np.isnan(grid.final_values[key]))
+                    and any(pd.notna(grid.final_values[key]))
                 ]
             if self.out_nan_keys is None:
                 self.out_nan_keys = [
                     key for key in grid.final_values.dtype.names
                     if type(grid.final_values[key][0]) != np.str_
-                    and all(np.isnan(grid.final_values[key]))
+                    and all(pd.isna(grid.final_values[key]))
                 ]
 
             self.constraints = find_constraints_to_apply(self.out_keys)
@@ -489,7 +490,7 @@ class BaseIFInterpolator:
                 print("\nFilling missing values (nans) with 1NN")
                 self._fillNans(grid.final_values[self.c_key])
             elif self.interp_method == '1NN':
-                self.YT[np.isnan(self.YT)] = -100
+                self.YT[pd.isna(self.YT)] = -100
 
             if (self.in_scaling is None) or (self.out_scaling is None):
                 if self.interp_method == '1NN':
@@ -606,7 +607,7 @@ class BaseIFInterpolator:
             print(f"Discarded {np.sum(which)} binaries with "
                   f"interpolation_class = [{flag}]")
 
-        which = np.isnan(np.sum(X, axis=1))
+        which = pd.isna(np.sum(X, axis=1))
         valid[which] = -1
         print(f"Discarded {np.sum(which)} binaries with nans in input values.")
         for i, flag in enumerate(self.valid_classes):
@@ -861,7 +862,7 @@ class BaseIFInterpolator:
         m1 = grid.initial_values['star_1_mass'].copy()
         m2 = grid.initial_values['star_2_mass'].copy()
         # Make sure nans do not affect
-        wnan = np.isnan(m1) | np.isnan(m2)
+        wnan = pd.isna(m1) | pd.isna(m2)
         m1, m2 = m1[~wnan], m2[~wnan]
 
         tol = 1
@@ -982,7 +983,7 @@ class BaseIFInterpolator:
 
             out_scaling = []
             for i in range(self.n_out):
-                if where_min[i] < r or np.isnan(where_min[i]):
+                if where_min[i] < r or pd.isna(where_min[i]):
                     out_scaling.append(out_scalings[0][i])
                 else:
                     out_scaling.append(out_scalings[1][i])
@@ -1006,7 +1007,7 @@ class BaseIFInterpolator:
     def _fillNans(self, ic):
         """Fill nan values i numerical magnitudes with 1NN."""
         for i in range(self.n_out):
-            wnan = np.isnan(self.YT[:, i]) | np.isinf(self.YT[:, i])
+            wnan = pd.isna(self.YT[:, i]) | np.isinf(self.YT[:, i])
             if any(np.isinf(self.YT[:, i])):
                 print(f"inftys: {np.sum(np.isinf(self.YT[:, i]))}, "
                       f"{self.out_keys[i]}")
@@ -1155,7 +1156,7 @@ class LinInterpolator(Interpolator):
         super().predict(Xt)
 
         Ypred = self.interpolator[0](Xt)
-        wnan = np.isnan(Ypred[:, 0])
+        wnan = pd.isna(Ypred[:, 0])
         # 1NN interpolation for binaries out of hull
         if np.any(wnan):
             Ypred[wnan, :] = self.interpolator[1].predict(Xt[wnan, :])
@@ -1516,7 +1517,7 @@ class MatrixScaler:
         self.scalers = []
         for i in range(self.N):
             self.scalers.append(DataScaler())
-            which = ~np.isnan(XT[:, i])
+            which = pd.notna(XT[:, i])
             self.scalers[i].fit(XT[which, i], method=norms[i])
 
     def normalize(self, X):
@@ -1802,7 +1803,7 @@ def analize_nans(out_keys, YT, valid):
     for i, key in enumerate(out_keys):
         n = []
         for v in range(4):
-            n.append(np.sum(np.isnan(YT[valid == v, i])))
+            n.append(np.sum(pd.isna(YT[valid == v, i])))
         if np.sum(np.array(n)) > 0:
             print(f"[i_MT] = {n[0]:5d}, [no_MT] = {n[1]:5d}, "
                   f"[st_MT] = {n[2]:5d}, [u_MT] = {n[3]:5d} : {i:3d} {key}")

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -8,6 +8,7 @@ __authors__ = [
 
 import pickle
 import numpy as np
+import pandas as pd
 from sklearn.neighbors import NearestNeighbors
 from .data_scaling import DataScaler
 from posydon.grids.psygrid import PSyGrid
@@ -100,9 +101,9 @@ class psyTrackInterp:
         # mask out binaries with any nan value
         # mask = np.logical_and(self.grid.final_values['interpolation_class']
         #                       != 'not_converged',
-        # np.invert([np.isnan(XTn)[x,:].any() for x in range(XTn.shape[0])]))
+        # np.invert([pd.isna(XTn)[x,:].any() for x in range(XTn.shape[0])]))
         mask = (self.grid.final_values['interpolation_class']
-                != 'not_converged') & ~np.isnan(np.sum(XT, axis=1))
+                != 'not_converged') & pd.notna(np.sum(XT, axis=1))
         self.valid_ind = np.arange(XT.shape[0])[mask]
 
         if self.method == 'NearestNeighbor':
@@ -602,7 +603,7 @@ class GRIDInterpolator():
                 self.load_grid(mass_low)
                 kvalue_low = self.grid_final_values[mass_low][key]
 
-            while (kvalue_low is None or np.isnan(kvalue_low)):
+            while pd.isna(kvalue_low):
                 # escape if no lower mass is available
                 if np.sum(mass_low > self.grid_mass) == 0:
                     break
@@ -619,7 +620,7 @@ class GRIDInterpolator():
                 self.load_grid(mass_high)
                 kvalue_high = self.grid_final_values[mass_high][key]
 
-            while (kvalue_high is None or np.isnan(kvalue_high)):
+            while pd.isna(kvalue_high):
                 # escape if no higher mass is available
                 if np.sum(mass_high < self.grid_mass) == 0:
                     break

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -1517,7 +1517,7 @@ class Population(PopulationIO):
             )
             events = self.history.select(start=previous, stop=end, columns=["event"])
 
-            mask = ~pd.isna(interp_class_HMS_HMS["interp_class_HMS_HMS"].values)
+            mask = pd.notna(interp_class_HMS_HMS["interp_class_HMS_HMS"].values)
             interp_class_HMS_HMS.loc[mask, "interp_class_HMS_HMS"] = (
                 interp_class_HMS_HMS[mask]
                 .apply(lambda x: HMS_HMS_event_dict[x["interp_class_HMS_HMS"]], axis=1)

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -289,7 +289,7 @@ def DCO_detectability(sensitivity, transient_pop_chunk, z_events_chunk, z_weight
     detectable_weights = z_weights_chunk.to_numpy()
     for i in tqdm(range(z_events_chunk.shape[1]), total=z_events_chunk.shape[1], disable= not verbose):
         data_slice['z'] = z_events_chunk.iloc[:,i]
-        mask = ~np.isnan(data_slice['z']).to_numpy()
+        mask = pd.notna(data_slice['z']).to_numpy()
         if np.sum(mask) == 0:
             detectable_weights[mask, i] = 0.0
         else:

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -2126,12 +2126,12 @@ def period_change_stable_MT(period_i, Mdon_i, Mdon_f, Macc_i,
 def linear_interpolation_between_two_cells(array_y, array_x, x_target,
                                            top=None, bot=None, verbose=False):
     """Interpolate quantities between two star profile shells."""
-    if ((top is None or np.isnan(top)) and (bot is None or np.isnan(bot))):
+    if (pd.isna(top) and pd.isna(bot)):
         top = np.argmax(array_x >= x_target)
         bot = top - 1
-    elif bot is None or np.isnan(bot):
+    elif pd.isna(bot):
         bot = top - 1
-    elif top is None or np.isnan(top):
+    elif pd.isna(top):
         top = bot + 1
 
     if top >= len(array_y):
@@ -2252,7 +2252,7 @@ def calculate_lambda_from_profile(
     # get mass and radius and dm from profile
     donor_mass, donor_radius, donor_dm = get_mass_radius_dm_from_profile(
         profile, m1_i, radius1, tolerance)
-    # if np.isnan(m1_i) or m1_i is None or np.isnan(radius1) or radius1 is None
+    # if pd.isna(m1_i) or pd.isna(radius1)
     m1_i = donor_mass[0]
     radius1 = donor_radius[0]
     specific_internal_energy = get_internal_energy_from_profile(
@@ -2321,7 +2321,7 @@ def calculate_lambda_from_profile(
               m1_i, radius1, len(donor_mass), " vs ", ind_core, mc1_i, rc1_i)
         print("Ebind_i from profile ", Ebind_i)
         print("lambda_CE ", lambda_CE)
-    if not (lambda_CE > -tolerance) and not np.isnan(lambda_CE):
+    if not (lambda_CE > -tolerance) and pd.notna(lambda_CE):
         raise ValueError("lambda_CE has a negative value")
     return lambda_CE, mc1_i, rc1_i
 

--- a/posydon/visualization/VH_diagram/Presenter.py
+++ b/posydon/visualization/VH_diagram/Presenter.py
@@ -18,6 +18,7 @@ from posydon.config import PATH_TO_POSYDON
 from datetime import datetime
 import os
 import numpy as np
+import pandas as pd
 
 
 def to_megayears(nb):
@@ -165,18 +166,18 @@ def get_max_distance(data):
 
     """
     if data["separation"].state_after is not None:
-        if np.isnan(data["separation"].state_after) or (
+        if pd.isna(data["separation"].state_after) or (
             data["separation"].state_before > data["separation"].state_after
         ):
             return (
                 data["separation"].state_before
-                if (not np.isnan(data["separation"].state_before))
+                if pd.notna(data["separation"].state_before)
                 else 0
             )
         else:
             return data["separation"].state_after
     else:
-        if np.isnan(data["separation"].state_before):
+        if pd.isna(data["separation"].state_before):
             return 0
         else:
             return data["separation"].state_before
@@ -638,9 +639,7 @@ class Presenter:
         if max_distance == 0:
             return 0
 
-        if simplified_distance.state_after is not None and not np.isnan(
-            simplified_distance.state_after
-        ):
+        if pd.notna(simplified_distance.state_after):
             if simplified_distance.state_after < 1:
                 simplified_distance.state_after = 1
             if max_distance < 1:
@@ -650,7 +649,7 @@ class Presenter:
                     / np.log(max_distance))
 
         else:
-            if np.isnan(simplified_distance.state_before):
+            if pd.isna(simplified_distance.state_before):
                 return 0
             elif simplified_distance.state_before < 1:
                 simplified_distance.state_before = 1

--- a/posydon/visualization/interpolation.py
+++ b/posydon/visualization/interpolation.py
@@ -7,6 +7,7 @@ __authors__ = [
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 
 class EvaluateIFInterpolator:
     """ Class that is helpful for evaluating interpolation performance
@@ -146,7 +147,7 @@ class EvaluateIFInterpolator:
 
     def __clean_errs(self, errs):
 
-        errs = errs[~np.isnan(errs).any(axis = 1)] # dropping nans
+        errs = errs[pd.notna(errs).any(axis = 1)] # dropping nans
         errs = errs[~np.isinf(errs).any(axis = 1)] # dropping infs
 
         return errs

--- a/posydon/visualization/plot2D.py
+++ b/posydon/visualization/plot2D.py
@@ -14,6 +14,7 @@ __authors__ = [
 ]
 
 import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
 from posydon.utils.gridutils import add_field
 from posydon.utils.constants import Zsun
@@ -506,9 +507,9 @@ class plot2D(object):
                     for i in range(len(self.x_var[selection])):
                         if not isinstance(self.x_var_oRLO[selection][i],
                                           float):
-                            if (not any(np.isnan(
+                            if (not any(pd.isna(
                                 self.x_var_oRLO[selection][i]))
-                                    and not any(np.isnan(
+                                    and not any(pd.isna(
                                         self.y_var_oRLO[selection][i]))):
                                 plt.plot(
                                     self.x_var[selection][i],
@@ -562,8 +563,8 @@ class plot2D(object):
                             if not isinstance(self.x_var_oRLO[selection][i],
                                               float):
                                 if not any(
-                                    np.isnan(self.x_var_oRLO[selection][i])
-                                ) and not any(np.isnan(
+                                    pd.isna(self.x_var_oRLO[selection][i])
+                                ) and not any(pd.isna(
                                         self.y_var_oRLO[selection][i])):
                                     plt.plot(
                                         self.x_var[selection][i],
@@ -793,11 +794,11 @@ class plot2D(object):
         # fix max min color bar
         if self.z_var is not None:
             if self.zmin is None:
-                not_nan = np.invert(np.isnan(self.z_var))
+                not_nan = pd.notna(self.z_var)
                 self.zmin = min(self.z_var[not_nan])
 
             if self.zmax is None:
-                not_nan = np.invert(np.isnan(self.z_var))
+                not_nan = pd.notna(self.z_var)
                 self.zmax = max(self.z_var[not_nan])
 
     def get_x_var(self):
@@ -1243,9 +1244,9 @@ class plot2D(object):
                             for i in range(len(self.x_var[selection])):
                                 if not isinstance(self.x_var_oRLO[selection]
                                                   [i], float):
-                                    if (not any(np.isnan(
+                                    if (not any(pd.isna(
                                          self.x_var_oRLO[selection][i]))
-                                        and not any(np.isnan(
+                                        and not any(pd.isna(
                                          self.y_var_oRLO[selection][i]))):
                                         ax.plot(
                                             self.x_var[selection][i],
@@ -1301,9 +1302,9 @@ class plot2D(object):
                                 for i in range(len(self.x_var[selection])):
                                     if not isinstance(self.x_var_oRLO
                                                       [selection][i], float):
-                                        if not any(np.isnan(
+                                        if not any(pd.isna(
                                              self.x_var_oRLO[selection][i]))\
-                                            and not any(np.isnan(
+                                            and not any(pd.isna(
                                              self.y_var_oRLO[selection][i])):
                                             ax.plot(
                                                 self.x_var[selection][i],


### PR DESCRIPTION
It is saver to use pandas functions to check for `nan`s as they are able to handle `None` as well, while treating it the same as `nan`.

- [x] replace `~np.isnan(x)`, `not np.isnan(x)`, and `np.invert(np.isnan(x))` by `pd.notna(x)` and simplify `x is not None and not np.isnan(x)` to `pd.notna(x)`
- [x] replace `math.isnan(x)` and `np.isnan(x)` by `pd.isna(x)` and simplify `x is None or np.isnan(x)` to `pd.isna(x)`
- [x] no replacements in tests, to ensure that the value is really `nan` and not `None`.
- [x] tested on small pop-syn

P.S.: Replacement in `step_SN.py` skipped as it is included in PR #482 .