### PR TITLE
[feat] natal_kick_array renaming

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1497,8 +1497,8 @@ class StepSN(object):
             M_companion = binary.star_2.mass
 
             # check if a kick is passed, otherwise generate it
-            if not binary.star_1.natal_kick_array[0] is None:
-                Vkick = binary.star_1.natal_kick_array[0]
+            if not binary.star_1.natal_kick_velocity is None:
+                Vkick = binary.star_1.natal_kick_velocity
             else:
                 # Draw a random orbital kick
                 # Vkick is the kick velocity with components Vkx, Vky, Vkz in
@@ -1536,29 +1536,29 @@ class StepSN(object):
                 else:
                     raise ValueError("The SN type is not ECSN neither CCSN.")
 
-                binary.star_1.natal_kick_array[0] = Vkick
+                binary.star_1.natal_kick_velocity = Vkick
 
-            if not binary.star_1.natal_kick_array[1] is None:
-                phi = binary.star_1.natal_kick_array[1]
+            if not binary.star_1.natal_kick_azimuthal_angle is None:
+                phi = binary.star_1.natal_kick_azimuthal_angle
             else:
                 phi = np.random.uniform(0, 2 * np.pi)
-                binary.star_1.natal_kick_array[1] = phi
+                binary.star_1.natal_kick_azimuthal_angle = phi
 
-            if not binary.star_1.natal_kick_array[2] is None:
-                cos_theta = np.cos(binary.star_1.natal_kick_array[2])
+            if not binary.star_1.natal_kick_polar_angle is None:
+                cos_theta = np.cos(binary.star_1.natal_kick_polar_angle)
             else:
                 cos_theta = np.random.uniform(-1, 1)
-                binary.star_1.natal_kick_array[2] = np.arccos(cos_theta)
+                binary.star_1.natal_kick_polar_angle = np.arccos(cos_theta)
 
             # generate random point in the orbit where the kick happens
-            if not binary.star_1.natal_kick_array[3] is None:
-                mean_anomaly = binary.star_1.natal_kick_array[3]
+            if not binary.star_1.natal_kick_mean_anomaly is None:
+                mean_anomaly = binary.star_1.natal_kick_mean_anomaly
                 # check that ONLY one value is passed and is of type float
                 if not isinstance(mean_anomaly, float):
                     raise ValueError("mean_anomaly must be a single float value.")
             else:
                 mean_anomaly = np.random.uniform(0, 2 * np.pi)
-                binary.star_1.natal_kick_array[3] = mean_anomaly
+                binary.star_1.natal_kick_mean_anomaly = mean_anomaly
 
         elif binary.event == "CC2":
             if binary.star_2.SN_type == "WD":
@@ -1602,8 +1602,8 @@ class StepSN(object):
             M_companion = binary.star_1.mass
 
             # check if a kick is passed, otherwise generate it
-            if not binary.star_2.natal_kick_array[0] is None:
-                Vkick = binary.star_2.natal_kick_array[0]
+            if not binary.star_2.natal_kick_velocity is None:
+                Vkick = binary.star_2.natal_kick_velocity
             else:
                 # Draw a random orbital kick
                 # Vkick is the kick velocity with components Vkx, Vky, Vkz in
@@ -1636,29 +1636,29 @@ class StepSN(object):
                 else:
                     raise ValueError("The SN type is not ECSN neither CCSN.")
 
-                binary.star_2.natal_kick_array[0] = Vkick
+                binary.star_2.natal_kick_velocity = Vkick
 
-            if not binary.star_2.natal_kick_array[1] is None:
-                phi = binary.star_2.natal_kick_array[1]
+            if not binary.star_2.natal_kick_azimuthal_angle is None:
+                phi = binary.star_2.natal_kick_azimuthal_angle
             else:
                 phi = np.random.uniform(0, 2 * np.pi)
-                binary.star_2.natal_kick_array[1] = phi
+                binary.star_2.natal_kick_azimuthal_angle = phi
 
-            if not binary.star_2.natal_kick_array[2] is None:
-                cos_theta = np.cos(binary.star_2.natal_kick_array[2])
+            if not binary.star_2.natal_kick_polar_angle is None:
+                cos_theta = np.cos(binary.star_2.natal_kick_polar_angle)
             else:
                 cos_theta = np.random.uniform(-1, 1)
