### PR TITLE
[feat/fix] .gitignore dev-tools POSYDON_* folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ venv.bak/
 
 # macOS
 .DS_store
+
+# dev-tools folders
+/dev-tools/POSYDON_*


### PR DESCRIPTION
Makes sure to ignore any folders created in `dev-tools/POSYDON_*`
