### PR TITLE
[feat] Additional kick options

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1997,7 +1997,7 @@ class StepSN(object):
     ##### Generating the CCSN SN kick of a single star #####
     """
 
-    def generate_kick(self, star, sigma=None, mean=None):
+    def generate_kick(self, star, sigma, mean):
         """Draw a kick from a Maxwellian distribution.
 
         We follow Hobbs G., Lorimer D. R., Lyne A. G., Kramer M., 2005, MNRAS, 360, 974
@@ -2010,6 +2010,10 @@ class StepSN(object):
         ----------
         star : object
             Star object containing the star properties.
+        sigma : float
+            Velocity dispersion for Hobbs+05 or log-normal distribution.
+        mean : float
+            Mean for the log-normal distribution.
 
         Returns
         -------

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -94,7 +94,7 @@ SN_MODEL = {
     "sigma_kick_CCSN_NS": 265.0,
     "mean_kick_CCSN_NS": None,
     "sigma_kick_CCSN_BH": 265.0,
-    "mean_kciK_CCSN_BH": None,
+    "mean_kick_CCSN_BH": None,
     "sigma_kick_ECSN": 20.0,
     "mean_kick_ECSN": None,
     # other
@@ -2064,11 +2064,17 @@ class StepSN(object):
         """
 
         if self.kick_prescription == "Hobbs+05":
+            # sigma==None should never be reached, since in that case Vkick=0
+            # in generate_kick function
+            # this is a fallback
             if sigma is None:
                 sigma = 265.0
             Vkick_ej = sp.stats.maxwell.rvs(loc=0., scale=sigma, size=1)[0]
 
         elif self.kick_prescription == "log_normal":
+            # sigma==None should never be reached, since in that case Vkick=0
+            # in generate_kick function
+            # this is a fallback
             if sigma is None:
                 sigma = 0.68
             if mean is None:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -90,7 +90,7 @@ SN_MODEL = {
     # kick physics
     "kick": True,
     "kick_normalisation": 'one_over_mass',
-    "kick_prescription": 'Hobbs+05',
+    "kick_prescription": 'maxwellian',
     "sigma_kick_CCSN_NS": 265.0,
     "mean_kick_CCSN_NS": None,
     "sigma_kick_CCSN_BH": 265.0,
@@ -2011,7 +2011,7 @@ class StepSN(object):
         star : object
             Star object containing the star properties.
         sigma : float
-            Velocity dispersion for Hobbs+05 or log-normal distribution.
+            Velocity dispersion for maxwellian or log-normal distribution.
         mean : float
             Mean for the log-normal distribution.
 
@@ -2074,7 +2074,7 @@ class StepSN(object):
             Kick velocity drawn from the chosen distribution.
         """
 
-        if self.kick_prescription == "Hobbs+05":
+        if self.kick_prescription == "maxwellian":
             # sigma==None should never be reached, since in that case Vkick=0
             # in generate_kick function
             # this is a fallback

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -266,17 +266,18 @@ class StepSN(object):
             for varname in SN_MODEL:
                 default_value = SN_MODEL[varname]
                 setattr(self, varname, kwargs.get(varname, default_value))
-                # backward compatibility for kick
-                if (self.kick_normalisation == 'asym_ej'
-                    or self.kick_normalisation == 'linear'):
-                    Pwarn("kick_normalisation 'asym_ej' and 'linear' are "
-                          "deprecated, use kick_prescription instead.",
-                          "DeprecationWarning")
-                    self.kick_prescription = self.kick_normalisation
         else:
             for varname in SN_MODEL:
                 default_value = SN_MODEL[varname]
                 setattr(self, varname, default_value)
+                
+        # backward compatibility for kick
+        if (self.kick_normalisation == 'asym_ej'
+            or self.kick_normalisation == 'linear'):
+            Pwarn("kick_normalisation 'asym_ej' and 'linear' are "
+                "deprecated, use kick_prescription instead.",
+                "DeprecationWarning")
+            self.kick_prescription = self.kick_normalisation
 
         if self.max_neutrino_mass_loss is None:
             self.max_neutrino_mass_loss = 0

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -275,9 +275,11 @@ class StepSN(object):
         if (self.kick_normalisation == 'asym_ej'
             or self.kick_normalisation == 'linear'):
             Pwarn("kick_normalisation 'asym_ej' and 'linear' are "
-                "deprecated, use kick_prescription instead.",
+                "deprecated, use kick_prescription instead. Setting "
+                "kick normalization to unity.",
                 "DeprecationWarning")
             self.kick_prescription = self.kick_normalisation
+            self.kick_normalisation = 'one'
 
         if self.max_neutrino_mass_loss is None:
             self.max_neutrino_mass_loss = 0

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -266,6 +266,13 @@ class StepSN(object):
             for varname in SN_MODEL:
                 default_value = SN_MODEL[varname]
                 setattr(self, varname, kwargs.get(varname, default_value))
+                # backward compatibility for kick
+                if (self.kick_normalisation == 'asym_ej'
+                    or self.kick_normalisation == 'linear'):
+                    Pwarn("kick_normalisation 'asym_ej' and 'linear' are "
+                          "deprecated, use kick_prescription instead.",
+                          "DeprecationWarning")
+                    self.kick_prescription = self.kick_normalisation
         else:
             for varname in SN_MODEL:
                 default_value = SN_MODEL[varname]

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -270,7 +270,7 @@ class StepSN(object):
             for varname in SN_MODEL:
                 default_value = SN_MODEL[varname]
                 setattr(self, varname, default_value)
-                
+
         # backward compatibility for kick
         if (self.kick_normalisation == 'asym_ej'
             or self.kick_normalisation == 'linear'):

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -90,6 +90,7 @@ SN_MODEL = {
     # kick physics
     "kick": True,
     "kick_normalisation": 'one_over_mass',
+    "kick_prescription": 'Hobbs+05',
     "sigma_kick_CCSN_NS": 265.0,
     "mean_kick_CCSN_NS": None,
     "sigma_kick_CCSN_BH": 265.0,

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -91,8 +91,11 @@ SN_MODEL = {
     "kick": True,
     "kick_normalisation": 'one_over_mass',
     "sigma_kick_CCSN_NS": 265.0,
+    "mean_kick_CCSN_NS": None,
     "sigma_kick_CCSN_BH": 265.0,
+    "mean_kciK_CCSN_BH": None,
     "sigma_kick_ECSN": 20.0,
+    "mean_kick_ECSN": None,
     # other
     "verbose": False,
 }
@@ -1493,23 +1496,28 @@ class StepSN(object):
                 if binary.star_1.SN_type == "ECSN":
                     # Kick for electron-capture SN
                     Vkick = self.generate_kick(
-                        star=binary.star_1, sigma=self.sigma_kick_ECSN
+                        star=binary.star_1,
+                        sigma=self.sigma_kick_ECSN,
+                        mean=self.mean_kick_ECSN,
                     )
                 elif ((binary.star_1.SN_type == "CCSN")
                       or (binary.star_1.SN_type == "PPISN")
                       or (binary.star_1.SN_type == "PISN")):
                     if binary.star_1.state == 'NS':
                         sigma = self.sigma_kick_CCSN_NS
+                        mean = self.mean_kick_CCSN_NS
                     elif binary.star_1.state == 'BH':
                         sigma = self.sigma_kick_CCSN_BH
+                        mean = self.mean_kick_CCSN_BH
                     elif binary.star_1.state == 'massless_remnant':
                         # No kick on a massless object
                         sigma = None
+                        mean = None
                     else:
                         raise ValueError("CCSN/PPISN/PISN only for NS/BH.")
                     # Kick for core-collapse SN
                     Vkick = self.generate_kick(
-                        star=binary.star_1, sigma=sigma
+                        star=binary.star_1, sigma=sigma, mean=mean
                     )
                 elif binary.star_1.SN_type == "WD":
                     # Kick for white dwarfs (allways f_fb = 1 => Vkick = 0)
@@ -1593,21 +1601,27 @@ class StepSN(object):
                 if binary.star_2.SN_type == "ECSN":
                     # Kick for electron-capture SN
                     Vkick = self.generate_kick(star=binary.star_2,
-                                               sigma=self.sigma_kick_ECSN)
+                                               sigma=self.sigma_kick_ECSN,
+                                               mean=self.mean_kick_ECSN)
                 elif ((binary.star_2.SN_type == "CCSN")
                       or (binary.star_2.SN_type == "PPISN")
                       or (binary.star_2.SN_type == "PISN")):
                     if binary.star_2.state == 'NS':
                         sigma = self.sigma_kick_CCSN_NS
+                        mean = self.mean_kick_CCSN_NS
                     elif binary.star_2.state == 'BH':
                         sigma = self.sigma_kick_CCSN_BH
+                        mean = self.mean_kick_CCSN_BH
                     elif binary.star_2.state == 'massless_remnant':
                         # No kick on a massless object
                         sigma = None
+                        mean = None
                     else:
                         raise ValueError("CCSN/PPISN/PISN only for NS/BH.")
                     # Kick for core-collapse SN
-                    Vkick = self.generate_kick(star=binary.star_2, sigma=sigma)
+                    Vkick = self.generate_kick(star=binary.star_2,
+                                               sigma=sigma,
+                                               mean=mean)
                 else:
                     raise ValueError("The SN type is not ECSN neither CCSN.")
 
@@ -1975,7 +1989,7 @@ class StepSN(object):
     ##### Generating the CCSN SN kick of a single star #####
     """
 
-    def generate_kick(self, star, sigma):
+    def generate_kick(self, star, sigma=None, mean=None):
         """Draw a kick from a Maxwellian distribution.
 
         We follow Hobbs G., Lorimer D. R., Lyne A. G., Kramer M., 2005, MNRAS, 360, 974
@@ -2020,24 +2034,47 @@ class StepSN(object):
 
 
         """
-        if self.kick_normalisation == 'one_minus_fallback':
-            # Normalization from Eq. 21, Fryer, C. L., Belczynski, K., Wiktorowicz,
-            # G., Dominik, M., Kalogera, V., & Holz, D. E. (2012), ApJ, 749(1), 91.
-            norm = (1.0 - star.f_fb)
-        elif self.kick_normalisation == 'one_over_mass':
-            if star.state == 'BH':
-                norm = 1.4/star.mass
-            else:
-                norm = 1.0
+        if sigma is None:
+            Vkick = 0.0
+        else:
+            norm = self._get_kick_normalisation(star)
+            Vkick_ej = self._get_kick_velocity(star, sigma=sigma, mean=mean)
+            Vkick = norm * Vkick_ej
 
-        elif self.kick_normalisation == 'log_normal':
-            if star.state == 'BH':
-                norm = 1.4/star.mass
-            else:
-                norm = 1.0
+        return Vkick
 
-        elif self.kick_normalisation == 'asym_ej':
 
+    def _get_kick_velocity(self, star, sigma=None, mean=None):
+        """Get the kick velocity based on the chosen prescription.
+
+        Parameters
+        ----------
+        star : object
+            Star object containing the star properties.
+        sigma : float, optional
+            Velocity dispersion for the distribution.
+        mean : float, optional
+            Mean for the log-normal distribution.
+
+        Returns
+        -------
+        Vkick_ej : float
+            Kick velocity drawn from the chosen distribution.
+        """
+
+        if self.kick_prescription == "Hobbs+05":
+            if sigma is None:
+                sigma = 265.0
+            Vkick_ej = sp.stats.maxwell.rvs(loc=0., scale=sigma, size=1)[0]
+
+        elif self.kick_prescription == "log_normal":
+            if sigma is None:
+                sigma = 0.68
+            if mean is None:
+                mean = np.exp(5.60)
+            Vkick_ej = sp.stats.lognorm.rvs(s=sigma, scale=mean, size=1)[0]
+
+        elif self.kick_prescription == "asym_ej":
             f_kin = 0.1         # Fraction of SN explosion energy that is kinetic energy of the gas
             beta = 0.1          # Fraction of ejecta mass that is neutrino heated
             epsilon = 1
@@ -2048,8 +2085,7 @@ class StepSN(object):
 
             Vkick_ej = 211*(f_kin*beta*epsilon)**(1/2)*(alpha_ej/0.1)*(M_ej/0.1)*(M_NS/1.5)**(-1)
 
-        elif self.kick_normalisation == 'linear':
-
+        elif self.kick_prescription == "linear":
             M_ej = star.co_core_mass_history[-1]-star.mass        # Ejecta mass
             M_rem = star.mass                                     # Neutron star mass
             alpha = 115                                           # alpha and beta are best-fit parameters
@@ -2057,6 +2093,34 @@ class StepSN(object):
 
             Vkick_ej = alpha * (M_ej/M_rem) + beta
 
+        else:
+            raise ValueError('kick_prescription option not supported!')
+
+        return Vkick_ej
+
+    def _get_kick_normalisation(self, star):
+        """Get the kick normalisation method.
+
+        Parameters
+        ----------
+        star : object
+            Star object containing the star properties.
+        Returns
+        -------
+        norm : float
+            Normalisation factor for the natal kick.
+
+        """
+
+        if self.kick_normalisation == 'one_minus_fallback':
+            # Normalization from Eq. 21, Fryer, C. L., Belczynski, K., Wiktorowicz,
+            # G., Dominik, M., Kalogera, V., & Holz, D. E. (2012), ApJ, 749(1), 91.
+            norm = (1.0 - star.f_fb)
+        elif self.kick_normalisation == 'one_over_mass':
+            if star.state == 'BH':
+                norm = 1.4/star.mass
+            else:
+                norm = 1.0
         elif self.kick_normalisation == 'NS_one_minus_fallback_BH_one':
             if star.state == 'BH':
                 norm = 1.
@@ -2071,21 +2135,7 @@ class StepSN(object):
         else:
             raise ValueError('kick_normalisation option not supported!')
 
-        if sigma is not None:
-            # f_fb = self.compute_m_rembar(star, None)[1]
-
-            if self.kick_normalisation in ['asym_ej', 'linear']:
-                Vkick = Vkick_ej
-            elif self.kick_normalisation == 'log_normal':
-                Vkick = norm * sp.stats.lognorm.rvs(s=0.68, scale=np.exp(5.60), size=1)[0]
-            else:
-                Vkick = norm * sp.stats.maxwell.rvs(loc=0., scale=sigma, size=1)[0]
-
-        else:
-            Vkick = 0.0
-
-        return Vkick
-
+        return norm
 
     def get_combined_tilt(self, tilt_1, tilt_2, true_anomaly_1, true_anomaly_2):
         """Get the combined spin-orbit-tilt after two supernovae, assuming

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -308,13 +308,21 @@
     # True, False
   kick_normalisation = 'one_over_mass'
     # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one",
-    # "one", "zero", "asym_ej", "linear", "log_normal"
+    # "one", "zero"
+  kick_prescription = 'Hobbs+05'
+    # "Hobbs+05", "log_normal", "asym_ej", "linear"
   sigma_kick_CCSN_NS = 265.0
     # float (0,inf)
+  mean_kick_CCSN_NS = None
+    # float or None
   sigma_kick_CCSN_BH = 265.0
     # float (0,inf)
+  mean_kick_CCSN_BH = None
+    # float or None
   sigma_kick_ECSN = 20.0
     # float (0,inf)
+  mean_kick_ECSN = None
+    # float or None
   verbose = False
     # True, False
 

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -309,7 +309,7 @@
   kick_normalisation = 'one_over_mass'
     # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one",
     # "one", "zero"
-  kick_prescription = 'Hobbs+05'
+  kick_prescription = 'maxwellian'
     # "Hobbs+05", "log_normal", "asym_ej", "linear"
   sigma_kick_CCSN_NS = 265.0
     # float (0,inf)

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -310,7 +310,7 @@
     # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one",
     # "one", "zero"
   kick_prescription = 'maxwellian'
-    # "Hobbs+05", "log_normal", "asym_ej", "linear"
+    # "maxwellian", "log_normal", "asym_ej", "linear"
   sigma_kick_CCSN_NS = 265.0
     # float (0,inf)
   mean_kick_CCSN_NS = None

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -572,6 +572,36 @@ class TestStepWarning:
                           totest.StepWarning)
         assert StepWarning.message == ''
 