-                binary.star_2.natal_kick_array[2] = np.arccos(cos_theta)
+                binary.star_2.natal_kick_polar_angle = np.arccos(cos_theta)
 
             # generate random point in the orbit where the kick happens
-            if not binary.star_2.natal_kick_array[3] is None:
-                mean_anomaly = binary.star_2.natal_kick_array[3]
+            if not binary.star_2.natal_kick_mean_anomaly is None:
+                mean_anomaly = binary.star_2.natal_kick_mean_anomaly
                 # check that ONLY one value is passed and is of type float
                 if not isinstance(mean_anomaly, float):
                     raise ValueError("mean_anomaly must be a single float value.")
             else:
                 mean_anomaly = np.random.uniform(0, 2 * np.pi)
-                binary.star_2.natal_kick_array[3] = mean_anomaly
+                binary.star_2.natal_kick_mean_anomaly = mean_anomaly
 
         # update the orbit
         if binary.state == "disrupted" or binary.state == "initially_single_star" or binary.state == "merged":

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -859,17 +859,26 @@ class BinaryStar:
         assert len(set(hist_lengths)) == 1
         history_length = set(hist_lengths).pop()
 
+        # Handle backward compatibility for natal_kick_array
         if any(['S1_natal_kick_array' in name for name in oneline_df.columns]):
             natalkick_names = ['S1_natal_kick_array_{}'.format(i)
                                for i in range(4)]
-            star1_params['natal_kick_array'] = \
-                oneline_df[natalkick_names].values
+            natal_kick_values = oneline_df[natalkick_names].values[0]
+            # Set individual natal kick properties
+            star1_params['natal_kick_velocity'] = natal_kick_values[0]
+            star1_params['natal_kick_azimuthal_angle'] = natal_kick_values[1]
+            star1_params['natal_kick_polar_angle'] = natal_kick_values[2]
+            star1_params['natal_kick_mean_anomaly'] = natal_kick_values[3]
 
         if any(['S2_natal_kick_array' in name for name in oneline_df.columns]):
             natalkick_names = ['S2_natal_kick_array_{}'.format(i)
                                for i in range(4)]
-            star2_params['natal_kick_array'] = \
-                oneline_df[natalkick_names].values
+            natal_kick_values = oneline_df[natalkick_names].values[0]
+            # Set individual natal kick properties
+            star2_params['natal_kick_velocity'] = natal_kick_values[0]
+            star2_params['natal_kick_azimuthal_angle'] = natal_kick_values[1]
+            star2_params['natal_kick_polar_angle'] = natal_kick_values[2]
+            star2_params['natal_kick_mean_anomaly'] = natal_kick_values[3]
 
         if ('binary_index' in oneline_df.index.name
                 and not kwargs.get('index', None)):
@@ -1109,8 +1118,14 @@ class BinaryStar:
                     f"eccentricity: {self.eccentricity_history[0]} \n",
                     f"binary state: {self.state_history[0] }\n",
                     f"binary event: {self.state_history[0] }\n",
-                    f"S1 natal kick array: {self.star_1.natal_kick_array }\n",
-                    f"S2 natal kick array: {self.star_2.natal_kick_array}\n"]
+                    f"S1 natal kick velocity: {self.star_1.natal_kick_velocity}\n",
+                    f"S1 natal kick azimuthal angle: {self.star_1.natal_kick_azimuthal_angle}\n",
+                    f"S1 natal kick polar angle: {self.star_1.natal_kick_polar_angle}\n",
+                    f"S1 natal kick mean anomaly: {self.star_1.natal_kick_mean_anomaly}\n",
+                    f"S2 natal kick velocity: {self.star_2.natal_kick_velocity}\n",
+                    f"S2 natal kick azimuthal angle: {self.star_2.natal_kick_azimuthal_angle}\n",
+                    f"S2 natal kick polar angle: {self.star_2.natal_kick_polar_angle}\n",
+                    f"S2 natal kick mean anomaly: {self.star_2.natal_kick_mean_anomaly}\n"]
 
         message = ""
         for i in ini_params:

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -311,8 +311,14 @@ class SingleStar:
         # store extra values in the star object without a history
 
         # these quantities are updated in step_SN.py
