### PR TITLE
[fix] Add eccentricity scheme switch to Moe and Di Stefano 17 option

### DIFF
--- a/posydon/popsyn/independent_sample.py
+++ b/posydon/popsyn/independent_sample.py
@@ -60,10 +60,10 @@ def generate_independent_samples(orbital_scheme='period', **kwargs):
         m2_set, orbital_scheme_set, eccentricity_set, metallicity_set\
          = _gen_Moe_17_PsandQs(m1_set, M_min=M1_min, M_max=M1_max,
                                all_binaries=False)
-        
+
         ecc_scheme = kwargs.get('eccentricity_scheme', 'zero')
         if ecc_scheme != 'Moe+17-PsandQs':
-            # ensure that kwargs hold the current retrieved or 
+            # ensure that kwargs hold the current retrieved or
             # set value of eccentricity_scheme
             kwargs['eccentricity_scheme'] = ecc_scheme
             eccentricity_set = generate_eccentricities(**kwargs)

--- a/posydon/popsyn/independent_sample.py
+++ b/posydon/popsyn/independent_sample.py
@@ -60,6 +60,13 @@ def generate_independent_samples(orbital_scheme='period', **kwargs):
         m2_set, orbital_scheme_set, eccentricity_set, metallicity_set\
          = _gen_Moe_17_PsandQs(m1_set, M_min=M1_min, M_max=M1_max,
                                all_binaries=False)
+        
+        ecc_scheme = kwargs.get('eccentricity_scheme', 'zero')
+        if ecc_scheme != 'Moe+17-PsandQs':
+            # ensure that kwargs hold the current retrieved or 
+            # set value of eccentricity_scheme
+            kwargs['eccentricity_scheme'] = ecc_scheme
+            eccentricity_set = generate_eccentricities(**kwargs)
     else:
 
         # Generate secondary masses

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -418,8 +418,7 @@
     # value should be within the mass range given by the used grids
   secondary_mass_scheme = 'flat_mass_ratio'
     # 'flat_mass_ratio', 'q=1', 'Moe+17-PsandQs' (will enforce
-    #  orbital_period_scheme='Moe+17-PsandQs' and
-    #  eccentricity_scheme='Moe+17-PsandQs')
+    #  orbital_period_scheme='Moe+17-PsandQs')
   secondary_mass_min = 0.5
     # float (0,130)
     # value should be within the mass range given by the used grids
@@ -430,8 +429,7 @@
     # 'separation', 'period'
   orbital_period_scheme = 'Sana+12_period_extended'
     # (used only for orbital_scheme = 'period') 'Sana+12_period_extended',
-    # 'Moe+17-PsandQs' (will enforce secondary_mass_scheme='Moe+17-PsandQs' and
-    #                   eccentricity_scheme='Moe+17-PsandQs')
+    # 'Moe+17-PsandQs' (will enforce secondary_mass_scheme='Moe+17-PsandQs')
   orbital_period_min = 0.75
     # float (0, inf) (used only for orbital_scheme = 'period')
     # value should be within the period range given by the used grids


### PR DESCRIPTION
This PR makes it so that the Moe and Di Stefano '17 P and q distribution option uses the `eccentricity_scheme`, rather than always enforcing its own eccentricity scheme (which leads to non-zero initial eccentricities).