### PR TITLE
[fix] Remove `step_disrupted` parameters from population_params.ini

### DIFF
--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -176,20 +176,6 @@
     # float, DEF: 1e-2
   matching_tolerance_hard = 1e-1
     # float, DEF: 1e-1
-  do_wind_loss = True
-    # True, False
-  do_tides = True
-    # True, False
-  do_gravitational_radiation = True
-    # True, False
-  do_magnetic_braking = True
-    # True, False
-  magnetic_braking_mode = 'RVJ83'
-    # 'RVJ83', 'M15', 'G18', 'CARB'
-  do_stellar_evolution_and_spin_from_winds = True
-    # True, False
-  RLO_orbit_at_orbit_with_same_am = False
-    # True, False
   record_matching = False
     # True, False
   verbose = False


### PR DESCRIPTION
Removes the `step_disrupted` parameters from the `population_params.ini` file, which was incorrectly setting the options for `step_disrupted` to `step_detached` values. Now we fall back to the defaults from `IsolatedStep`