### PR TITLE
[v2.1.6] Remove `interp1d` from defaults

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.1.5" %}
+{% set version = "2.1.6" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -651,7 +651,6 @@
                   'he4_mass_ej',
                   #'M4',
                   #'mu4',
-                  'interp1d',
                   'avg_c_in_c_core_at_He_depletion',
                   'co_core_mass_at_He_depletion',
                   #'m_core_CE_1cent',

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -565,7 +565,6 @@
                   'he4_mass_ej',
                   #'M4',
                   #'mu4',
-                  'interp1d',
                   'avg_c_in_c_core_at_He_depletion',
                   'co_core_mass_at_He_depletion',
                   #'m_core_CE_1cent',


### PR DESCRIPTION
`interp1d` causes an error with population saving because it is a complex data type. This removes `interp1d` from the default .ini file.