### PR TITLE
Update macOS version to sequoia in CI workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest]
+        os: [macos-15, macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
 
     steps:


### PR DESCRIPTION
github workflows with  macos-13 is deprecated
made a fresh PR instead of rebasing to fix precommit issue