### PR TITLE
[fix] replace `np.array_equal` with `np.allclose` in `unit_tests`

### DIFF
--- a/posydon/unit_tests/grids/test_downsampling.py
+++ b/posydon/unit_tests/grids/test_downsampling.py
@@ -66,13 +66,13 @@ class TestFunctions:
                        [0.8, 0.5, 0.0, 1.0]]
         min_values = [0.0, 1.0, 3.0, -2.0]
         max_values = [0.5, 2.0, 3.0, -1.0]
-        assert np.array_equal(totest.rescale_from_0_to_1(test_values),\
+        assert np.allclose(totest.rescale_from_0_to_1(test_values),\
                               np.array(norm_values))
         arr, minima, maxima = totest.rescale_from_0_to_1(test_values,\
                                                          return_minmax=True)
-        assert np.array_equal(arr, np.array(norm_values))
-        assert np.array_equal(minima, np.array(min_values))
-        assert np.array_equal(maxima, np.array(max_values))
+        assert np.allclose(arr, np.array(norm_values))
+        assert np.allclose(minima, np.array(min_values))
+        assert np.allclose(maxima, np.array(max_values))
 
 
 class TestTrackDownsampler:
@@ -101,12 +101,12 @@ class TestTrackDownsampler:
         # __init__ got executed: the elements are created and initialized
         assert TrackDownsampler.verbose == False
         assert TrackDownsampler.keep == None
-        assert np.array_equal(TrackDownsampler.t, independent_sample)
-        assert np.array_equal(TrackDownsampler.X, norm_dependent_sample)
+        assert np.allclose(TrackDownsampler.t, independent_sample)
+        assert np.allclose(TrackDownsampler.X, norm_dependent_sample)
         # examples: dependend is 1D
         test_TrackDownsampler = totest.TrackDownsampler([0.0, 0.1], [1.0, 2.0])
-        assert np.array_equal(test_TrackDownsampler.t, np.array([0.0, 0.1]))
-        assert np.array_equal(test_TrackDownsampler.X, np.array([[0.0],\
+        assert np.allclose(test_TrackDownsampler.t, np.array([0.0, 0.1]))
+        assert np.allclose(test_TrackDownsampler.X, np.array([[0.0],\
                                                                  [1.0]]))
         # bad input
         with raises(ValueError, match="`independent` is not iterable."):
@@ -149,9 +149,9 @@ class TestTrackDownsampler:
         arr, minima, maxima = totest.rescale_from_0_to_1(dependent_sample,\
                                                          return_minmax=True)
         TrackDownsampler.rescale()
-        assert np.array_equal(arr, TrackDownsampler.X)
-        assert np.array_equal(minima, TrackDownsampler.minima)
-        assert np.array_equal(maxima, TrackDownsampler.maxima)
+        assert np.allclose(arr, TrackDownsampler.X)
+        assert np.allclose(minima, TrackDownsampler.minima)
+        assert np.allclose(maxima, TrackDownsampler.maxima)
 
     def test_extract_downsample(self, independent_sample, dependent_sample,\
                                 norm_dependent_sample, TrackDownsampler):
@@ -160,11 +160,11 @@ class TestTrackDownsampler:
         for k in [None, independent_sample<1.0]:
             TrackDownsampler.keep = k
             t, X = TrackDownsampler.extract_downsample()
-            assert np.array_equal(t, independent_sample[k])
-            assert np.array_equal(X, dependent_sample[k, :])
+            assert np.allclose(t, independent_sample[k])
+            assert np.allclose(X, dependent_sample[k, :])
             t, X = TrackDownsampler.extract_downsample(scale_back=False)
-            assert np.array_equal(t, independent_sample[k])
-            assert np.array_equal(X, norm_dependent_sample[k, :])
+            assert np.allclose(t, independent_sample[k])
+            assert np.allclose(X, norm_dependent_sample[k, :])
 
     def test_find_downsample(self, TrackDownsampler, capsys):
         assert isroutine(TrackDownsampler.find_downsample)
@@ -202,5 +202,5 @@ class TestTrackDownsampler:
         assert isroutine(TrackDownsampler.downsample)
         # examples
         t, X = TrackDownsampler.downsample()
-        assert np.array_equal(t, independent_sample)
-        assert np.array_equal(X, dependent_sample)
+        assert np.allclose(t, independent_sample)
+        assert np.allclose(X, dependent_sample)

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -636,9 +636,9 @@ class TestFunctions:
         # examples:
         bh, h1, h2 = totest.downsample_history(binary_history, star_history,\
                                                star_history, ConfigFile)
-        assert np.array_equal(bh, binary_history)
-        assert np.array_equal(h1, star_history)
-        assert np.array_equal(h2, star_history)
+        assert np.allclose(bh, binary_history)
+        assert np.allclose(h1, star_history)
+        assert np.allclose(h2, star_history)
 
     def test_downsample_profile(self, ConfigFile, profile):
         # missing argument
@@ -649,7 +649,7 @@ class TestFunctions:
         with raises(TypeError, match="'NoneType' object is not subscriptable"):
             totest.downsample_profile(None, None)
         # examples: failed
-        assert np.array_equal(totest.downsample_profile(profile, ConfigFile),\
+        assert np.allclose(totest.downsample_profile(profile, ConfigFile),\
                               profile)
         ConfigFile.entries["profile_DS_error"] = 0.1
         assert totest.downsample_profile(None, ConfigFile) is None
@@ -659,7 +659,7 @@ class TestFunctions:
             totest.downsample_profile(profile, ConfigFile)
         # examples
         ConfigFile.entries["profile_DS_exclude"] = ['mass']
-        assert np.array_equal(totest.downsample_profile(profile, ConfigFile),\
+        assert np.allclose(totest.downsample_profile(profile, ConfigFile),\
                               profile)
 
     def test_join_grids(self, monkeypatch, no_path, h5_out_path, grid1_path,\
@@ -694,7 +694,7 @@ class TestFunctions:
                     if v is None:
                         assert s in hdf5_file.keys()
                     else:
-                        assert np.array_equal(hdf5_file[s][()], v)
+                        assert np.allclose(hdf5_file[s][()], v)
         def mock_get_detected_initial_RLO(grid):
             # mocked list of initial RLO systems
             if (hasattr(grid, "config") and ("description" in grid.config)):
@@ -825,9 +825,9 @@ class TestFunctions:
             new_ini_val = hdf5_file['/grid/initial_values'][()]
             new_fin_val = hdf5_file['/grid/final_values'][()]
         for col in ['star_1_mass', 'star_2_mass', 'period_days']:
-            assert np.array_equal(ini_val[col], new_ini_val[col],\
+            assert np.allclose(ini_val[col], new_ini_val[col],\
                                   equal_nan=True)
-            assert np.array_equal(fin_val[col], new_fin_val[col],\
+            assert np.allclose(fin_val[col], new_fin_val[col],\
                                   equal_nan=True)
         for r in [1, 4, 5]: # done initial RLO replacements
             fin_val['termination_flag_1'][r] = b'forced_initial_RLO'
@@ -838,7 +838,7 @@ class TestFunctions:
         for col in ['termination_flag_1', 'termination_flag_2',\
                     'termination_flag_3', 'termination_flag_4',\
                     'interpolation_class']:
-            assert np.array_equal(fin_val[col], new_fin_val[col])
+            assert np.allclose(fin_val[col], new_fin_val[col])
         # examples: compressions
         for c in [None, "lzf", "gzip", "gzip9"]:
             totest.join_grids([grid2_path], h5_out_path, compression=c,\
@@ -1742,17 +1742,17 @@ class TestPSyGrid:
         PSyGrid.n_runs = 1
         new_values1 = np.array([3])
         PSyGrid.add_column("test", new_values1)
-        assert np.array_equal(PSyGrid.final_values["test"], new_values1)
+        assert np.allclose(PSyGrid.final_values["test"], new_values1)
         # examples: overwrite
         new_values2 = np.array([4])
         PSyGrid.add_column("test", new_values2)
-        assert np.array_equal(PSyGrid.final_values["test"], new_values2)
+        assert np.allclose(PSyGrid.final_values["test"], new_values2)
         # examples: overwrite protected
         new_values3 = np.array([5])
         with raises(totest.POSYDONError, match="Column `test` already exists "\
                                                +"in final values."):
             PSyGrid.add_column("test", new_values3, overwrite=False)
-        assert np.array_equal(PSyGrid.final_values["test"], new_values2)
+        assert np.allclose(PSyGrid.final_values["test"], new_values2)
 
     def test_update_final_values(self, PSyGrid, tmp_path):
         assert isroutine(PSyGrid.update_final_values)
@@ -1772,12 +1772,12 @@ class TestPSyGrid:
         PSyGrid.final_values = fv.copy()
         PSyGrid.update_final_values()
         for (n, f) in fv.dtype.descr:
-           assert np.array_equal(PSyGrid.final_values[n], fv[n])
+           assert np.allclose(PSyGrid.final_values[n], fv[n])
            if n == 'test_state':
-               assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
+               assert np.allclose(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n].astype(totest.H5_REC_STR_DTYPE))
            else:
-               assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
+               assert np.allclose(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n])
         # examples: replace previous
         fv = np.array([(3.0, "UnitTest")],\
@@ -1785,12 +1785,12 @@ class TestPSyGrid:
         PSyGrid.final_values = fv.copy()
         PSyGrid.update_final_values()
         for (n, f) in fv.dtype.descr:
-           assert np.array_equal(PSyGrid.final_values[n], fv[n])
+           assert np.allclose(PSyGrid.final_values[n], fv[n])
            if n == 'test_state':
-               assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
+               assert np.allclose(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n].astype(totest.H5_REC_STR_DTYPE))
            else:
-               assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
+               assert np.allclose(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n])
 
     def test_reload_hdf5_file(self, PSyGrid, tmp_path):
@@ -1996,7 +1996,7 @@ class TestPSyGrid:
             # for float types allow nans, but others e.g. strings would fail on
             # allowing nans
             allow_nan = 'f' in PSyGrid.initial_values[key].dtype.descr[0][1]
-            assert np.array_equal(PSyGrid.initial_values[key],\
+            assert np.allclose(PSyGrid.initial_values[key],\
                                   np.array(test_df["initial_"+key]),\
                                   equal_nan=allow_nan)
         for key in PSyGrid.final_values.dtype.names:
@@ -2004,7 +2004,7 @@ class TestPSyGrid:
             # for float types allow nans, but others e.g. strings would fail on
             # allowing nans
             allow_nan = 'f' in PSyGrid.final_values[key].dtype.descr[0][1]
-            assert np.array_equal(PSyGrid.final_values[key],\
+            assert np.allclose(PSyGrid.final_values[key],\
                                   np.array(test_df["final_"+key]),\
                                   equal_nan=allow_nan)
 
@@ -2561,7 +2561,7 @@ class TestPSyRunView:
                 assert getattr(PSyRunView.psygrid[PSyRunView.index], k)\
                        == PSyRunView.__getitem__(k)
             else:
-                assert np.array_equal(PSyRunView.__getitem__(k),\
+                assert np.allclose(PSyRunView.__getitem__(k),\
                         getattr(PSyRunView.psygrid[PSyRunView.index], k))
         # bad input
         with raises(IOError, match="The HDF5 file is not open."):

--- a/posydon/unit_tests/grids/test_scrubbing.py
+++ b/posydon/unit_tests/grids/test_scrubbing.py
@@ -118,7 +118,7 @@ class TestFunctions:
         assert totest.scrub([None], [models], [ages]) == [None]
         assert totest.scrub([tables], [None], [ages]) == [None]
         assert totest.scrub([tables], [models], [None]) == [None]
-        assert np.array_equal(totest.scrub([np.array([])], [np.array([])],\
+        assert np.allclose(totest.scrub([np.array([])], [np.array([])],\
                                            [np.array([])]), [np.array([])])
         # examples: no scrubbing for two tables and a None type object
         for (t, r) in zip(totest.scrub([tables, tables, None],\
@@ -126,16 +126,16 @@ class TestFunctions:
                                        [ages, ages, None]),\
                                        [tables, tables, None]):
             if (isinstance(t, np.ndarray) and isinstance(r, np.ndarray)):
-                assert np.array_equal(t, r)
+                assert np.allclose(t, r)
             else:
                 assert t == r
         # examples: scrub element 1 on age
         ages[2] = ages[1]
-        assert np.array_equal(totest.scrub([tables], [models], [ages])[0],\
+        assert np.allclose(totest.scrub([tables], [models], [ages])[0],\
                tables[np.array([True, False, True, True, True])])
         # examples: additionally scrub element 3 on model
         models[4] = models[3]
-        assert np.array_equal(totest.scrub([tables], [models], [ages])[0],\
+        assert np.allclose(totest.scrub([tables], [models], [ages])[0],\
                tables[np.array([True, False, True, False, True])])
 
     def test_keep_after_RLO(self, star_history, binary_history):
@@ -162,10 +162,10 @@ class TestFunctions:
         bh, h1, h2 = totest.keep_after_RLO(binary_history[[\
          'rl_relative_overflow_1', 'lg_mtransfer_rate', 'age']], star_history,\
          None)
-        assert np.array_equal(binary_history[['rl_relative_overflow_1',\
+        assert np.allclose(binary_history[['rl_relative_overflow_1',\
                                               'lg_mtransfer_rate',\
                                               'age']][1:], bh)
-        assert np.array_equal(star_history[1:], h1)
+        assert np.allclose(star_history[1:], h1)
         assert h2 is None
         # examples: cut out element 0 and history of star 2; test numerical
         # correction, incl. fail
@@ -180,10 +180,10 @@ class TestFunctions:
         bh, h1, h2 = totest.keep_after_RLO(binary_history[[\
          'rl_relative_overflow_1', 'lg_mtransfer_rate', 'age']], None,\
          star_history)
-        assert np.array_equal(binary_history[['rl_relative_overflow_1',\
+        assert np.allclose(binary_history[['rl_relative_overflow_1',\
                                               'lg_mtransfer_rate', 'age']], bh)
         assert h1 is None
-        assert np.array_equal(star_history, h2)
+        assert np.allclose(star_history, h2)
         # examples: no RLO
         for i in range(len(binary_history)):
             binary_history['rl_relative_overflow_1'][i] =\
@@ -214,46 +214,46 @@ class TestFunctions:
             if args[0] is None:
                 assert bh is None
             else:
-                assert np.array_equal(bh, args[0])
+                assert np.allclose(bh, args[0])
             if args[1] is None:
                 assert h1 is None
             else:
-                assert np.array_equal(h1, args[1])
+                assert np.allclose(h1, args[1])
             if args[2] is None:
                 assert h2 is None
             else:
-                assert np.array_equal(h2, args[2])
+                assert np.allclose(h2, args[2])
             assert tf == ""
         for cols in [['star_age'], ['star_age', 'center_he4', 'center_c12']]:
             bh, h1, h2, tf = totest.keep_till_central_abundance_He_C(\
                               binary_history[['age']], star_history[cols],\
                               star_history[cols])
-            assert np.array_equal(binary_history[['age']], bh)
-            assert np.array_equal(star_history[cols], h1)
-            assert np.array_equal(star_history[cols], h2)
+            assert np.allclose(binary_history[['age']], bh)
+            assert np.allclose(star_history[cols], h1)
+            assert np.allclose(star_history[cols], h2)
             assert tf == ""
         # examples: one star is depleted
         bh, h1, h2, tf = totest.keep_till_central_abundance_He_C(\
                           binary_history[['age']], star_history2,\
                           star_history)
-        assert np.array_equal(binary_history[['age']][:2], bh)
-        assert np.array_equal(star_history2[:2], h1)
-        assert np.array_equal(star_history[:2], h2)
+        assert np.allclose(binary_history[['age']][:2], bh)
+        assert np.allclose(star_history2[:2], h1)
+        assert np.allclose(star_history[:2], h2)
         assert tf == "Primary got stopped before central carbon depletion"
         bh, h1, h2, tf = totest.keep_till_central_abundance_He_C(\
                           binary_history[['age']], star_history,\
                           star_history2)
-        assert np.array_equal(binary_history[['age']][:2], bh)
-        assert np.array_equal(star_history[:2], h1)
-        assert np.array_equal(star_history2[:2], h2)
+        assert np.allclose(binary_history[['age']][:2], bh)
+        assert np.allclose(star_history[:2], h1)
+        assert np.allclose(star_history2[:2], h2)
         assert tf == "Secondary got stopped before central carbon depletion"
         # examples: both stars are depleted
         bh, h1, h2, tf = totest.keep_till_central_abundance_He_C(\
                           binary_history[['age']], star_history2,\
                           star_history2)
-        assert np.array_equal(binary_history[['age']][:2], bh)
-        assert np.array_equal(star_history2[:2], h1)
-        assert np.array_equal(star_history2[:2], h2)
+        assert np.allclose(binary_history[['age']][:2], bh)
+        assert np.allclose(star_history2[:2], h1)
+        assert np.allclose(star_history2[:2], h2)
         assert tf == "Primary got stopped before central carbon depletion"
         star_history['center_he4'][-1] = 0.0
         star_history['center_c12'][-1] = 0.0
@@ -261,15 +261,15 @@ class TestFunctions:
         bh, h1, h2, tf = totest.keep_till_central_abundance_He_C(\
                           binary_history[['age']], star_history[cols],\
                           star_history2[cols], XCstop=0.5)
-        assert np.array_equal(binary_history[['age']][:2], bh)
-        assert np.array_equal(star_history[cols][:2], h1)
-        assert np.array_equal(star_history2[cols][:2], h2)
+        assert np.allclose(binary_history[['age']][:2], bh)
+        assert np.allclose(star_history[cols][:2], h1)
+        assert np.allclose(star_history2[cols][:2], h2)
         assert tf == "Secondary got stopped before central carbon depletion"
         # examples: stars have history of length 0
         bh, h1, h2, tf = totest.keep_till_central_abundance_He_C(\
                           binary_history[['age']], star_history[0:0],\
                           star_history[0:0])
-        assert np.array_equal(binary_history[['age']], bh)
-        assert np.array_equal(star_history[0:0], h1)
-        assert np.array_equal(star_history[0:0], h2)
+        assert np.allclose(binary_history[['age']], bh)
+        assert np.allclose(star_history[0:0], h1)
+        assert np.allclose(star_history[0:0], h2)
         assert tf == ""

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -795,13 +795,13 @@ class TestFunctions:
                  (np.array([1.0, 0.0]), np.array([0.2, 0.8]), 6,\
                   np.array([0.0, 0.2, 0.4, 0.0, 0.5, 0.0]))]
         for (x, y, s, r) in tests:
-            assert np.array_equal(totest.rejection_sampler(x=x, y=y, size=s),\
+            assert np.allclose(totest.rejection_sampler(x=x, y=y, size=s),\
                                   r)
-        assert np.array_equal(totest.rejection_sampler(x_lim=np.array([0.0,\
+        assert np.allclose(totest.rejection_sampler(x_lim=np.array([0.0,\
                                                                        1.0]),\
                                                        pdf=mock_pdf, size=5),\
                               np.array([0.0, 0.25, 0.0, 0.0, 0.0]))
-        assert np.array_equal(totest.rejection_sampler(x=np.array([1.0, 0.0]),\
+        assert np.allclose(totest.rejection_sampler(x=np.array([1.0, 0.0]),\
                                                        y=np.array([0.2, 0.8]),\
                                                        x_lim=np.array([0.0,\
                                                                        1.0]),\
@@ -878,7 +878,7 @@ class TestFunctions:
                                                     y=np.array([0.2, 0.8]),\
                                                     size=5),\
                            np.array([0.0, 0.5, 0.66666667, 0.83333333, 1.0]))
-        assert np.array_equal(totest.histogram_sampler(x_edges=np.array([0.0,\
+        assert np.allclose(totest.histogram_sampler(x_edges=np.array([0.0,\
                                                                          0.5,\
                                                                          1.0]\
                                                        ), y=np.array([0.2,\
@@ -916,11 +916,11 @@ class TestFunctions:
             totest.read_histogram_from_file(path=csv_path_failing_element_types)
         # examples:
         arrays = totest.read_histogram_from_file(path=csv_path_ex1)
-        assert np.array_equal(arrays[0], np.array([0.1, 1.1, 2.1]))
-        assert np.array_equal(arrays[1], np.array([1.0, 1.0]))
+        assert np.allclose(arrays[0], np.array([0.1, 1.1, 2.1]))
+        assert np.allclose(arrays[1], np.array([1.0, 1.0]))
         arrays = totest.read_histogram_from_file(path=csv_path_ex2)
-        assert np.array_equal(arrays[0], np.array([0.2, 1.2, 2.2]))
-        assert np.array_equal(arrays[1], np.array([2.0, 2.0]))
+        assert np.allclose(arrays[0], np.array([0.2, 1.2, 2.2]))
+        assert np.allclose(arrays[1], np.array([2.0, 2.0]))
 
     def test_inspiral_timescale_from_separation(self):
         # missing argument
@@ -2098,9 +2098,9 @@ class TestFunctions:
                 test_profile = star_profile[['mass', 'radius']]
                 d_mass, d_radius, d_dm =\
                     totest.get_mass_radius_dm_from_profile(test_profile)
-                assert np.array_equal(d_mass, star_profile['mass'])
-                assert np.array_equal(d_radius, star_profile['radius'])
-                assert np.array_equal(d_dm, star_profile['dm'])
+                assert np.allclose(d_mass, star_profile['mass'])
+                assert np.allclose(d_radius, star_profile['radius'])
+                assert np.allclose(d_dm, star_profile['dm'])
         # get total mass and radius
         M = star_profile['mass'].max()
         R = star_profile['radius'].max()
@@ -2109,19 +2109,19 @@ class TestFunctions:
             totest.get_mass_radius_dm_from_profile(star_profile[['mass',\
                                                                  'log_R']],\
                                                    m1_i = M, radius1 = R)
-        assert np.array_equal(d_mass, star_profile['mass'])
-        assert np.array_equal(d_radius, star_profile['radius'])
-        assert np.array_equal(d_dm, star_profile['dm'])
+        assert np.allclose(d_mass, star_profile['mass'])
+        assert np.allclose(d_radius, star_profile['radius'])
+        assert np.allclose(d_dm, star_profile['dm'])
         # examples: profile with radius and dm (in grams)
         d_mass, d_radius, d_dm =\
             totest.get_mass_radius_dm_from_profile(star_profile[['mass', 'dm',\
                                                                  'radius']],\
                                                    m1_i = M, radius1 = R)
-        assert np.array_equal(d_mass, star_profile['mass'])
-        assert np.array_equal(d_radius, star_profile['radius'])
+        assert np.allclose(d_mass, star_profile['mass'])
+        assert np.allclose(d_radius, star_profile['radius'])
         # convert Msun to grams
         d_dm = d_dm * totest.const.Msun
-        assert np.array_equal(d_dm, star_profile['dm'])
+        assert np.allclose(d_dm, star_profile['dm'])
 
     def test_get_internal_energy_from_profile(self, star_profile, monkeypatch):
         def mock_calculate_H2recombination_energy(profile, tolerance=0.001):
@@ -2165,7 +2165,7 @@ class TestFunctions:
                                                    + "energy giving negative "\
                                                    + "values."
         # examples: no internal energy
-        assert np.array_equal(np.array([0, 0, 0, 0]),\
+        assert np.allclose(np.array([0, 0, 0, 0]),\
                               totest.get_internal_energy_from_profile(\
                               "lambda_from_profile_gravitational",\
                               star_profile[['radius']]))
@@ -2173,7 +2173,7 @@ class TestFunctions:
                                                +"internal energy -- "\
                                                +"proceeding with 'lambda_from"\
                                                +"_profile_gravitational'"):
-            assert np.array_equal(np.array([0, 0, 0, 0]),\
+            assert np.allclose(np.array([0, 0, 0, 0]),\
                    totest.get_internal_energy_from_profile("test",\
                                                            star_profile[[\
                                                            'radius']]))
@@ -2211,7 +2211,7 @@ class TestFunctions:
                                                +"calculate H2 recombination "\
                                                +"energy -- H2 recombination "\
                                                +"energy is assumed 0"):
-            assert np.array_equal(np.array([0, 0, 0, 0]),\
+            assert np.allclose(np.array([0, 0, 0, 0]),\
                                   totest.calculate_H2recombination_energy(\
                                   star_profile[['radius']]))
 
@@ -2249,7 +2249,7 @@ class TestFunctions:
                                                +"calculate recombination "\
                                                +"energy -- recombination "\
                                                +"energy is assumed 0"):
-            assert np.array_equal(np.array([0, 0, 0, 0]),\
+            assert np.allclose(np.array([0, 0, 0, 0]),\
                                   totest.calculate_recombination_energy(\
                                   star_profile[['radius']]))
 
@@ -2393,21 +2393,21 @@ class TestFunctions:
                 for z in range(3):
                     if ((x!=0) or (y!=0) or (z!=0)):
                         # angle=0 -> no rotation
-                        assert np.array_equal(totest.rotate(\
+                        assert np.allclose(totest.rotate(\
                                np.array([x, y, z]), 0.0),\
                                np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
                         # inverse rotation around inverted axis
-                        assert np.array_equal(totest.rotate(\
+                        assert np.allclose(totest.rotate(\
                                np.array([-x, -y, -z]), -1.0),\
                                totest.rotate(np.array([x, y, z]), 1.0))
         # examples: angle=1.0
         s = np.sin(1.0)
         c = np.cos(1.0)
-        assert np.array_equal(totest.rotate(np.array([1, 0, 0]), 1.0),\
+        assert np.allclose(totest.rotate(np.array([1, 0, 0]), 1.0),\
                               np.array([[1, 0, 0], [0, c, -s], [0, s, c]]))
-        assert np.array_equal(totest.rotate(np.array([0, 1, 0]), 1.0),\
+        assert np.allclose(totest.rotate(np.array([0, 1, 0]), 1.0),\
                               np.array([[c, 0, s], [0, 1, 0], [-s, 0, c]]))
-        assert np.array_equal(totest.rotate(np.array([0, 0, 1]), 1.0),\
+        assert np.allclose(totest.rotate(np.array([0, 0, 1]), 1.0),\
                               np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]]))
         assert np.allclose(totest.rotate(np.array([1, 1, 0]), 1.0),\
                            np.array([[0.77015115, 0.22984885, 0.59500984],\

--- a/posydon/unit_tests/utils/test_gridutils.py
+++ b/posydon/unit_tests/utils/test_gridutils.py
@@ -411,20 +411,20 @@ class TestFunctions:
         assert totest.read_MESA_data_file(None, ['Test']) is None
         assert totest.read_MESA_data_file(no_path, ['Test']) is None
         # read full test file
-        assert np.array_equal(MESA_data,\
+        assert np.allclose(MESA_data,\
                               totest.read_MESA_data_file(MESA_data_path,\
                                                          MESA_data.dtype.names\
                               ))
         # read columns individually from test file
         for k in MESA_data.dtype.names:
-            assert np.array_equal(MESA_data[[k]],\
+            assert np.allclose(MESA_data[[k]],\
                                   totest.read_MESA_data_file(MESA_data_path,\
                                                              [k]))
         # read column pairs from test file
         k0 = MESA_data.dtype.names[0]
         for k in MESA_data.dtype.names:
             if k != k0:
-                assert np.array_equal(MESA_data[[k0, k]],\
+                assert np.allclose(MESA_data[[k0, k]],\
                                       totest.read_MESA_data_file(\
                                       MESA_data_path, [k0, k]))
         # warning for non readable data
@@ -446,19 +446,19 @@ class TestFunctions:
                                               +no_path):
             assert totest.read_EEP_data_file(no_path, ['Test']) is None
         # read full test file
-        assert np.array_equal(MESA_data,\
+        assert np.allclose(MESA_data,\
                               totest.read_EEP_data_file(EEP_data_path,\
                                                         MESA_data.dtype.names))
         # read columns individually from test file
         for k in MESA_data.dtype.names:
-            assert np.array_equal(MESA_data[[k]],\
+            assert np.allclose(MESA_data[[k]],\
                                   totest.read_EEP_data_file(EEP_data_path,\
                                                             [k]))
         # read column pairs from test file
         k0 = MESA_data.dtype.names[0]
         for k in MESA_data.dtype.names:
             if k != k0:
-                assert np.array_equal(MESA_data[[k0, k]],\
+                assert np.allclose(MESA_data[[k0, k]],\
                                       totest.read_EEP_data_file(EEP_data_path,\
                                                                 [k0, k]))
         # warning for non readable data
@@ -476,7 +476,7 @@ class TestFunctions:
         # history is None
         assert totest.fix_He_core(None) is None
         # history is ndarray without the required columns
-        assert np.array_equal(MESA_data, totest.fix_He_core(MESA_data))
+        assert np.allclose(MESA_data, totest.fix_He_core(MESA_data))
         # history is ndarray with the required columns and corrects them
         test_history = np.array([(1, 2, 3, 4), (1, 2, 4, 3), (2, 1, 3, 4),\
                                  (2, 1, 4, 3)],\
@@ -490,7 +490,7 @@ class TestFunctions:
                                         ('co_core_mass', '<f8'),\
                                         ('he_core_radius', '<f8'),\
                                         ('co_core_radius', '<f8')])
-        assert np.array_equal(fixed_history, totest.fix_He_core(test_history))
+        assert np.allclose(fixed_history, totest.fix_He_core(test_history))
 
     def test_add_field(self, MESA_data):
         # missing argument
@@ -504,7 +504,7 @@ class TestFunctions:
         extended_ndarray = totest.add_field(MESA_data, [('new', '<f8')])
         assert MESA_data.dtype.descr+[('new', '<f8')] ==\
                extended_ndarray.dtype.descr
-        assert np.array_equal(MESA_data,\
+        assert np.allclose(MESA_data,\
                               extended_ndarray[[k for k in\
                                                 MESA_data.dtype.names]])
 

--- a/posydon/unit_tests/utils/test_interpolators.py
+++ b/posydon/unit_tests/utils/test_interpolators.py
@@ -65,8 +65,8 @@ class Testinterp1d:
         # check that the instance is of correct type and all code in the
         # __init__ got executed: the elements are created and initialized
         assert isinstance(interp1d, totest.interp1d)
-        assert np.array_equal(interp1d.x, np.array(data[0]))
-        assert np.array_equal(interp1d.y, np.array(data[1]))
+        assert np.allclose(interp1d.x, np.array(data[0]))
+        assert np.allclose(interp1d.y, np.array(data[1]))
         assert interp1d.kind == 'linear'
         assert interp1d.below is None
         assert interp1d.above is None
@@ -94,13 +94,13 @@ class Testinterp1d:
         # x not strictly monotonic
         example_data = ([0.0, 1.0, 0.5], [0.0, 0.5, 1.0])
         test_interp1d = totest.interp1d(example_data[0], example_data[1])
-        assert np.array_equal(test_interp1d.x, [0.0, 0.5, 1.0])
-        assert np.array_equal(test_interp1d.y, [0.0, 1.0, 0.5])
+        assert np.allclose(test_interp1d.x, [0.0, 0.5, 1.0])
+        assert np.allclose(test_interp1d.y, [0.0, 1.0, 0.5])
 
         # examples: reversible data
         test_interp1d = totest.interp1d(data[0][::-1], data[1][::-1])
-        assert np.array_equal(test_interp1d.x, np.array(data[0]))
-        assert np.array_equal(test_interp1d.y, np.array(data[1]))
+        assert np.allclose(test_interp1d.x, np.array(data[0]))
+        assert np.allclose(test_interp1d.y, np.array(data[1]))
         # examples
         kinds = ['linear']
         for k in kinds:


### PR DESCRIPTION
Replace to avoid errors in float comparisons
