### PR TITLE
[fix] Matching logic for failed matches

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -1492,16 +1492,14 @@ class StepCEE(object):
                       f"The Roche lobe of the companion is: {RL2}, The radius is: {rc2_i}")
                 print("Adjusting the companion's radius by matching to single star.")
             t_i = binary.time
-            if comp_star == binary.star_1:
-                match_s1 = True
-                match_s2 = False
-            else:
-                match_s1 = False
-                match_s2 = True
+
+
+            match_primary = False
+            match_secondary = True
 
             _, _, only_CO = self.track_matcher.do_matching(binary, step_name="step_CE",
-                                                           match_s1=match_s1,
-                                                           match_s2=match_s2)
+                                                           match_primary=match_primary,
+                                                           match_secondary=match_secondary)
 
             rc2_i = 10**comp_star.interp1d['log_R'](t_i)
 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1723,7 +1723,7 @@ class TrackMatcher:
 
         return omega0_pri, omega0_sec
 
-    def do_matching(self, binary, step_name="step_match", 
+    def do_matching(self, binary, step_name="step_match",
                     match_secondary=True, match_primary=True):
 
         """

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1408,11 +1408,6 @@ class TrackMatcher:
 
         """
 
-        #if star == binary.star_1 and not self.match_s1:
-        #    return None, None
-        #elif star == binary.star_2 and not self.match_s2:
-        #    return None, None
-
         with np.errstate(all="ignore"):
             # get the initial m0, t0 track
             if star.co:
@@ -1833,7 +1828,7 @@ class TrackMatcher:
 
             self.get_star_match_data(binary, primary)
 
-        elif self.primary_not_normal:
+        elif self.match_primary and self.primary_not_normal:
             # copy the secondary star except mass which is of the primary,
             # and radius, mdot, Idot = 0
             self.get_star_match_data(binary, primary,
@@ -1857,8 +1852,6 @@ class TrackMatcher:
            (primary.interp1d == None and self.match_primary):
             failed_state = binary.state
             set_binary_to_failed(binary)
-            print(primary.interp1d, self.match_primary)
-            print(secondary.interp1d, self.match_secondary)
             raise MatchingError("Grid matching failed for "
                                 f"{failed_state} binary.")
 


### PR DESCRIPTION
The matching logic in `v2.2` would check if the `interp1d` object was `None` (which happens if matching fails) and if the star was `matched`, like this:

```
if (secondary.interp1d == None and secondary.matched) or \
   (primary.interp1d == None and primary.matched):

   # FAILED BINARY
```

What should be checked instead by `TrackMatcher` is not whether the star was `matched`, but whether it was supposed to match the star in the first place. This is indicated now by the bools `match_secondary` and `match_primary` (renamed from `match_s1` and `match_s2`):

```
if (secondary.interp1d == None and self.match_secondary) or \
   (primary.interp1d == None and self.match_primary):

   # FAILED BINARY
```

This is specific to `v2.2`. The current `main` branch does not suffer from this issue. It is related to changes that came with the new additions to `step_CE`.