+class TestSFHModelWarning:
+    @fixture
+    def SFHModelWarning(self):
+        # initialize an instance of the class with defaults
+        return totest.SFHModelWarning()
+
+    # test the SFHModelWarning class
+    def test_init(self, SFHModelWarning):
+        assert isroutine(SFHModelWarning.__init__)
+        # check that the instance is of correct type and all code in the
+        # __init__ got executed: the elements are created and initialized
+        assert isinstance(SFHModelWarning, totest.SFHModelWarning)
+        assert SFHModelWarning.message == ''
+
+
+class TestDeprecationWarning:
+    @fixture
+    def DeprecationWarning(self):
+        # initialize an instance of the class with defaults
+        return totest.DeprecationWarning()
+
+    # test the DeprecationWarning class
+    def test_init(self, DeprecationWarning):
+        assert isroutine(DeprecationWarning.__init__)
+        # check that the instance is of correct type and all code in the
+        # __init__ got executed: the elements are created and initialized
+        assert isinstance(DeprecationWarning, totest.DeprecationWarning)
+        assert DeprecationWarning.message == ''
+
+
 class Test_Caught_POSYDON_Warnings:
     @fixture
     def clear_registry(self):

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -110,7 +110,7 @@ class TestElements:
     def test_instance_SFHModelWarning(self):
         assert isclass(totest.SFHModelWarning)
         assert issubclass(totest.SFHModelWarning, totest.POSYDONWarning)
