### PR TITLE
`model_weights` warning

### DIFF
--- a/posydon/popsyn/distributions.py
+++ b/posydon/popsyn/distributions.py
@@ -259,15 +259,18 @@ class Sana12Period():
         B = 1./beta * (np.log10(self.p_max)**beta - np.log10(10**0.15)**beta)
         C = 1./(A + B)
         logp_valid = logp[mask2]
-        result[mask2] = np.where(
-            (np.log10(self.p_min) <= logp_valid) & (logp_valid < 0.15),
-            C * 0.15**(-self.slope),
-            np.where(
-                (0.15 <= logp_valid) & (logp_valid <= np.log10(self.p_max)),
-                C * logp_valid**(-self.slope),
-                0
-            )
-        )
+
+        temp_result = np.zeros_like(logp_valid, dtype=float)
+
+        # Handle the first region: p_min <= logp < 0.15
+        mask_region1 = (np.log10(self.p_min) <= logp_valid) & (logp_valid < 0.15)
+        temp_result[mask_region1] = C * 0.15**(-self.slope)
+
+        # Handle the second region: 0.15 <= logp <= p_max
+        mask_region2 = (0.15 <= logp_valid) & (logp_valid <= np.log10(self.p_max))
+        temp_result[mask_region2] = C * logp_valid[mask_region2]**(-self.slope)
+
+        result[mask2] = temp_result
 
         return result
 


### PR DESCRIPTION
When using the `model_weights` calculation, a warning is generally thrown:

```
.../python3.11/site-packages/posydon/popsyn/distributions.py:266: RuntimeWarning: invalid value encountered in power
```

This is caused by the calculation inside the Sana+12 period distribution weighting.
There are two regimes logP<0.15, where the distribution is flat. And logP>0.15, which follows logP^-0.55
Inside `np.where`, both "arrays" are calculated, which leads to logP<0.15 being calculated in the logP^-0.55 regime as well. This raises a warning, since negative numbers cannot go to a negative power. 

It's not an issue in the result, because the other regime is used. 
This fixes this warning by only performing the calculation on the relevant regions.