### PR TITLE
Move closing grid to TrackMatcher

### DIFF
--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -109,7 +109,7 @@ class SimulationProperties:
             if isinstance(step_func, MesaGridStep):
                 step_func.close()
             elif isinstance(step_func, detached_step):
-                for grid_interpolator in [step_func.grid_Hrich, step_func.grid_strippedHe]:
+                for grid_interpolator in [step_func.track_matcher.grid_Hrich, step_func.track_matcher.grid_strippedHe]:
                     grid_interpolator.close()
 
     def pre_evolve(self, binary):


### PR DESCRIPTION
The `grid_Hrich` and `grid_strippedHe` got moved into the `TrackMatcher` instance. Currently, this fails to close the grid at the end of a population run. This closes them inside the `TrackMatcher`.