-        
+
     def test_instance_DeprecationWarning(self):
         assert isclass(totest.DeprecationWarning)
         assert issubclass(totest.DeprecationWarning, totest.POSYDONWarning)

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -110,6 +110,10 @@ class TestElements:
     def test_instance_SFHModelWarning(self):
         assert isclass(totest.SFHModelWarning)
         assert issubclass(totest.SFHModelWarning, totest.POSYDONWarning)
+        
+    def test_instance_DeprecationWarning(self):
+        assert isclass(totest.DeprecationWarning)
+        assert issubclass(totest.DeprecationWarning, totest.POSYDONWarning)
 
     def test_instance_POSYDONWarning_subclasses(self):
         assert isinstance(totest._POSYDONWarning_subclasses, (dict))

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -32,7 +32,7 @@ class TestElements:
                     'InterpolationWarning', 'MissingFilesWarning',\
                     'NoPOSYDONWarnings', 'OverwriteWarning', 'SFHModelWarning',\
                     'POSYDONWarning','Pwarn', 'ReplaceValueWarning',\
-                    'SetPOSYDONWarnings', 'ValueWarning',\
+                    'SetPOSYDONWarnings', 'ValueWarning', 'DeprecationWarning', \
                     'InitializationWarning','StepWarning',\
                     'UnsupportedModelWarning', '_CAUGHT_POSYDON_WARNINGS',\
                     '_Caught_POSYDON_Warnings', '_POSYDONWarning_subclasses',\

