### PR TITLE
`tides` and `winds` output sanitise

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1244,8 +1244,6 @@ class detached_evolution:
         .. [8] Gossage et al. 2021, ApJ, 912, 65
 
         """
-        print('t = ', t)
-        print('y = ', y)
         # update star/orbital props w/ current time during integration
         self.update_props(t, y)
 

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1257,14 +1257,16 @@ class detached_evolution:
         if self.do_tides:
             self.tides()
 
-        print(f"After tides: da = {self.da}, de = {self.de}, "
+        if self.verbose:
+            print(f"After tides: da = {self.da}, de = {self.de}, "
                   f"dOmega_sec = {self.dOmega_sec}, dOmega_pri = {self.dOmega_pri}")
 
         #  Gravitional radiation affecting the orbit
         if self.do_gravitational_radiation:
             self.gravitational_radiation()
 
-        print(f"After gravrad: da = {self.da}, de = {self.de}, "
+        if self.verbose:
+            print(f"After gravrad: da = {self.da}, de = {self.de}, "
                   f"dOmega_sec = {self.dOmega_sec}, dOmega_pri = {self.dOmega_pri}")
 
         #  Magnetic braking affecting stellar spins

--- a/posydon/binary_evol/DT/step_initially_single.py
+++ b/posydon/binary_evol/DT/step_initially_single.py
@@ -23,7 +23,7 @@ LIST_ACCEPTABLE_STATES_FOR_POSTHeMS = STAR_STATES_HE_RICH.copy()
 
 class InitiallySingleStep(IsolatedStep):
     """
-    Prepare a runaway star to do an an isolated_step)
+    Prepare a runaway star to do an isolated_step
     """
 
     def __init__(self,

--- a/posydon/binary_evol/DT/tides/default_tides.py
+++ b/posydon/binary_evol/DT/tides/default_tides.py
@@ -156,7 +156,7 @@ def default_tides(a, e, primary, secondary, verbose=False):
             R1,
             m1
         )
-        print("convective tiimescales and efficiencies",
+        print("convective timescales and efficiencies",
             tau_conv_2, P_orb, P_spin_sec, P_tid_sec,
             f_conv_sec,
             F_tid,
@@ -328,6 +328,22 @@ def default_tides(a, e, primary, secondary, verbose=False):
             / (1 - e ** 2) ** 6
             * (f2 - (1 - e ** 2) ** (3 / 2) * f5 * omega1 / n)
     )
+    # check if values are finite
+    # secondary
+    if not np.isfinite(da_tides_sec):
+        da_tides_sec = 0.0
+    if not np.isfinite(de_tides_sec):
+        de_tides_sec = 0.0
+    if not np.isfinite(dOmega_tides_sec):
+        dOmega_tides_sec = 0.0
+    # primary
+    if not np.isfinite(da_tides_pri):
+        da_tides_pri = 0.0
+    if not np.isfinite(de_tides_pri):
+        de_tides_pri = 0.0
+    if not np.isfinite(dOmega_tides_pri):
+        dOmega_tides_pri = 0.0
+
     if verbose:
         print("da,de,dOmega_tides = ",
             da_tides_sec, de_tides_sec, dOmega_tides_sec,

--- a/posydon/binary_evol/DT/winds/default_winds.py
+++ b/posydon/binary_evol/DT/winds/default_winds.py
@@ -139,6 +139,10 @@ def default_sep_from_winds(a, e, primary, secondary, verbose = False):
     m1 = primary.latest["mass"] # Msol
     mdot_1 = primary.latest["mdot"] # Msol/yr
 
+    if verbose:
+        print("Wind mass loss rates (Msol/yr): ", mdot_1, mdot_2)
+        print("Masses (Msol): ", m1, m2)
+
     q1 = m2 / m1
     k11 = (1 / (1 + q1)) * (mdot_2 / m2)
     k21 = mdot_2 / m2
@@ -152,6 +156,11 @@ def default_sep_from_winds(a, e, primary, secondary, verbose = False):
     k22 = mdot_1 / m1
     k32 = mdot_1 / (m1 + m2)
     da_mt_pri = a * (2 * k12 - 2 * k22 + k32)
+
+    if not np.isfinite(da_mt_sec):
+        da_mt_sec = 0.0
+    if not np.isfinite(da_mt_pri):
+        da_mt_pri = 0.0
 
     if verbose:
         print("da_mt = ", da_mt_sec, da_mt_pri)


### PR DESCRIPTION
For a massless_remnant companion, the `tides` and `wind` calculation results in NaN values being added to the period.
This causes the solver to get stuck with NaN values.
In this PR, the outputs of `default_tides` and `default_winds` are sanitised to set NaN values to 0.


Additionally:
- Some additional typos are fixed
- verbose information added
- verbose passed to `detached_evolution` class.