### PR TITLE
[fix] Adding a case for post HeMS matching and fix `step_CE` surface He assignment

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -56,6 +56,7 @@ from posydon.utils.common_functions import (
     check_state_of_star,
 )
 from posydon.utils.posydonwarning import Pwarn
+from posydon.utils.constants import Zsun
 
 MODEL = {"prescription": 'alpha-lambda',
          "common_envelope_efficiency": 1.0,
@@ -1154,9 +1155,9 @@ class StepCEE(object):
                 star.he_core_mass = core_mass
                 star.he_core_radius = core_radius
                 if star.metallicity is None:
-                    star.surface_he4 = 1 - star.surface_h1 - 0.0142
+                    star.surface_he4 = 1 - star.surface_h1 - Zsun
                 else:
-                    star.surface_he4 = 1.0-star.surface_h1-star.metallicity * 0.0142
+                    star.surface_he4 = 1 - star.surface_h1 - star.metallicity * Zsun
                 star.log_LH = -1e99
                 attributes_changing.extend([
                                         "surface_h1",

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -1156,7 +1156,7 @@ class StepCEE(object):
                 if star.metallicity is None:
                     star.surface_he4 = 1 - star.surface_h1 - 0.0142
                 else:
-                    star.surface_he4 = 1.0-star.surface_h1-star.metallicity
+                    star.surface_he4 = 1.0-star.surface_h1-star.metallicity * 0.0142
                 star.log_LH = -1e99
                 attributes_changing.extend([
                                         "surface_h1",

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -55,8 +55,8 @@ from posydon.utils.common_functions import (
     calculate_Mejected_for_integrated_binding_energy,
     check_state_of_star,
 )
-from posydon.utils.posydonwarning import Pwarn
 from posydon.utils.constants import Zsun
+from posydon.utils.posydonwarning import Pwarn
 
 MODEL = {"prescription": 'alpha-lambda',
          "common_envelope_efficiency": 1.0,

--- a/posydon/binary_evol/DT/gravitational_radiation/default_gravrad.py
+++ b/posydon/binary_evol/DT/gravitational_radiation/default_gravrad.py
@@ -70,8 +70,8 @@ def default_gravrad(a, e, primary, secondary, verbose = False):
         ) * const.secyer
     # eq. (36) of Junker et al. 1992, 254, 146
 
-    if verbose:
-        print("da, de_gr = ", da_gr, de_gr)
+    #if verbose:
+    #    print("da, de_gr = ", da_gr, de_gr)
 
     da = da_gr
     de = de_gr

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1348,9 +1348,9 @@ class detached_evolution:
                 "'M15' for Matt et al. 2015"
                 "'CARB' for Van & Ivanova 2019", "UnsupportedModelWarning")
 
-        if self.verbose:
-            print("magnetic_braking_mode = ", self.magnetic_braking_mode)
-            print("dOmega_mb = ", dOmega_mb_sec, dOmega_mb_pri)
+        #if self.verbose:
+        #    print("magnetic_braking_mode = ", self.magnetic_braking_mode)
+        #    print("dOmega_mb = ", dOmega_mb_sec, dOmega_mb_pri)
 
         # update spins
         self.dOmega_sec += dOmega_mb_sec

--- a/posydon/binary_evol/DT/tides/default_tides.py
+++ b/posydon/binary_evol/DT/tides/default_tides.py
@@ -137,33 +137,33 @@ def default_tides(a, e, primary, secondary, verbose=False):
     if kT_conv_pri is None or not np.isfinite(kT_conv_pri):
         kT_conv_pri = 0.0
 
-        if verbose:
-            print("kT_conv_sec is", kT_conv_sec, ", set to 0.")
-            print("kT_conv_pri is", kT_conv_pri, ", set to 0.")
+        #if verbose:
+        #    print("kT_conv_sec is", kT_conv_sec, ", set to 0.")
+        #    print("kT_conv_pri is", kT_conv_pri, ", set to 0.")
     # this is the 1/timescale of all d/dt calculted below in yr^-1
 
-    if verbose:
-        print(
-            "Equilibrium tides in deep convective envelope",
-            m_env2,
-            dr_env2,
-            rmid_env2,
-            R2,
-            m2,
-            m_env1,
-            dr_env1,
-            rmid_env1,
-            R1,
-            m1
-        )
-        print("convective tiimescales and efficiencies",
-            tau_conv_2, P_orb, P_spin_sec, P_tid_sec,
-            f_conv_sec,
-            F_tid,
-            tau_conv_1, P_orb, P_spin_pri, P_tid_pri,
-            f_conv_pri,
-            F_tid,
-            )
+    #if verbose:
+    #    print(
+    #        "Equilibrium tides in deep convective envelope",
+    #        m_env2,
+    #        dr_env2,
+    #        rmid_env2,
+    #        R2,
+    #        m2,
+    #        m_env1,
+    #        dr_env1,
+    #        rmid_env1,
+    #        R1,
+    #        m1
+    #    )
+    #    print("convective timescales and efficiencies",
+    #        tau_conv_2, P_orb, P_spin_sec, P_tid_sec,
+    #        f_conv_sec,
+    #        F_tid,
+    #        tau_conv_1, P_orb, P_spin_pri, P_tid_pri,
+    #        f_conv_pri,
+    #        F_tid,
+    #        )
 
     # dynamical timecale
     F_tid = 1
@@ -207,22 +207,22 @@ def default_tides(a, e, primary, secondary, verbose=False):
     if (R_conv_pri > R1 or R_conv_pri <= 0.0
             or rbot_env1 / R1 > 0.1):
         E22 = 1.592e-9 * m1 ** (2.84)
-        if verbose:
-            print(
-                "R_conv of the convective core is not behaving well or we "
-                "are not calculating the convective core, we switch to "
-                "Zahn+1975 calculation of E2",
-                R_conv_sec,
-                R2,
-                rtop_env2,
-                rbot_env2,
-                E21,
-                R_conv_pri,
-                R1,
-                rtop_env1,
-                rbot_env1,
-                E22
-            )
+        #if verbose:
+        #    print(
+        #        "R_conv of the convective core is not behaving well or we "
+        #        "are not calculating the convective core, we switch to "
+        #        "Zahn+1975 calculation of E2",
+        #        R_conv_sec,
+        #        R2,
+        #        rtop_env2,
+        #        rbot_env2,
+        #        E21,
+        #        R_conv_pri,
+        #        R1,
+        #        rtop_env1,
+        #        rbot_env1,
+        #        E22
+        #    )
     else:
         if R1 <= 0:
             E22 = 0
@@ -251,25 +251,25 @@ def default_tides(a, e, primary, secondary, verbose=False):
         * E22
         * const.secyer)
     # this is the 1/timescale of all d/dt calculted below in yr^-1
-    if verbose:
-        print(
-            "Dynamical tides in radiative envelope",
-            rtop_env2,
-            rbot_env2,
-            R_conv_sec,
-            E21,
-            rtop_env1,
-            rbot_env1,
-            R_conv_pri,
-            E22,
-            F_tid
-        )
+    #if verbose:
+    #    print(
+    #        "Dynamical tides in radiative envelope",
+    #        rtop_env2,
+    #        rbot_env2,
+    #        R_conv_sec,
+    #        E21,
+    #        rtop_env1,
+    #        rbot_env1,
+    #        R_conv_pri,
+    #        E22,
+    #        F_tid
+    #    )
     kT_sec = max(kT_conv_sec, kT_rad_sec)
     kT_pri = max(kT_conv_pri, kT_rad_pri)
-    if verbose:
-        print("kT_conv/rad of tides is ", kT_conv_sec, kT_rad_sec,
-            kT_conv_pri, kT_rad_pri, "in 1/yr, and we picked the ",
-            kT_sec, kT_pri)
+    #if verbose:
+    #    print("kT_conv/rad of tides is ", kT_conv_sec, kT_rad_sec,
+    #        kT_conv_pri, kT_rad_pri, "in 1/yr, and we picked the ",
+    #        kT_sec, kT_pri)
 
     da_tides_sec = (
             -6
@@ -328,10 +328,10 @@ def default_tides(a, e, primary, secondary, verbose=False):
             / (1 - e ** 2) ** 6
             * (f2 - (1 - e ** 2) ** (3 / 2) * f5 * omega1 / n)
     )
-    if verbose:
-        print("da,de,dOmega_tides = ",
-            da_tides_sec, de_tides_sec, dOmega_tides_sec,
-            da_tides_pri, de_tides_pri, dOmega_tides_pri)
+    #if verbose:
+    #    print("da,de,dOmega_tides = ",
+    #        da_tides_sec, de_tides_sec, dOmega_tides_sec,
+    #        da_tides_pri, de_tides_pri, dOmega_tides_pri)
 
     da = da_tides_sec + da_tides_pri
     de = de_tides_sec + de_tides_pri

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -34,8 +34,8 @@ from posydon.binary_evol.flow_chart import (
     STAR_STATES_H_RICH,
     STAR_STATES_HE_RICH,
     STAR_STATES_FOR_Hestar_MATCHING,
+    STAR_STATES_FOR_postHeMS_MATCHING,
     STAR_STATES_FOR_postMS_MATCHING,
-    STAR_STATES_FOR_postHeMS_MATCHING
 )
 from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.interpolation.data_scaling import DataScaler

--- a/posydon/binary_evol/DT/winds/default_winds.py
+++ b/posydon/binary_evol/DT/winds/default_winds.py
@@ -76,19 +76,19 @@ def default_spin_from_winds(a, e, primary, secondary, verbose = False):
     dOmega_deformation_pri = np.min(
         [-omega1 * Idot_1 / MOI_1, 100]
     )
-    if verbose:
-        print(
-            "dOmega_spin_wind , dOmega_deformation = ",
-            dOmega_spin_wind_sec,
-            dOmega_deformation_sec,
-            dOmega_spin_wind_pri,
-            dOmega_deformation_pri,
-        )
+    #if verbose:
+    #    print(
+    #        "dOmega_spin_wind , dOmega_deformation = ",
+    #        dOmega_spin_wind_sec,
+    #        dOmega_deformation_sec,
+    #        dOmega_spin_wind_pri,
+    #        dOmega_deformation_pri,
+    #    )
     dOmega_sec = dOmega_spin_wind_sec + dOmega_deformation_sec
     dOmega_pri = dOmega_spin_wind_pri + dOmega_deformation_pri
 
-    if verbose:
-        print("a[Ro],e,Omega[rad/yr] have been =", a, e, omega2, omega1)
+    #if verbose:
+    #    print("a[Ro],e,Omega[rad/yr] have been =", a, e, omega2, omega1)
         #print("da,de,dOmega (all) in 1yr is = ",
         #    da, de, dOmega_sec, dOmega_pri)
 
@@ -153,8 +153,8 @@ def default_sep_from_winds(a, e, primary, secondary, verbose = False):
     k32 = mdot_1 / (m1 + m2)
     da_mt_pri = a * (2 * k12 - 2 * k22 + k32)
 
-    if verbose:
-        print("da_mt = ", da_mt_sec, da_mt_pri)
+    #if verbose:
+    #    print("da_mt = ", da_mt_sec, da_mt_pri)
 
     da_mt_tot = da_mt_sec + da_mt_pri
 

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -129,6 +129,10 @@ STAR_STATES_FOR_postMS_MATCHING = [st for st in STAR_STATES_NORMALSTAR if \
 STAR_STATES_FOR_Hestar_MATCHING = [st for st in STAR_STATES_NORMALSTAR if \
                                    ("stripped_He" in st)]
 STAR_STATES_FOR_Hestar_MATCHING.extend(['accreted_He_Core_He_burning'])
+STAR_STATES_FOR_postHeMS_MATCHING = [st for st in STAR_STATES_NORMALSTAR if \
+                                   (("Core_He_burning" not in st) & ("stripped_He" in st))]
+STAR_STATES_FOR_Hestar_MATCHING = list(set(STAR_STATES_FOR_Hestar_MATCHING)
+                                      - set(STAR_STATES_FOR_postHeMS_MATCHING))
 
 BINARY_STATES_ALL = [
     'initially_single_star',


### PR DESCRIPTION
This adds a new case for post HeMS stars that ignores the central he4 abundance in matching. This parameter appears to cause issues in matching when it is extremely small in these core He depleted stars.

This also comments out some of the verbose statements in the ODEs of detached evolution. They print out every timestep which may be a bit much, but we can revert back if that is preferred. It may be more suitable to enable these outputs with e.g., a debugging mode instead of simple verbose output.

This also includes a small fix to `step_CE` in the assignment of surface helium. Previous code used `star.metallicity`, which for solar is `1`, for example. The fix multiplies by our current metallicity scaling, 0.0142 (Asplund et al. 2009) to calculate the abundance in the intended way. Previously this led to negative surface abundance being assigned to the star.

Tested w/ our test suite, fixing some of the previous grid match failures.