### PR TITLE
[fix] `BinaryPopulation` .ini file metallicity handling

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.2.2" %}
+{% set version = "2.2.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -133,7 +133,9 @@ class BinaryPopulation:
         # grab all metallicities in population or use single metallicity
         self.metallicities = self.kwargs.get('metallicities', [1.])
 
-        # the first index of the metallicities list will be chosen unless told otherwise
+        # The first index of the metallicities list will be chosen unless told otherwise.
+        # If metallicity is provided (as e.g., PopulationRunner does automatically), the 
+        # provided metallicity is used instead.
         self.metallicity_index = self.kwargs.get('metallicity_index', 0)
         self.kwargs['metallicity'] = self.kwargs.get('metallicity',
                                           self.metallicities[self.metallicity_index])

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -131,11 +131,11 @@ class BinaryPopulation:
         atexit.register(lambda: BinaryPopulation.close(self))
 
         # a .ini file will normally contain a list of metallicities, as
-        # expected by the PopulationRunner() class. However, if running 
+        # expected by the PopulationRunner() class. However, if running
         # evolve straight from this class, we need a float
         if isinstance(self.kwargs['metallicity'], (list, np.ndarray)):
             Pwarn('An array of metallicities was provided to the '
-                    'BinaryPopulation class but a single value is ' 
+                    'BinaryPopulation class but a single value is '
                     'needed. Taking the first element.', "ReplaceValueWarning")
             self.kwargs['metallicity'] = self.kwargs['metallicity'][0]
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -141,7 +141,7 @@ class BinaryPopulation:
         # evolve straight from this class, we need a float
         if isinstance(self.metallicity, (list, np.ndarray)):
             Pwarn('An array of metallicities was provided to the '
-                  'BinaryPopulation class but a single value is ' 
+                  'BinaryPopulation class but a single value is '
                   'needed. Taking the first element.', "ReplaceValueWarning")
             self.metallicity = self.kwargs['metallicity'][0]
             self.kwargs['metallicity'] = self.metallicity

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -134,7 +134,7 @@ class BinaryPopulation:
         self.metallicities = self.kwargs.get('metallicities', [1.])
 
         # The first index of the metallicities list will be chosen unless told otherwise.
-        # If metallicity is provided (as e.g., PopulationRunner does automatically), the 
+        # If metallicity is provided (as e.g., PopulationRunner does automatically), the
         # provided metallicity is used instead.
         self.metallicity_index = self.kwargs.get('metallicity_index', 0)
         self.kwargs['metallicity'] = self.kwargs.get('metallicity',

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -135,7 +135,7 @@ class BinaryPopulation:
 
         # the first index of the metallicities list will be chosen unless told otherwise
         self.metallicity_index = self.kwargs.get('metallicity_index', 0)
-        self.kwargs['metallicity'] = self.kwargs.get('metallicity', 
+        self.kwargs['metallicity'] = self.kwargs.get('metallicity',
                                           self.metallicities[self.metallicity_index])
         self.metallicity = self.kwargs['metallicity']
 
@@ -207,8 +207,8 @@ class BinaryPopulation:
             Path to an inifile to load in.
 
         metallicity_index : int
-            Used to select a metallicity from the metallicities array 
-            in the .ini file. This is mainly useful if you are creating 
+            Used to select a metallicity from the metallicities array
+            in the .ini file. This is mainly useful if you are creating
             a BinaryPopulation class from scratch.
 
         verbose : bool
@@ -224,7 +224,7 @@ class BinaryPopulation:
         sim_prop_kwargs = simprop_kwargs_from_ini(path)
         pop_kwargs['population_properties'] = SimulationProperties(
             **sim_prop_kwargs)
-        
+
         pop_kwargs['metallicity_index'] = metallicity_index
 
         return cls(**pop_kwargs)

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -130,19 +130,21 @@ class BinaryPopulation:
                                                      SimulationProperties())
         atexit.register(lambda: BinaryPopulation.close(self))
 
+        # grab all metallicities in population or use single metallicity
+        self.metallicities = self.kwargs.get('metallicities', [1.])
+
+        # PopulationRunner provides this; the .ini file does not by default
+        self.metallicity = self.kwargs.get('metallicity', self.metallicities[0])
+
         # a .ini file will normally contain a list of metallicities, as
         # expected by the PopulationRunner() class. However, if running 
         # evolve straight from this class, we need a float
-        if isinstance(self.kwargs['metallicity'], (list, np.ndarray)):
+        if isinstance(self.metallicity, (list, np.ndarray)):
             Pwarn('An array of metallicities was provided to the '
-                    'BinaryPopulation class but a single value is ' 
-                    'needed. Taking the first element.', "ReplaceValueWarning")
-            self.kwargs['metallicity'] = self.kwargs['metallicity'][0]
-
-        self.metallicity = self.kwargs.get('metallicity', 1)
-
-        # grab all metallicities in population or use single metallicity
-        self.metallicities = self.kwargs.get('metallicities', [self.metallicity])
+                  'BinaryPopulation class but a single value is ' 
+                  'needed. Taking the first element.', "ReplaceValueWarning")
+            self.metallicity = self.kwargs['metallicity'][0]
+            self.kwargs['metallicity'] = self.metallicity
 
         # force the metallicity on to the simulation properties
         for key in STEP_NAMES_LOADING_GRIDS:

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -129,6 +129,16 @@ class BinaryPopulation:
         self.population_properties = self.kwargs.get('population_properties',
                                                      SimulationProperties())
         atexit.register(lambda: BinaryPopulation.close(self))
+
+        # a .ini file will normally contain a list of metallicities, as
+        # expected by the PopulationRunner() class. However, if running 
+        # evolve straight from this class, we need a float
+        if isinstance(self.kwargs['metallicity'], (list, np.ndarray)):
+            Pwarn('An array of metallicities was provided to the '
+                    'BinaryPopulation class but a single value is ' 
+                    'needed. Taking the first element.', "ReplaceValueWarning")
+            self.kwargs['metallicity'] = self.kwargs['metallicity'][0]
+
         self.metallicity = self.kwargs.get('metallicity', 1)
 
         # grab all metallicities in population or use single metallicity

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -133,18 +133,11 @@ class BinaryPopulation:
         # grab all metallicities in population or use single metallicity
         self.metallicities = self.kwargs.get('metallicities', [1.])
 
-        # PopulationRunner provides this; the .ini file does not by default
-        self.metallicity = self.kwargs.get('metallicity', self.metallicities[0])
-
-        # a .ini file will normally contain a list of metallicities, as
-        # expected by the PopulationRunner() class. However, if running
-        # evolve straight from this class, we need a float
-        if isinstance(self.metallicity, (list, np.ndarray)):
-            Pwarn('An array of metallicities was provided to the '
-                  'BinaryPopulation class but a single value is '
-                  'needed. Taking the first element.', "ReplaceValueWarning")
-            self.metallicity = self.kwargs['metallicity'][0]
-            self.kwargs['metallicity'] = self.metallicity
+        # the first index of the metallicities list will be chosen unless told otherwise
+        self.metallicity_index = self.kwargs.get('metallicity_index', 0)
+        self.kwargs['metallicity'] = self.kwargs.get('metallicity', 
+                                          self.metallicities[self.metallicity_index])
+        self.metallicity = self.kwargs['metallicity']
 
         # force the metallicity on to the simulation properties
         for key in STEP_NAMES_LOADING_GRIDS:
@@ -205,13 +198,18 @@ class BinaryPopulation:
         self.find_failed = self.manager.find_failed
 
     @classmethod
-    def from_ini(cls, path, verbose=False):
+    def from_ini(cls, path, metallicity_index=0, verbose=False):
         """Create a BinaryPopulation instance from an inifile.
 
         Parameters
         ----------
         path : str
             Path to an inifile to load in.
+
+        metallicity_index : int
+            Used to select a metallicity from the metallicities array 
+            in the .ini file. This is mainly useful if you are creating 
+            a BinaryPopulation class from scratch.
 
         verbose : bool
             Print useful info.
@@ -226,6 +224,8 @@ class BinaryPopulation:
         sim_prop_kwargs = simprop_kwargs_from_ini(path)
         pop_kwargs['population_properties'] = SimulationProperties(
             **sim_prop_kwargs)
+        
+        pop_kwargs['metallicity_index'] = metallicity_index
 
         return cls(**pop_kwargs)
 

--- a/posydon/popsyn/defaults.py
+++ b/posydon/popsyn/defaults.py
@@ -15,7 +15,7 @@ default_kwargs = {
 
     # Size of the population
     'number_of_binaries': 100,
-    'metallicity' : 1.0, # in Zsolar
+    'metallicities' : [1.0], # in Zsolar
 
     # Star Formation History
     'star_formation': 'constant',

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -373,7 +373,7 @@
     # convert BinaryStars into DataFrames after evolution: True, False
   use_MPI = False
     # use only for local MPI runs: True, False
-  metallicity = [1.]
+  metallicities = [1.]
     # in units of solar metallicity: list of float
     # e.g. [2., 1., 0.45, 0.2, 0.1, 0.01, 0.001, 0.0001]
   error_checking_verbose = False

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -118,7 +118,7 @@ class PopulationRunner:
             raise ValueError("You did not provide a valid path_to_ini!")
         else:
             self.pop_params = binarypop_kwargs_from_ini(path_to_ini)
-            self.solar_metallicities = self.pop_params["metallicity"]
+            self.solar_metallicities = self.pop_params["metallicities"]
             self.verbose = verbose
             if not isinstance(self.solar_metallicities, list):
                 self.solar_metallicities = [self.solar_metallicities]


### PR DESCRIPTION
The .ini file has a list normally for the `metallicity` argument in the .ini file. This works for the `PopulationRunner` class but not the `BinaryPopulation` class, if `BinaryPopulation` is created outside of `PopulationRunner`. Right now this means that creating a `BinaryPopulation` from a .ini file can lead to an error if the `metallicity` field is a list.

This adds handling of lists, printing a warning and taking the first element of the list as the metallicity for a `BinaryPopulation` class that is constructed from a .ini file.

This also changes the `metallicity` field in the default .ini file to `metallicities`, as that field is expected to be a list of metallicities.

Also adds a new `metallicity_index` argument to `BinaryPopulation.from_ini()` that can be used to select a metallicity for the `BinaryPopulation` class that a user is creating from the `metallicities` array in their .ini file. E.g.

```
my_ini_filename = "population_params.ini"
pop = BinaryPopulation.from_ini(my_ini_filename, verbose=True, metallicity_index = 1)
```

would select the 2nd element of the `metallcities` array and use that to create the `BinaryPopulation`.