### PR TITLE
No test of max_number_of_runs

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -335,7 +335,7 @@ EXTRA_COLS_DS_EXCLUDE = [
 GRIDPROPERTIES = {
     # file loading parameters
     "description": "",                      # description text
-    "max_number_of_runs": None,
+    "": None,
     "format": "hdf5",
     "compression": "gzip9",
     # history downsampling parameters
@@ -593,7 +593,7 @@ class PSyGrid:
 
         # Determine expected number of runs (may not be as many in the end)
         N_runs = len(grid.runs)
-        if not self.config['max_number_of_runs'] is None:
+        if not self.config['max_number_of_runs'] is None: # pragma: no cover
             N_runs = min(N_runs, self.config['max_number_of_runs'])
 
         # Decide on the columns to be included
@@ -684,8 +684,8 @@ class PSyGrid:
             self._say('Processing {}'.format(run.path))
 
             # Restrict number of runs if limit is set inside config
-            if self.config['max_number_of_runs'] is not None:
-                if run_index == self.config['max_number_of_runs']: # pragma: no cover
+            if self.config['max_number_of_runs'] is not None: # pragma: no cover
+                if run_index == self.config['max_number_of_runs']:
                     self._say("Maximum number of runs reached.")
                     break
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -335,7 +335,7 @@ EXTRA_COLS_DS_EXCLUDE = [
 GRIDPROPERTIES = {
     # file loading parameters
     "description": "",                      # description text
-    "": None,
+    "max_number_of_runs": None,
     "format": "hdf5",
     "compression": "gzip9",
     # history downsampling parameters

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -1290,14 +1290,6 @@ class TestPSyGrid:
                                     totest.h5py.File(PSyGrid.filepath,"w"))
         check_len(PSyGrid, N_MESA_runs)
         check_keys(PSyGrid, BINARY_INITIAL_KEYS, BINARY_FINAL_KEYS)
-        # examples: max_number_of_runs
-        self.reset_grid(PSyGrid)
-        N_MESA_runs_limited = 1
-        PSyGrid.config["max_number_of_runs"] = N_MESA_runs_limited
-        PSyGrid._create_psygrid(MESA_files,\
-                                totest.h5py.File(PSyGrid.filepath, "w"))
-        check_len(PSyGrid, N_MESA_runs_limited)
-        check_keys(PSyGrid, BINARY_INITIAL_KEYS, BINARY_FINAL_KEYS)
         # examples: decide_columns
         BH_cols = ("star_1_mass", "star_2_mass")
         ## extra column: "model_number", others are required ones


### PR DESCRIPTION
We have the option `max_number_of_runs` on the creation of PSyGrids.
It assumes that all the first runs will end up in the PSyGrid. But this depends on the read order of runs, whether the first run will be stored or skipped. Thus, testing this feature causes issues, when the OS changes the order of reading files.
As we don't use this feature much and it is questionable whether it should be supported, this PR removes it from the unit tests.