-        if not hasattr(self, 'natal_kick_array'):
-            self.natal_kick_array = [None] * 4
+        if not hasattr(self, 'natal_kick_velocity'):
+            self.natal_kick_velocity = None
+        if not hasattr(self, 'natal_kick_azimuthal_angle'):
+            self.natal_kick_azimuthal_angle = None
+        if not hasattr(self, 'natal_kick_polar_angle'):
+            self.natal_kick_polar_angle = None
+        if not hasattr(self, 'natal_kick_mean_anomaly'):
+            self.natal_kick_mean_anomaly = None
         if not hasattr(self, 'spin_orbit_tilt_first_SN'):
             self.spin_orbit_tilt_first_SN = None
         if not hasattr(self, 'spin_orbit_tilt_second_SN'):
@@ -531,8 +537,15 @@ class SingleStar:
 
         for name in scalar_names:
             if hasattr(self, name):
+                # Handle legacy natal_kick_array for backward compatibility
                 if name == 'natal_kick_array':
-                    natal_kick_array = getattr(self, name)
+                    # Create array from individual properties
+                    natal_kick_array = [
+                        getattr(self, 'natal_kick_velocity', None),
+                        getattr(self, 'natal_kick_azimuthal_angle', None),
+                        getattr(self, 'natal_kick_polar_angle', None),
+                        getattr(self, 'natal_kick_mean_anomaly', None)
+                    ]
                     for i in range(4):
                         col_name = prefix+name+'_{}'.format(int(i))
                         oneline_df[col_name] = [natal_kick_array[i]]

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -534,11 +534,18 @@ class SingleStar:
                                       columns=oneline_names)
         else:
             oneline_df = pd.DataFrame()
-
         for name in scalar_names:
             if hasattr(self, name):
                 # Handle legacy natal_kick_array for backward compatibility
                 if name == 'natal_kick_array':
+                    Pwarn("The 'natal_kick_array' attribute will be deprecated. "
+                            "Please use 'natal_kick_velocity', "
+                            "'natal_kick_azimuthal_angle', "
+                            "'natal_kick_polar_angle', and "
+                            "'natal_kick_mean_anomaly' instead. "
+                            "Adding both properties to the DataFrame.",
+                            "DeprecationWarning"
+                    )
                     # Create array from individual properties
                     natal_kick_array = [
                         getattr(self, 'natal_kick_velocity', None),
@@ -548,7 +555,13 @@ class SingleStar:
                     ]
                     for i in range(4):
                         col_name = prefix+name+'_{}'.format(int(i))
-                        oneline_df[col_name] = [natal_kick_array[i]]
+                        oneline_df[col_name] = natal_kick_array[i]
+
+                    # also output better named columns
+                    oneline_df[prefix+'natal_kick_velocity'] = natal_kick_array[0]
+                    oneline_df[prefix+'natal_kick_azimuthal_angle'] = natal_kick_array[1]
+                    oneline_df[prefix+'natal_kick_polar_angle'] = natal_kick_array[2]
+                    oneline_df[prefix+'natal_kick_mean_anomaly'] = natal_kick_array[3]
                 else:
                     oneline_df[prefix+name] = [getattr(self, name)]
         return oneline_df

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -1092,18 +1092,24 @@ class BinaryGenerator:
         else:
             raise KeyError(f"{Z_div_Zsun} is a not defined metallicity")
         X = 1. - Z - Y
+
         # Extract individual kick components for star 1
