### PR TITLE
Fixing some typos from merge conflict resolution during rebase of v2.1

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.4" %}
+{% set version = "2.1.0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1555,12 +1555,12 @@ class detached_step:
                     "'M15' for Matt et al. 2015"
                     "'CARB' for Van & Ivanova 2019", "UnsupportedModelWarning")
 
-        if verbose and verbose != 1:
-            print("magnetic_braking_mode = ", magnetic_braking_mode)
-            print("dOmega_mb = ", dOmega_mb_sec, dOmega_mb_pri)
-            
-        dOmega_sec = dOmega_sec + dOmega_mb_sec
-        dOmega_pri = dOmega_pri + dOmega_mb_pri
+            if verbose and verbose != 1:
+                print("magnetic_braking_mode = ", magnetic_braking_mode)
+                print("dOmega_mb = ", dOmega_mb_sec, dOmega_mb_pri)
+                
+            dOmega_sec = dOmega_sec + dOmega_mb_sec
+            dOmega_pri = dOmega_pri + dOmega_mb_pri
 
         if do_stellar_evolution_and_spin_from_winds:
             # Due to the secondary's own evolution, we have:

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -37,7 +37,6 @@ from tqdm import tqdm
 import psutil
 import sys
 
-
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import (SingleStar,properties_massless_remnant)
 from posydon.binary_evol.simulationproperties import SimulationProperties

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -935,7 +935,6 @@ class BinaryGenerator:
         self.kwargs = kwargs.copy()
         self.sampler = sampler
         self.star_formation = kwargs.get('star_formation', 'burst')
-        self.binary_fraction_generator =  binary_fraction_value
         self.Z_div_Zsun = kwargs.get('metallicity', 1.)
 
     def reset_rng(self):


### PR DESCRIPTION
This PR just fixes some syntax errors introduced by merge conflict resolution during the rebasing of `v2.1-dev` with `main`.

- Indentation error on block assigning AML from magnetic braking in detached step
- Removes `binary_fraction` variable in `binarypopulation.py` as in the update to include the Moe & di Stefano q distribution.

This PR also removes a conditional import of `BinaryStar` in `binarypopulation.py` that appears to cause an error after the update to v2.0.3. Now `BinaryStar` is imported unconditionally. This should also be implemented in v2.0.3 or v2.0.4.