--- a/posydon/utils/posydonwarning.py
+++ b/posydon/utils/posydonwarning.py
@@ -118,6 +118,11 @@ class SFHModelWarning(POSYDONWarning):
     """Warnings related to the SFH model."""
     def __init__(self, message=''):
         super().__init__(message)
+        
+class DeprecationWarning(POSYDONWarning):
+    """Warnings related to deprecated features."""
+    def __init__(self, message=''):
+        super().__init__(message)
 
 class ValueWarning(POSYDONWarning):
     """Warnings related to a ValueError."""

--- a/posydon/utils/posydonwarning.py
+++ b/posydon/utils/posydonwarning.py
@@ -118,7 +118,7 @@ class SFHModelWarning(POSYDONWarning):
     """Warnings related to the SFH model."""
     def __init__(self, message=''):
         super().__init__(message)
-        
+
 class DeprecationWarning(POSYDONWarning):
     """Warnings related to deprecated features."""
     def __init__(self, message=''):


### PR DESCRIPTION
Rework of #685 onto v2.1.8 branch using cherry-picks on 


Small rework of the kick prescriptions and normalisations, allowing for more flexibility of the input parameters of the distributions.
- It splits up kick_normalisation and kick_prescription. I needed to have a "one" normalised kick, but with "log_normal" drawn. This is not currently possible.
- Adds new parameters to step_SN in the population ini file. 'kick_prescription' mean_kick_XXXX for BH, NS, and ECSN
- If asym_ej or linear are still used as part of the kick_normalisation parameters, they're automatically set as the 'kick_prescription' to allow older inlists to still be used. A DeprecationWarning is thrown as well.

I'm interested in hearing if we should keep these functions in the step_SN class or move them out, since they're basically independent.
