### PR TITLE
[fix] changes `array_equal` to `allclose` where possible

### DIFF
--- a/posydon/unit_tests/grids/test_downsampling.py
+++ b/posydon/unit_tests/grids/test_downsampling.py
@@ -66,13 +66,13 @@ class TestFunctions:
                        [0.8, 0.5, 0.0, 1.0]]
         min_values = [0.0, 1.0, 3.0, -2.0]
         max_values = [0.5, 2.0, 3.0, -1.0]
-        assert np.array_equal(totest.rescale_from_0_to_1(test_values),\
+        assert np.allclose(totest.rescale_from_0_to_1(test_values),\
                               np.array(norm_values))
         arr, minima, maxima = totest.rescale_from_0_to_1(test_values,\
                                                          return_minmax=True)
-        assert np.array_equal(arr, np.array(norm_values))
-        assert np.array_equal(minima, np.array(min_values))
-        assert np.array_equal(maxima, np.array(max_values))
+        assert np.allclose(arr, np.array(norm_values))
+        assert np.allclose(minima, np.array(min_values))
+        assert np.allclose(maxima, np.array(max_values))
 
 
 class TestTrackDownsampler:
@@ -101,13 +101,12 @@ class TestTrackDownsampler:
         # __init__ got executed: the elements are created and initialized
         assert TrackDownsampler.verbose == False
         assert TrackDownsampler.keep == None
-        assert np.array_equal(TrackDownsampler.t, independent_sample)
-        assert np.array_equal(TrackDownsampler.X, norm_dependent_sample)
+        assert np.allclose(TrackDownsampler.t, independent_sample)
+        assert np.allclose(TrackDownsampler.X, norm_dependent_sample)
         # examples: dependend is 1D
         test_TrackDownsampler = totest.TrackDownsampler([0.0, 0.1], [1.0, 2.0])
-        assert np.array_equal(test_TrackDownsampler.t, np.array([0.0, 0.1]))
-        assert np.array_equal(test_TrackDownsampler.X, np.array([[0.0],\
-                                                                 [1.0]]))
+        assert np.allclose(test_TrackDownsampler.t, np.array([0.0, 0.1]))
+        assert np.allclose(test_TrackDownsampler.X, np.array([[0.0], [1.0]]))
         # bad input
         with raises(ValueError, match="`independent` is not iterable."):
             test_TrackDownsampler = totest.TrackDownsampler(None, None)
@@ -149,9 +148,9 @@ class TestTrackDownsampler:
         arr, minima, maxima = totest.rescale_from_0_to_1(dependent_sample,\
                                                          return_minmax=True)
         TrackDownsampler.rescale()
-        assert np.array_equal(arr, TrackDownsampler.X)
-        assert np.array_equal(minima, TrackDownsampler.minima)
-        assert np.array_equal(maxima, TrackDownsampler.maxima)
+        assert np.allclose(arr, TrackDownsampler.X)
+        assert np.allclose(minima, TrackDownsampler.minima)
+        assert np.allclose(maxima, TrackDownsampler.maxima)
 
     def test_extract_downsample(self, independent_sample, dependent_sample,\
                                 norm_dependent_sample, TrackDownsampler):
@@ -160,11 +159,11 @@ class TestTrackDownsampler:
         for k in [None, independent_sample<1.0]:
             TrackDownsampler.keep = k
             t, X = TrackDownsampler.extract_downsample()
-            assert np.array_equal(t, independent_sample[k])
-            assert np.array_equal(X, dependent_sample[k, :])
+            assert np.allclose(t, independent_sample[k])
+            assert np.allclose(X, dependent_sample[k, :])
             t, X = TrackDownsampler.extract_downsample(scale_back=False)
-            assert np.array_equal(t, independent_sample[k])
-            assert np.array_equal(X, norm_dependent_sample[k, :])
+            assert np.allclose(t, independent_sample[k])
+            assert np.allclose(X, norm_dependent_sample[k, :])
 
     def test_find_downsample(self, TrackDownsampler, capsys):
         assert isroutine(TrackDownsampler.find_downsample)
@@ -202,5 +201,5 @@ class TestTrackDownsampler:
         assert isroutine(TrackDownsampler.downsample)
         # examples
         t, X = TrackDownsampler.downsample()
-        assert np.array_equal(t, independent_sample)
-        assert np.array_equal(X, dependent_sample)
+        assert np.allclose(t, independent_sample)
+        assert np.allclose(X, dependent_sample)

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -694,7 +694,7 @@ class TestFunctions:
                     if v is None:
                         assert s in hdf5_file.keys()
                     else:
-                        assert np.array_equal(hdf5_file[s][()], v)
+                        assert np.allclose(hdf5_file[s][()], v)
         def mock_get_detected_initial_RLO(grid):
             # mocked list of initial RLO systems
             if (hasattr(grid, "config") and ("description" in grid.config)):
@@ -825,9 +825,9 @@ class TestFunctions:
             new_ini_val = hdf5_file['/grid/initial_values'][()]
             new_fin_val = hdf5_file['/grid/final_values'][()]
         for col in ['star_1_mass', 'star_2_mass', 'period_days']:
-            assert np.array_equal(ini_val[col], new_ini_val[col],\
+            assert np.allclose(ini_val[col], new_ini_val[col],\
                                   equal_nan=True)
-            assert np.array_equal(fin_val[col], new_fin_val[col],\
+            assert np.allclose(fin_val[col], new_fin_val[col],\
                                   equal_nan=True)
         for r in [1, 4, 5]: # done initial RLO replacements
             fin_val['termination_flag_1'][r] = b'forced_initial_RLO'
@@ -1742,17 +1742,17 @@ class TestPSyGrid:
         PSyGrid.n_runs = 1
         new_values1 = np.array([3])
         PSyGrid.add_column("test", new_values1)
-        assert np.array_equal(PSyGrid.final_values["test"], new_values1)
+        assert np.allclose(PSyGrid.final_values["test"], new_values1)
         # examples: overwrite
         new_values2 = np.array([4])
         PSyGrid.add_column("test", new_values2)
-        assert np.array_equal(PSyGrid.final_values["test"], new_values2)
+        assert np.allclose(PSyGrid.final_values["test"], new_values2)
         # examples: overwrite protected
         new_values3 = np.array([5])
         with raises(totest.POSYDONError, match="Column `test` already exists "\
                                                +"in final values."):
             PSyGrid.add_column("test", new_values3, overwrite=False)
-        assert np.array_equal(PSyGrid.final_values["test"], new_values2)
+        assert np.allclose(PSyGrid.final_values["test"], new_values2)
 
     def test_update_final_values(self, PSyGrid, tmp_path):
         assert isroutine(PSyGrid.update_final_values)
@@ -1777,7 +1777,7 @@ class TestPSyGrid:
                assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n].astype(totest.H5_REC_STR_DTYPE))
            else:
-               assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
+               assert np.allclose(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n])
         # examples: replace previous
         fv = np.array([(3.0, "UnitTest")],\
@@ -1790,7 +1790,7 @@ class TestPSyGrid:
                assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n].astype(totest.H5_REC_STR_DTYPE))
            else:
