### PR TITLE
[fix] Making it so `SimulationProperties` accepts arbitrary `kwargs`

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.2.2" %}
+{% set version = "2.2.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -43,7 +43,7 @@ class SimulationProperties:
                        step_CE = (NullStep(), {}),
                        step_end = (NullStep(), {}),
                        extra_hooks = [],
-                       verbose=False):
+                       **kwargs):
 
         """Construct the simulation properties object.
 
@@ -117,8 +117,11 @@ class SimulationProperties:
             'extra_post_evolve') and the corresponding function.
         """
 
+        self.kwargs = kwargs
+        verbose = self.kwargs.get('verbose', False)
+
         # gather kwargs
-        self.kwargs = {"flow": flow}
+        self.kwargs["flow"] = flow
 
         step_kwargs = {"step_HMS_HMS": step_HMS_HMS,
                        "step_CO_HeMS": step_CO_HeMS,

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -209,9 +209,12 @@ class BinaryPopulation:
         BinaryPopulation
             A new instance of a BinaryPopulation.
         """
+        
         pop_kwargs = binarypop_kwargs_from_ini(path, verbose=verbose)
+
         # finally get the population properties
         sim_prop_kwargs = simprop_kwargs_from_ini(path)
+        sim_prop_kwargs['verbose'] = verbose
         pop_kwargs['population_properties'] = SimulationProperties(
             **sim_prop_kwargs)
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -209,7 +209,7 @@ class BinaryPopulation:
         BinaryPopulation
             A new instance of a BinaryPopulation.
         """
-        
+
         pop_kwargs = binarypop_kwargs_from_ini(path, verbose=verbose)
 
         # finally get the population properties


### PR DESCRIPTION
Adding a `kwargs` argument to the `SimulationProperties` class. This allows the class to accept custom step names for example that are not a part of the standard set.