### PR TITLE
add try/finally around evolution of single binary

### DIFF
--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -238,7 +238,8 @@ class BinaryStar:
                     
         finally:
             signal.alarm(0)     # turning off alarm
-            self.properties.post_evolve(self)
+            
+        self.properties.post_evolve(self)
 
     def run_step(self):
         """Evolve the binary through one evolutionary step."""

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -23,7 +23,8 @@ __authors__ = [
     "Philipp Moura Srivastava <philipp.msrivastava@gmail.com>",
     "Devina Misra <devina.misra@unige.ch>",
     "Scott Coughlin <scottcoughlin2014@u.northwestern.edu>",
-    "Seth Gossage <seth.gossage@northwestern.edu>"
+    "Seth Gossage <seth.gossage@northwestern.edu>",
+    "Max Briel <max.briel@gmail.com>"
 ]
 
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -223,19 +223,22 @@ class BinaryStar:
         max_n_steps = self.properties.max_n_steps_per_binary
         n_steps = 0
 
-        while (self.event != 'END' and self.event != 'FAILED'
+        try:
+            while (self.event != 'END' and self.event != 'FAILED'
                 and self.event not in self.properties.end_events
                 and self.state not in self.properties.end_states):
 
-            signal.alarm(MAXIMUM_STEP_TIME)
-            self.run_step()
+                signal.alarm(MAXIMUM_STEP_TIME)
+                self.run_step()
 
-            n_steps += 1
-            if max_n_steps is not None:
-                if n_steps > max_n_steps:
-                    raise RuntimeError("Exceeded maximum number of steps ({})".format(max_n_steps))
-        signal.alarm(0)     # turning off alarm
-        self.properties.post_evolve(self)
+                n_steps += 1
+                if max_n_steps is not None:
+                    if n_steps > max_n_steps:
+                        raise RuntimeError("Exceeded maximum number of steps ({})".format(max_n_steps))
+                    
+        finally:
+            signal.alarm(0)     # turning off alarm
+            self.properties.post_evolve(self)
 
     def run_step(self):
         """Evolve the binary through one evolutionary step."""


### PR DESCRIPTION
I noticed that while debugging and running individual binaries the kernel would crash after a failed binary.
I suspect that's because a `signal.alarm` is started, but never properly closed. 

We caught this before in the population runs, but this does it on an individual binary level. 
The `finally` always runs, even when an Error is raised. 
Should the `post-step` still be ran?