-               assert np.array_equal(PSyGrid.hdf5["/grid/final_values"][n],\
+               assert np.allclose(PSyGrid.hdf5["/grid/final_values"][n],\
                                      fv[n])
 
     def test_reload_hdf5_file(self, PSyGrid, tmp_path):
@@ -1996,7 +1996,7 @@ class TestPSyGrid:
             # for float types allow nans, but others e.g. strings would fail on
             # allowing nans
             allow_nan = 'f' in PSyGrid.initial_values[key].dtype.descr[0][1]
-            assert np.array_equal(PSyGrid.initial_values[key],\
+            assert np.allclose(PSyGrid.initial_values[key],\
                                   np.array(test_df["initial_"+key]),\
                                   equal_nan=allow_nan)
         for key in PSyGrid.final_values.dtype.names:

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -795,13 +795,13 @@ class TestFunctions:
                  (np.array([1.0, 0.0]), np.array([0.2, 0.8]), 6,\
                   np.array([0.0, 0.2, 0.4, 0.0, 0.5, 0.0]))]
         for (x, y, s, r) in tests:
-            assert np.array_equal(totest.rejection_sampler(x=x, y=y, size=s),\
-                                  r)
-        assert np.array_equal(totest.rejection_sampler(x_lim=np.array([0.0,\
-                                                                       1.0]),\
-                                                       pdf=mock_pdf, size=5),\
-                              np.array([0.0, 0.25, 0.0, 0.0, 0.0]))
-        assert np.array_equal(totest.rejection_sampler(x=np.array([1.0, 0.0]),\
+            assert np.allclose(totest.rejection_sampler(x=x, y=y, size=s),\
+                               r)
+        assert np.allclose(totest.rejection_sampler(x_lim=np.array([0.0,\
+                                                                     1.0]),\
+                                                     pdf=mock_pdf, size=5),\
+                           np.array([0.0, 0.25, 0.0, 0.0, 0.0]))
+        assert np.allclose(totest.rejection_sampler(x=np.array([1.0, 0.0]),\
                                                        y=np.array([0.2, 0.8]),\
                                                        x_lim=np.array([0.0,\
                                                                        1.0]),\
@@ -878,7 +878,7 @@ class TestFunctions:
                                                     y=np.array([0.2, 0.8]),\
                                                     size=5),\
                            np.array([0.0, 0.5, 0.66666667, 0.83333333, 1.0]))
-        assert np.array_equal(totest.histogram_sampler(x_edges=np.array([0.0,\
+        assert np.allclose(totest.histogram_sampler(x_edges=np.array([0.0,\
                                                                          0.5,\
                                                                          1.0]\
                                                        ), y=np.array([0.2,\
@@ -916,11 +916,11 @@ class TestFunctions:
             totest.read_histogram_from_file(path=csv_path_failing_element_types)
         # examples:
         arrays = totest.read_histogram_from_file(path=csv_path_ex1)
-        assert np.array_equal(arrays[0], np.array([0.1, 1.1, 2.1]))
-        assert np.array_equal(arrays[1], np.array([1.0, 1.0]))
+        assert np.allclose(arrays[0], np.array([0.1, 1.1, 2.1]))
+        assert np.allclose(arrays[1], np.array([1.0, 1.0]))
         arrays = totest.read_histogram_from_file(path=csv_path_ex2)
-        assert np.array_equal(arrays[0], np.array([0.2, 1.2, 2.2]))
-        assert np.array_equal(arrays[1], np.array([2.0, 2.0]))
+        assert np.allclose(arrays[0], np.array([0.2, 1.2, 2.2]))
+        assert np.allclose(arrays[1], np.array([2.0, 2.0]))
 
     def test_inspiral_timescale_from_separation(self):
         # missing argument
@@ -2098,9 +2098,9 @@ class TestFunctions:
                 test_profile = star_profile[['mass', 'radius']]
                 d_mass, d_radius, d_dm =\
                     totest.get_mass_radius_dm_from_profile(test_profile)
-                assert np.array_equal(d_mass, star_profile['mass'])
-                assert np.array_equal(d_radius, star_profile['radius'])
-                assert np.array_equal(d_dm, star_profile['dm'])
+                assert np.allclose(d_mass, star_profile['mass'])
+                assert np.allclose(d_radius, star_profile['radius'])
+                assert np.allclose(d_dm, star_profile['dm'])
         # get total mass and radius
         M = star_profile['mass'].max()
         R = star_profile['radius'].max()
@@ -2109,19 +2109,19 @@ class TestFunctions:
             totest.get_mass_radius_dm_from_profile(star_profile[['mass',\
                                                                  'log_R']],\
                                                    m1_i = M, radius1 = R)
-        assert np.array_equal(d_mass, star_profile['mass'])
-        assert np.array_equal(d_radius, star_profile['radius'])
-        assert np.array_equal(d_dm, star_profile['dm'])
+        assert np.allclose(d_mass, star_profile['mass'])
+        assert np.allclose(d_radius, star_profile['radius'])
+        assert np.allclose(d_dm, star_profile['dm'])
         # examples: profile with radius and dm (in grams)
         d_mass, d_radius, d_dm =\
             totest.get_mass_radius_dm_from_profile(star_profile[['mass', 'dm',\
                                                                  'radius']],\
                                                    m1_i = M, radius1 = R)
-        assert np.array_equal(d_mass, star_profile['mass'])
-        assert np.array_equal(d_radius, star_profile['radius'])
+        assert np.allclose(d_mass, star_profile['mass'])
+        assert np.allclose(d_radius, star_profile['radius'])
         # convert Msun to grams
         d_dm = d_dm * totest.const.Msun
-        assert np.array_equal(d_dm, star_profile['dm'])
+        assert np.allclose(d_dm, star_profile['dm'])
 
     def test_get_internal_energy_from_profile(self, star_profile, monkeypatch):
         def mock_calculate_H2recombination_energy(profile, tolerance=0.001):
@@ -2165,7 +2165,7 @@ class TestFunctions:
                                                    + "energy giving negative "\
                                                    + "values."
         # examples: no internal energy
-        assert np.array_equal(np.array([0, 0, 0, 0]),\
+        assert np.allclose(np.array([0, 0, 0, 0]),\
                               totest.get_internal_energy_from_profile(\
                               "lambda_from_profile_gravitational",\
                               star_profile[['radius']]))
@@ -2173,7 +2173,7 @@ class TestFunctions:
                                                +"internal energy -- "\
                                                +"proceeding with 'lambda_from"\
                                                +"_profile_gravitational'"):
-            assert np.array_equal(np.array([0, 0, 0, 0]),\
+            assert np.allclose(np.array([0, 0, 0, 0]),\
                    totest.get_internal_energy_from_profile("test",\
                                                            star_profile[[\
                                                            'radius']]))
@@ -2211,7 +2211,7 @@ class TestFunctions:
                                                +"calculate H2 recombination "\
                                                +"energy -- H2 recombination "\
                                                +"energy is assumed 0"):
-            assert np.array_equal(np.array([0, 0, 0, 0]),\
+            assert np.allclose(np.array([0, 0, 0, 0]),\
                                   totest.calculate_H2recombination_energy(\
                                   star_profile[['radius']]))
 
@@ -2249,7 +2249,7 @@ class TestFunctions:
                                                +"calculate recombination "\
                                                +"energy -- recombination "\
                                                +"energy is assumed 0"):
-            assert np.array_equal(np.array([0, 0, 0, 0]),\
+            assert np.allclose(np.array([0, 0, 0, 0]),\
                                   totest.calculate_recombination_energy(\
                                   star_profile[['radius']]))
 
@@ -2393,21 +2393,21 @@ class TestFunctions:
                 for z in range(3):
                     if ((x!=0) or (y!=0) or (z!=0)):
                         # angle=0 -> no rotation
-                        assert np.array_equal(totest.rotate(\
+                        assert np.allclose(totest.rotate(\
                                np.array([x, y, z]), 0.0),\
                                np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
                         # inverse rotation around inverted axis
-                        assert np.array_equal(totest.rotate(\
+                        assert np.allclose(totest.rotate(\
                                np.array([-x, -y, -z]), -1.0),\
                                totest.rotate(np.array([x, y, z]), 1.0))
         # examples: angle=1.0
         s = np.sin(1.0)
         c = np.cos(1.0)
-        assert np.array_equal(totest.rotate(np.array([1, 0, 0]), 1.0),\
+        assert np.allclose(totest.rotate(np.array([1, 0, 0]), 1.0),\
                               np.array([[1, 0, 0], [0, c, -s], [0, s, c]]))
-        assert np.array_equal(totest.rotate(np.array([0, 1, 0]), 1.0),\
+        assert np.allclose(totest.rotate(np.array([0, 1, 0]), 1.0),\
                               np.array([[c, 0, s], [0, 1, 0], [-s, 0, c]]))
-        assert np.array_equal(totest.rotate(np.array([0, 0, 1]), 1.0),\
+        assert np.allclose(totest.rotate(np.array([0, 0, 1]), 1.0),\
                               np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]]))
         assert np.allclose(totest.rotate(np.array([1, 1, 0]), 1.0),\
                            np.array([[0.77015115, 0.22984885, 0.59500984],\

--- a/posydon/unit_tests/utils/test_interpolators.py
+++ b/posydon/unit_tests/utils/test_interpolators.py
@@ -65,8 +65,8 @@ class Testinterp1d:
         # check that the instance is of correct type and all code in the
         # __init__ got executed: the elements are created and initialized
         assert isinstance(interp1d, totest.interp1d)
-        assert np.array_equal(interp1d.x, np.array(data[0]))
-        assert np.array_equal(interp1d.y, np.array(data[1]))
+        assert np.allclose(interp1d.x, np.array(data[0]))
+        assert np.allclose(interp1d.y, np.array(data[1]))
         assert interp1d.kind == 'linear'
         assert interp1d.below is None
         assert interp1d.above is None
@@ -94,13 +94,13 @@ class Testinterp1d:
         # x not strictly monotonic
         example_data = ([0.0, 1.0, 0.5], [0.0, 0.5, 1.0])
         test_interp1d = totest.interp1d(example_data[0], example_data[1])
-        assert np.array_equal(test_interp1d.x, [0.0, 0.5, 1.0])
-        assert np.array_equal(test_interp1d.y, [0.0, 1.0, 0.5])
+        assert np.allclose(test_interp1d.x, [0.0, 0.5, 1.0])
+        assert np.allclose(test_interp1d.y, [0.0, 1.0, 0.5])
 
         # examples: reversible data
         test_interp1d = totest.interp1d(data[0][::-1], data[1][::-1])
-        assert np.array_equal(test_interp1d.x, np.array(data[0]))
-        assert np.array_equal(test_interp1d.y, np.array(data[1]))
+        assert np.allclose(test_interp1d.x, np.array(data[0]))
+        assert np.allclose(test_interp1d.y, np.array(data[1]))
         # examples
         kinds = ['linear']
         for k in kinds:


### PR DESCRIPTION
I have replaced  `array_equal` with `allclose` wherever this was possible.
It cannot be done everywhere because some arrays contain non-numeric data, specifically it contains a `<class 'numpy._FloatAbstractDType'>`, which is probably a NaN.