-        kick1_velocity = output['S1_natal_kick_velocity'][0] if hasattr(output['S1_natal_kick_velocity'], '__len__') else output['S1_natal_kick_velocity']
-        kick1_azimuthal = output['S1_natal_kick_azimuthal_angle'][0] if hasattr(output['S1_natal_kick_azimuthal_angle'], '__len__') else output['S1_natal_kick_azimuthal_angle']
-        kick1_polar = output['S1_natal_kick_polar_angle'][0] if hasattr(output['S1_natal_kick_polar_angle'], '__len__') else output['S1_natal_kick_polar_angle']
-        kick1_anomaly = output['S1_natal_kick_mean_anomaly'][0] if hasattr(output['S1_natal_kick_mean_anomaly'], '__len__') else output['S1_natal_kick_mean_anomaly']
+        kick1_velocity = output['S1_natal_kick_velocity'].item()
+        kick1_azimuthal = output['S1_natal_kick_azimuthal_angle'].item()
+        kick1_polar = output['S1_natal_kick_polar_angle'].item()
+        kick1_anomaly = output['S1_natal_kick_mean_anomaly'].item()
 
         star1_params = dict(
-                mass=m1,
-                state="H-rich_Core_H_burning",
-                metallicity=kwargs.get('metallicity', 1.0),
-                natal_kick_array=kick1,
-            )
+            mass=m1,
+            state="H-rich_Core_H_burning",
+            metallicity=Z,
+            center_h1=X,
+            center_he4=Y,
+            natal_kick_velocity=kick1_velocity,
+            natal_kick_azimuthal_angle=kick1_azimuthal,
+            natal_kick_polar_angle=kick1_polar,
+            natal_kick_mean_anomaly=kick1_anomaly,
+        )
 
         if is_binary:
             separation = output['separation'].item()
@@ -1112,10 +1118,10 @@ class BinaryGenerator:
             m2 = output['S2_mass'].item()
 
             # Extract individual kick components for star 2
-            kick2_velocity = output['S2_natal_kick_velocity'][0] if hasattr(output['S2_natal_kick_velocity'], '__len__') else output['S2_natal_kick_velocity']
-            kick2_azimuthal = output['S2_natal_kick_azimuthal_angle'][0] if hasattr(output['S2_natal_kick_azimuthal_angle'], '__len__') else output['S2_natal_kick_azimuthal_angle']
-            kick2_polar = output['S2_natal_kick_polar_angle'][0] if hasattr(output['S2_natal_kick_polar_angle'], '__len__') else output['S2_natal_kick_polar_angle']
-            kick2_anomaly = output['S2_natal_kick_mean_anomaly'][0] if hasattr(output['S2_natal_kick_mean_anomaly'], '__len__') else output['S2_natal_kick_mean_anomaly']
+            kick2_velocity = output['S2_natal_kick_velocity'].item()
+            kick2_azimuthal = output['S2_natal_kick_azimuthal_angle'].item()
+            kick2_polar = output['S2_natal_kick_polar_angle'].item()
+            kick2_anomaly = output['S2_natal_kick_mean_anomaly'].item()
 
             binary_params = dict(
                 index=kwargs.get('index', default_index),
@@ -1127,17 +1133,7 @@ class BinaryGenerator:
                 eccentricity=eccentricity,
                 history_verbose=self.kwargs.get("history_verbose", False)
             )
-            star1_params = dict(
-                mass=m1,
-                state="H-rich_Core_H_burning",
-                metallicity=Z,
-                center_h1=X,
-                center_he4=Y,
-                natal_kick_velocity=kick1_velocity,
-                natal_kick_azimuthal_angle=kick1_azimuthal,
-                natal_kick_polar_angle=kick1_polar,
-                natal_kick_mean_anomaly=kick1_anomaly,
-            )
+
             star2_params = dict(
                 mass=m2,
                 state="H-rich_Core_H_burning",
@@ -1165,23 +1161,7 @@ class BinaryGenerator:
                 eccentricity=eccentricity,
                 history_verbose=self.kwargs.get("history_verbose", False)
             )
-            # Extract individual kick components
-            kick1_velocity = kick1[0] if kick1.ndim > 0 else kick1
-            kick1_azimuthal = kick1[1] if kick1.ndim > 0 else None
-            kick1_polar = kick1[2] if kick1.ndim > 0 else None
-            kick1_anomaly = kick1[3] if kick1.ndim > 0 else None
 
