### PR TITLE
[PATCH v2.0.4] Fix conditional import

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.3" %}
+{% set version = "2.0.4" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -37,8 +37,8 @@ from tqdm import tqdm
 import psutil
 import sys
 
-if 'posydon.binary_evol.binarystar' not in sys.modules.keys():
-    from posydon.binary_evol.binarystar import BinaryStar
+
+from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import (SingleStar,properties_massless_remnant)
 from posydon.binary_evol.simulationproperties import SimulationProperties
 


### PR DESCRIPTION
This makes `binarypopulation.py` always import `BinaryStar`. Previously it was conditional, producing an error, failing to import the needed module.