### PR TITLE
[fix] minimum redshift bin Chruslinska+21 data

### DIFF
--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -652,7 +652,8 @@ class IllustrisTNG(SFHBase):
 
         Note:
         We are using the closest redshift bin in the IllustrisTNG simulation
-        to extract the metallicity distribution for the requested redshift.
+        that is smaller than the requested redshift to extract the metallicity
+        distribution for the requested redshift.
 
         Parameters
         ----------

--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -826,7 +826,17 @@ class Chruslinska21(SFHBase):
             Fraction of the SFR in the given metallicity bin at the given redshift.
         """
         # only use data within the metallicity bounds (no lower bound)
-        redshift_indices = np.array([np.where(self.redshifts <= i)[0][0] for i in z])
+        if np.min(z) < np.min(self.redshifts):
+            Pwarn('Some redshift values are lower than the minimum '
+                    'redshift in the Chruslinska+21 data. '
+                    'Using the minimum redshift available.',
+                    'SFHModelWarning')
+            redshift_indices = np.array([-1 if i < np.min(self.redshifts)
+                                    else np.where(self.redshifts <= i)[0][0]
+                                    for i in z])
+        else:
+            redshift_indices = np.array([np.where(self.redshifts <= i)[0][0] for i in z])
+
         Z_dist = self.SFR_data[redshift_indices]
         fSFR = np.zeros((len(z), len(metallicity_bins) - 1))
 

--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -653,7 +653,7 @@ class IllustrisTNG(SFHBase):
         Note:
         We are using the closest redshift bin in the IllustrisTNG simulation
         to extract the metallicity distribution for the requested redshift.
-        
+
         Parameters
         ----------
         z : float or array-like
@@ -819,9 +819,9 @@ class Chruslinska21(SFHBase):
 
         Note:
         We are using the closest redshift from Chruslinska+21 models
-        that is smaller than the requested redshift to extract the 
+        that is smaller than the requested redshift to extract the
         metallicity distribution.
-        
+
         Parameters
         ----------
         z : float or array-like

--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -650,6 +650,10 @@ class IllustrisTNG(SFHBase):
         """Calculate the fractional SFR as a function of redshift and
         metallicity bins.
 
+        Note:
+        We are using the closest redshift bin in the IllustrisTNG simulation
+        to extract the metallicity distribution for the requested redshift.
+        
         Parameters
         ----------
         z : float or array-like
@@ -813,6 +817,11 @@ class Chruslinska21(SFHBase):
     def fSFR(self, z, metallicity_bins):
         """Calculate the fractional SFR as a function of redshift and metallicity bins
 
+        Note:
+        We are using the closest redshift from Chruslinska+21 models
+        that is smaller than the requested redshift to extract the 
+        metallicity distribution.
+        
         Parameters
         ----------
         z : float or array-like

--- a/posydon/unit_tests/popsyn/test_star_formation_history.py
+++ b/posydon/unit_tests/popsyn/test_star_formation_history.py
@@ -785,7 +785,7 @@ class TestChruslinska21:
 
         # The value at -1.0 should be the same as at 0.0
         assert np.isclose(result[0], result[1])
-        # The value at 0.5 should be different (interpolated)
+        # The value at 0.5 should be different
         assert not np.isclose(result[1], result[2])
 
     def test_csfrd_calculation(self, chruslinska_model, mock_chruslinska_data):

--- a/posydon/unit_tests/popsyn/test_star_formation_history.py
+++ b/posydon/unit_tests/popsyn/test_star_formation_history.py
@@ -778,6 +778,16 @@ class TestChruslinska21:
         with pytest.raises(AssertionError):
             result = chruslinska_model.mean_metallicity(z_values)
 
+    def test_lowest_z_bin(self, chruslinska_model, mock_chruslinska_data):
+        """Test that if z is below the lowest bin, it uses the lowest bin."""
+        z_values = np.array([-1.0, 0.0, 0.5])
+        result = chruslinska_model.CSFRD(z_values)
+
+        # The value at -1.0 should be the same as at 0.0
+        assert np.isclose(result[0], result[1])
+        # The value at 0.5 should be different (interpolated)
+        assert not np.isclose(result[1], result[2])
+
     def test_csfrd_calculation(self, chruslinska_model, mock_chruslinska_data):
         """Test the CSFRD method."""
         # Test at specific redshifts

--- a/posydon/unit_tests/popsyn/test_star_formation_history.py
+++ b/posydon/unit_tests/popsyn/test_star_formation_history.py
@@ -781,12 +781,12 @@ class TestChruslinska21:
     def test_lowest_z_bin(self, chruslinska_model, mock_chruslinska_data):
         """Test that if z is below the lowest bin, it uses the lowest bin."""
         z_values = np.array([-1.0, 0.0, 0.5])
-        result = chruslinska_model.CSFRD(z_values)
+        met_bins = np.array([0.001, 0.01, 0.02, 0.03])
+
+        result = chruslinska_model.fSFR(z_values, met_bins)
 
         # The value at -1.0 should be the same as at 0.0
-        assert np.isclose(result[0], result[1])
-        # The value at 0.5 should be different
-        assert not np.isclose(result[1], result[2])
+        assert np.allclose(result[0], result[1])
 
     def test_csfrd_calculation(self, chruslinska_model, mock_chruslinska_data):
         """Test the CSFRD method."""


### PR DESCRIPTION
Adds a fix for when the minimum requested redshift bin is lower than the Chruslinska+21 data has available.
Uses the lowest redshift bin as the appropriate proxy.