-            star1_params = dict(
-                mass=m1,
-                state="H-rich_Core_H_burning",
-                metallicity=Z,
-                center_h1=X,
-                center_he4=Y,
-                natal_kick_velocity=kick1_velocity,
-                natal_kick_azimuthal_angle=kick1_azimuthal,
-                natal_kick_polar_angle=kick1_polar,
-                natal_kick_mean_anomaly=kick1_anomaly,
-            )
             star2_params = properties_massless_remnant()
 
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -1077,21 +1077,6 @@ class BinaryGenerator:
 
         formation_time = output['time'].item()
         m1 = output['S1_mass'].item()
-        Z_div_Zsun = kwargs.get('metallicity', 1.)
-        zams_table = {2.: 2.915e-01,
-                      1.: 2.703e-01,
-                      0.45: 2.586e-01,
-                      0.2: 2.533e-01,
-                      0.1: 2.511e-01,
-                      0.01: 2.492e-01,
-                      0.001: 2.49e-01,
-                      0.0001: 2.49e-01}
-        Z = Z_div_Zsun*Zsun
-        if Z_div_Zsun in zams_table.keys():
-            Y = zams_table[Z_div_Zsun]
-        else:
-            raise KeyError(f"{Z_div_Zsun} is a not defined metallicity")
-        X = 1. - Z - Y
 
         # Extract individual kick components for star 1
         kick1_velocity = output['S1_natal_kick_velocity'].item()
