### PR TITLE
[fix] History array handling in step_detached.py

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.2.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -794,7 +794,7 @@ class detached_step:
                 else:
                     history = np.ones_like(t) * np.nan
 
-                history = np.atleast_1d(history)[:-1]
+                history = np.atleast_1d(history)
                 current = history[-1]
 
                 setattr(obj, key, current)


### PR DESCRIPTION
Fixes array access handling when accessing star properties after detached evolution. This also bumps the version number to 2.2.1