### PR TITLE
[v2.1.3] Fix run script to gather simprop kwargs and fix single star matching

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.1.2" %}
+{% set version = "2.1.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -420,34 +420,6 @@ This means that this step uses the single stars loaded by the detached step.
       | to find a solution.
     - ``1e-1``
 
-  * - ``do_wind_loss``
-    - | Enable orbital separation and eccentricity changes from stellar wind loss.
-    - ``True``
-
-  * - ``do_tides``
-    - | Enable tides following Hut, P. 1981, A&A, 99, 126.
-    - ``True``
-
-  * - ``do_gravitational_radiation``
-    - | Enable gravitational radiation following Junker, W., & Schafer, G. 1992, MNRAS, 254, 146.
-    - ``True``
-  
-  * - ``do_magnetic_braking``
-    - | Enable stellar angular momentum loss from magnetic braking.
-    - ``True``
-
-  * - ``magnetic_braking_mode``
-    - | A string corresponding to the desired magnetic braking prescription.
-      * ``'RVJ83'``: Rappaport, S., Joss, P. C., & Verbunt, F. 1983, ApJ, 275, 713
-      * ``'M15'``: Matt et al. 2015, ApJ, 799, L23
-      * ``'G18'``: Garraffo et al. 2018, ApJ, 862, 90
-      * ``'CARB'``: Van & Ivanova 2019, ApJ, 886, L31
-    - ``'RVJ83'``
-
-  * - ``do_stellar_evolution_and_spin_from_winds``
-    - | Enable stellar angular momentum loss from winds.
-    - ``True``
-
   * - ``record_matching``
     - | If true, append quantities achieved from track matching to the binary history.
     - ``True``

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -679,6 +679,7 @@ class detached_step:
             sep_interp, mass_interp_pri(t),
             mass_interp_sec(t))
 
+
         for obj, prop in zip([secondary, primary, binary], 
                                 [STARPROPERTIES, STARPROPERTIES, BINARYPROPERTIES]):
 
@@ -836,24 +837,23 @@ class detached_step:
             A single star object, representing the secondary (less evolved) star 
             in the binary and containing its properties.
         """
-        
-        for obj, prop in zip([secondary, primary], 
-                             [STARPROPERTIES, STARPROPERTIES]):
+
+        for obj, prop in zip([secondary, primary],
+                           [STARPROPERTIES, STARPROPERTIES]):
             
             # only update compact objects here
-            if ~obj.co: 
-                continue
-                
-            for key in prop:
+            if obj.co: 
 
-                # simply get the current attribute value and update
-                # this step's props with it. Detached evolution does not
-                # modify these properties for a CO by default, so they 
-                # typically remain unchanged from the previous step.
-                current = getattr(obj, key)
-                history = [current] * len(t[:-1])
-                setattr(obj, key, current)
-                getattr(obj, key + "_history").extend(history)
+                for key in prop:
+
+                    # simply get the current attribute value and update
+                    # this step's props with it. Detached evolution does not
+                    # modify these properties for a CO by default, so they 
+                    # typically remain unchanged from the previous step.
+                    current = getattr(obj, key)
+                    history = [current] * len(t[:-1])
+                    setattr(obj, key, current)
+                    getattr(obj, key + "_history").extend(history)
 
 class detached_evolution:
 

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -842,18 +842,19 @@ class detached_step:
                            [STARPROPERTIES, STARPROPERTIES]):
             
             # only update compact objects here
-            if obj.co: 
+            if not obj.co:
+                continue 
 
-                for key in prop:
+            for key in prop:
 
-                    # simply get the current attribute value and update
-                    # this step's props with it. Detached evolution does not
-                    # modify these properties for a CO by default, so they 
-                    # typically remain unchanged from the previous step.
-                    current = getattr(obj, key)
-                    history = [current] * len(t[:-1])
-                    setattr(obj, key, current)
-                    getattr(obj, key + "_history").extend(history)
+                # simply get the current attribute value and update
+                # this step's props with it. Detached evolution does not
+                # modify these properties for a CO by default, so they 
+                # typically remain unchanged from the previous step.
+                current = getattr(obj, key)
+                history = [current] * len(t[:-1])
+                setattr(obj, key, current)
+                getattr(obj, key + "_history").extend(history)
 
 class detached_evolution:
 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1407,12 +1407,12 @@ class TrackMatcher:
 
         with np.errstate(all="ignore"):
             # get the initial m0, t0 track
-            if binary.event == 'ZAMS' or binary.event == 'redirect_from_ZAMS':
+            if star.co:
+                match_m0, match_t0 = copy_prev_m0, copy_prev_t0
+            elif binary.event == 'ZAMS' or binary.event == 'redirect_from_ZAMS':
                 # ZAMS stars in wide (non-mass exchaging binaries) that are
                 # directed to detached step at birth
                 match_m0, match_t0 = star.mass, 0
-            elif star.co:
-                match_m0, match_t0 = copy_prev_m0, copy_prev_t0
             else:
                 t_before_matching = time.time()
                 # matching to single star grids (getting mass, age of 

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -249,7 +249,7 @@ class SimulationProperties:
         # for every other step, give it a metallicity and load each step
         for name, tup in self.kwargs.items():
             if isinstance(tup, tuple):
-                self.load_a_step(name, tup, metallicity, verbose)
+                self.load_a_step(name, tup, metallicity, verbose=verbose)
 
         # track that all steps have been loaded
         self.steps_loaded = True

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -581,6 +581,7 @@ def create_run_script_text(ini_file):
     text=["from posydon.popsyn.binarypopulation import BinaryPopulation",
          "from posydon.popsyn.io import binarypop_kwargs_from_ini",
          "from posydon.utils.common_functions import convert_metallicity_to_string",
+         "from posydon.binary_evol.simulationproperties import SimulationProperties",
          "import argparse",
 
          'if __name__ == "__main__":',
@@ -591,7 +592,8 @@ def create_run_script_text(ini_file):
          "    ini_kw['metallicity'] = args.metallicity",
          "    str_met = convert_metallicity_to_string(args.metallicity)",
          "    ini_kw['temp_directory'] = str_met+'_Zsun_' + ini_kw['temp_directory']",
-         "    synpop = BinaryPopulation(**ini_kw)",
+        f"    sim_props = SimulationProperties.from_ini('{ini_file}')",
+         "    synpop = BinaryPopulation(population_properties=sim_props, **ini_kw)", 
          "    synpop.evolve()"]
 
     text = '\n'.join(text)

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -214,18 +214,6 @@
     # float, DEF: 1e-2
   matching_tolerance_hard = 1e-1
     # float, DEF: 1e-1
-  do_wind_loss = True
-    # True, False
-  do_tides = True
-    # True, False
-  do_gravitational_radiation = True
-    # True, False
-  do_magnetic_braking = True
-    # True, False
-  magnetic_braking_mode = 'RVJ83'
-    # 'RVJ83', 'M15', 'G18', 'CARB'
-  do_stellar_evolution_and_spin_from_winds = True
-    # True, False
   record_matching = False
     # True, False
   verbose = False


### PR DESCRIPTION
For running populations, the population synthesis run script needs to load in the `SimulationProperties` kwargs. This updates the script to do that.

Fixes another critical error in track matching where initially single stars (who are initialized with a `massless_remnant` companion) would fail because the logic fails to check if the star being matched is a compact object first and foremost, so this has been corrected.

Also remove tides, magnetic braking options etc. from `step_initially_single` in the .ini file. These cause the single star evolution to time out if they are set to True.