@@ -1102,9 +1087,7 @@ class BinaryGenerator:
         star1_params = dict(
             mass=m1,
             state="H-rich_Core_H_burning",
-            metallicity=Z,
-            center_h1=X,
-            center_he4=Y,
+            metallicity=kwargs.get('metallicity', 1.0),
             natal_kick_velocity=kick1_velocity,
             natal_kick_azimuthal_angle=kick1_azimuthal,
             natal_kick_polar_angle=kick1_polar,
@@ -1137,9 +1120,7 @@ class BinaryGenerator:
             star2_params = dict(
                 mass=m2,
                 state="H-rich_Core_H_burning",
-                metallicity=Z,
-                center_h1=X,
-                center_he4=Y,
+                metallicity=kwargs.get('metallicity', 1.0),
                 natal_kick_velocity=kick2_velocity,
                 natal_kick_azimuthal_angle=kick2_azimuthal,
                 natal_kick_polar_angle=kick2_polar,
@@ -1163,7 +1144,6 @@ class BinaryGenerator:
             )
 
             star2_params = properties_massless_remnant()
-
 
         binary = BinaryStar(**binary_params,
                             star_1=SingleStar(**star1_params),

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -142,6 +142,12 @@ EXTRA_STAR_COLUMNS_DTYPES = {
 }
 
 SCALAR_NAMES_DTYPES = {
+    # Individual natal kick properties (new)
+    'natal_kick_velocity': 'float64',
+    'natal_kick_azimuthal_angle': 'float64',
+    'natal_kick_polar_angle': 'float64',
+    'natal_kick_mean_anomaly': 'float64',
+    # Legacy natal kick array components (for backward compatibility)
     'natal_kick_array_0': 'float64',
     'natal_kick_array_1': 'float64',
     'natal_kick_array_2': 'float64',

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -567,7 +567,10 @@
                          #'total_mass_he4',
                         ]
   scalar_names = [
-                  'natal_kick_array', # each value accessed by natal_kick_array_0 up to 3
+                  'natal_kick_velocity',
+                  'natal_kick_azimuthal_angle',
+                  'natal_kick_polar_angle',
+                  'natal_kick_mean_anomaly'
                   'spin_orbit_tilt_first_SN',
                   'spin_orbit_tilt_second_SN',
                   'f_fb',
@@ -652,8 +655,10 @@
                          #'total_mass_h1',
                          #'total_mass_he4',
                         ]
-  scalar_names = [
-                  'natal_kick_array', # each value accessed by natal_kick_array_0 up to 3
+  scalar_names = ['natal_kick_velocity',
+                  'natal_kick_azimuthal_angle',
+                  'natal_kick_polar_angle',
+                  'natal_kick_mean_anomaly',
                   'spin_orbit_tilt_first_SN',
                   'spin_orbit_tilt_second_SN',
                   'f_fb',

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -26,17 +26,17 @@ PERIOD_NAMES = ['orbital_period', 'period', 'p_orb', 'porb', 'p']
 SEPARATION_NAMES = ['orbital_separation', 'separation', 'semi-major_axis',\
                     'semi_major_axis', 'a']
 ECCENTRICITY_NAMES = ['eccentricity', 'ecc', 'e']
-PRIMARY_KICK_VELOCITY_NAMES = ['s1_natal_kick_array_0', 'w_1', 'w1']
-SECONDARY_KICK_VELOCITY_NAMES = ['s2_natal_kick_array_0', 'w_2', 'w2']
-PRIMARY_KICK_AZIMUTHAL_ANGLE_NAMES = ['s1_natal_kick_array_1', 'phi_1', 'phi1']
-SECONDARY_KICK_AZIMUTHAL_ANGLE_NAMES = ['s2_natal_kick_array_1', 'phi_2',\
+PRIMARY_KICK_VELOCITY_NAMES = ['s1_natal_kick_velocity', 's1_natal_kick_array_0', 'w_1', 'w1']
+SECONDARY_KICK_VELOCITY_NAMES = ['s2_natal_kick_velocity', 's2_natal_kick_array_0', 'w_2', 'w2']
+PRIMARY_KICK_AZIMUTHAL_ANGLE_NAMES = ['s1_natal_kick_azimuthal_angle', 's1_natal_kick_array_1', 'phi_1', 'phi1']
+SECONDARY_KICK_AZIMUTHAL_ANGLE_NAMES = ['s2_natal_kick_azimuthal_angle', 's2_natal_kick_array_1', 'phi_2',\
                                         'phi2']
-PRIMARY_KICK_POLAR_ANGLE_NAMES = ['s1_natal_kick_array_2', 'theta_1', 'theta1']
-SECONDARY_KICK_POLAR_ANGLE_NAMES = ['s2_natal_kick_array_2', 'theta_2',\
+PRIMARY_KICK_POLAR_ANGLE_NAMES = ['s1_natal_kick_polar_angle', 's1_natal_kick_array_2', 'theta_1', 'theta1']
+SECONDARY_KICK_POLAR_ANGLE_NAMES = ['s2_natal_kick_polar_angle', 's2_natal_kick_array_2', 'theta_2',\
                                     'theta2']
-PRIMARY_KICK_MEAN_ANOMALY_NAMES = ['s1_natal_kick_array_3', 'mean_anomaly_1',\
+PRIMARY_KICK_MEAN_ANOMALY_NAMES = ['s1_natal_kick_mean_anomaly', 's1_natal_kick_array_3', 'mean_anomaly_1',\
                                    'mean_anomaly1']
-SECONDARY_KICK_MEAN_ANOMALY_NAMES = ['s2_natal_kick_array_3',\
+SECONDARY_KICK_MEAN_ANOMALY_NAMES = ['s2_natal_kick_mean_anomaly', 's2_natal_kick_array_3',\
                                      'mean_anomaly_2', 'mean_anomaly2']
 
 def infer_key(available_keys=[], allowed_keys=[]):
@@ -192,11 +192,11 @@ def get_kick_samples_from_file(**kwargs):
 
     Returns
     -------
-    s1_natal_kick_array_set : ndarray of floats
-        natal kick array for the primary star
+    s1_natal_kick_set : ndarray of floats
+        natal kick components for the primary star
         containing: kick velocity, azimuthal angle, polar angle, mean anomaly
-    s2_natal_kick_array_set : ndarray of floats
-        natal kick array for the secondary star
+    s2_natal_kick_set : ndarray of floats
+        natal kick components for the secondary star
         containing: kick velocity, azimuthal angle, polar angle, mean anomaly
 
     """


### PR DESCRIPTION
Move from a `natal_kick_arary` to the individual components as part of the `SingleStar` object.

This is still backwards compatible, ie. if `natal_kick_array` is given in the configuration file, it will still be outputted in the original format, but a deprecation warning will be raised.
It will also output the new format at the same time. 

I've named the new components:
- natal_kick_velocity
- natal_kick_azimuthal_angle
- natal_kick_polar_angle
- natal_kick_mean_anomaly

