### PR TITLE
[fix] `BinaryPopulation.evolve()`

### DIFF
--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -103,7 +103,8 @@ ONELINE_MIN_ITEMSIZE = {'state_i': 30, 'state_f': 30,
 # load stellar or binary models by checked this list of steps.
 STEP_NAMES_LOADING_GRIDS = [
     'step_HMS_HMS', 'step_CO_HeMS', 'step_CO_HMS_RLO', 'step_CO_HeMS_RLO', 'step_HMS_HMS_RLO',
-    'step_detached','step_isolated','step_disrupted','step_initially_single', 'step_merged','step_CE'
+    'step_detached','step_isolated','step_disrupted','step_initially_single', 'step_merged','step_CE',
+    'step_dco'
 ]
 
 


### PR DESCRIPTION
`BinaryPopulation.evolve()` will currently encounter issues because it does not contain `step_dco` in its list of step functions to grant a metallicity -- which is now needed with the recent rewrite of `step_dco`.