### PR TITLE
[Fix] Preload import of MESA step and detached step in `simulationproperties.py`

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.2.1" %}
+{% set version = "2.2.2" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -190,6 +190,15 @@ class SimulationProperties:
         self.preload_imports()
 
     def preload_imports(self):
+        """
+            Preload the imports of detached_step and MesaGridStep to avoid 
+        importing them when they are needed when `close()` is called. In 
+        particular, detached_step imports sklearn, which in turn utilizes 
+        loky, which invokes its own register.at_exit call. If this happens 
+        during the `close()` call, which is invoked at shutdown, a 
+        failure occurs, hence the need for something like this.
+        """
+        
         from posydon.binary_evol.DT.step_detached import detached_step
         from posydon.binary_evol.MESA.step_mesa import MesaGridStep
 

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -191,14 +191,14 @@ class SimulationProperties:
 
     def preload_imports(self):
         """
-            Preload the imports of detached_step and MesaGridStep to avoid 
-        importing them when they are needed when `close()` is called. In 
-        particular, detached_step imports sklearn, which in turn utilizes 
-        loky, which invokes its own register.at_exit call. If this happens 
-        during the `close()` call, which is invoked at shutdown, a 
+            Preload the imports of detached_step and MesaGridStep to avoid
+        importing them when they are needed when `close()` is called. In
+        particular, detached_step imports sklearn, which in turn utilizes
+        loky, which invokes its own register.at_exit call. If this happens
+        during the `close()` call, which is invoked at shutdown, a
         failure occurs, hence the need for something like this.
         """
-        
+
         from posydon.binary_evol.DT.step_detached import detached_step
         from posydon.binary_evol.MESA.step_mesa import MesaGridStep
 

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -187,6 +187,15 @@ class SimulationProperties:
                 self.all_step_names.append(key)
         self.steps_loaded = False
 
+        self.preload_imports()
+
+    def preload_imports(self):
+        from posydon.binary_evol.DT.step_detached import detached_step
+        from posydon.binary_evol.MESA.step_mesa import MesaGridStep
+
+        self._detached_step = detached_step
+        self._MesaGridStep = MesaGridStep
+
     @classmethod
     def from_ini(cls, path, metallicity = None, load_steps=False, verbose=False, **override_sim_kwargs):
         """Create a SimulationProperties instance from an inifile.
@@ -341,14 +350,13 @@ class SimulationProperties:
 
     def close(self):
         """Close hdf5 files before exiting."""
-        from posydon.binary_evol.DT.step_detached import detached_step
-        from posydon.binary_evol.MESA.step_mesa import MesaGridStep
+
         all_step_funcs = [getattr(self, key) for key, val in
                           self.__dict__.items() if 'step_' in key]
         for step_func in all_step_funcs:
-            if isinstance(step_func, MesaGridStep):
+            if isinstance(step_func, self._MesaGridStep):
                 step_func.close()
-            elif isinstance(step_func, detached_step):
+            elif isinstance(step_func, self._detached_step):
                 for grid_interpolator in [step_func.track_matcher.grid_Hrich, step_func.track_matcher.grid_strippedHe]:
                     grid_interpolator.close()
 


### PR DESCRIPTION
This bumps `main` to `v2.2.2`.

Right now we import `step_detached` within

```
    def close(self):
        """Close hdf5 files before exiting."""
    ...

```

inside `simulationproperties.py` but this causes a (non-critical) failure at shutdown. The population will still save, but will throw an error along the lines of 

```

Exception ignored in atexit callback: <function BinaryPopulation.__init__.<locals>.<lambda> at 0x14e4c14baca0>
Traceback (most recent call last):
  File "/home/users/a/aguetar1/.conda/envs/posydon_env/lib/python3.11/site-packages/posydon/popsyn/binarypopulation.py", line 130, in <lambda>
    atexit.register(lambda: BinaryPopulation.close(self))

...

  File "/home/users/a/aguetar1/.conda/envs/posydon_env/lib/python3.11/site-packages/joblib/externals/loky/backend/context.py", line 21, in <module>
    from concurrent.futures.process import _MAX_WINDOWS_WORKERS
  File "/home/users/a/aguetar1/.conda/envs/posydon_env/lib/python3.11/concurrent/futures/process.py", line 101, in <module>
    threading._register_atexit(_python_exit)
  File "/home/users/a/aguetar1/.conda/envs/posydon_env/lib/python3.11/threading.py", line 1520, in _register_atexit
    raise RuntimeError("can't register atexit after shutdown")
RuntimeError: can't register atexit after shutdown
```

indicating a failure to import due to `loky` (a backend for `sklearn`, which is imported inside `step_detached`) trying to register an `atexit` call. This is not allowed since we have started our own shutdown at this point from `BinaryPopulation` (from the `atexit.register(lambda: BinaryPopulation.close(self))` call).

This PR adds a function that preloads the imports of `step_detached` and MESA step during the `__init__` call of `SimulationProperties` to avoid any imports during shutdown. These imports can not happen at a global level within this module because it causes a circular import.