### PR TITLE
[feat] Add explicit options for `record_matching` and `verbose` to `step_merged` in .ini file

### DIFF
--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -201,6 +201,11 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
+  record_matching = False
+    # True, False
+  verbose = False
+    # True, False
+
 
 [step_initially_single]
   import = ['posydon.binary_evol.DT.step_initially_single','InitiallySingleStep']


### PR DESCRIPTION
This adds 

```
  record_matching = False
    # True, False
  verbose = False
    # True, False
```

to `step_merged` in our default .ini file. Setting `record_matching = True` will produce an extra line in the history of the binary that indicates the single (merged) star that was matched to.