### PR TITLE
[fix] Lazy access for PSyGrid initial/final values to save RAM

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -74,7 +74,8 @@ MODEL = {"prescription": 'alpha-lambda',
                                               # assuming a final separation where the inner core RLOF starts.
          # "one_phase_variable_core_definition" for core_definition_H_fraction=0.01
          "metallicity": None,
-         "record_matching": False
+         "record_matching": False,
+         "track_matcher": None
          }
 
 
@@ -190,18 +191,19 @@ class StepCEE(object):
                         ["log_min_max", "min_max", "min_max"],
                         [0.1, 300], [0.0, None]
                     ]
-        self.track_matcher = TrackMatcher(grid_name_Hrich = None,
-                                    grid_name_strippedHe = None,
-                                    path=PATH_TO_POSYDON_DATA,
-                                    metallicity = self.metallicity,
-                                    matching_method = "minimize",
-                                    matching_tolerance=1e-2,
-                                    matching_tolerance_hard=1e-1,
-                                    list_for_matching_HMS = list_for_matching_HMS,
-                                    list_for_matching_HeStar = None,
-                                    list_for_matching_postMS = None,
-                                    record_matching = self.record_matching,
-                                    verbose = self.verbose)
+        #self.track_matcher = TrackMatcher(grid_name_Hrich = None,
+        #                            grid_name_strippedHe = None,
+        #                            path=PATH_TO_POSYDON_DATA,
+        #                            metallicity = self.metallicity,
+        #                            matching_method = "minimize",
+        #                            matching_tolerance=1e-2,
+        #                            matching_tolerance_hard=1e-1,
+        #                            list_for_matching_HMS = list_for_matching_HMS,
+        #                            list_for_matching_HeStar = None,
+        #                            list_for_matching_postMS = None,
+        #                            record_matching = self.record_matching,
+        #                            verbose = self.verbose)
+        self.track_matcher = kwargs.get('track_matcher', None)
     def __call__(self, binary):
         """Perform the CEE step for a BinaryStar object."""
         # Determine which star is the donor and which is the companion

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -36,7 +36,7 @@ from posydon.binary_evol.DT.magnetic_braking.prescriptions import (
     RVJ83_braking,
 )
 from posydon.binary_evol.DT.tides.default_tides import default_tides
-from posydon.binary_evol.DT.track_match import TrackMatcher
+#from posydon.binary_evol.DT.track_match import TrackMatcher
 from posydon.binary_evol.DT.winds.default_winds import (
     default_sep_from_winds,
     default_spin_from_winds,
@@ -237,7 +237,8 @@ class detached_step:
             matching_tolerance_hard=1e-1,
             list_for_matching_HMS=None,
             list_for_matching_postMS=None,
-            list_for_matching_HeStar=None
+            list_for_matching_HeStar=None,
+            **kwargs
     ):
         """Initialize the step. See class documentation for details."""
         self.dt = dt
@@ -272,17 +273,18 @@ class detached_step:
         self.KEYS = DEFAULT_TRANSLATED_KEYS
 
         # creating a track matching object
-        self.track_matcher = TrackMatcher(grid_name_Hrich = grid_name_Hrich,
-                                          grid_name_strippedHe = grid_name_strippedHe,
-                                          path=path, metallicity = metallicity,
-                                          matching_method = matching_method,
-                                          matching_tolerance=matching_tolerance,
-                                          matching_tolerance_hard=matching_tolerance_hard,
-                                          list_for_matching_HMS = list_for_matching_HMS,
-                                          list_for_matching_HeStar = list_for_matching_HeStar,
-                                          list_for_matching_postMS = list_for_matching_postMS,
-                                          record_matching = record_matching,
-                                          verbose = self.verbose)
+        #self.track_matcher = TrackMatcher(grid_name_Hrich = grid_name_Hrich,
+        #                                  grid_name_strippedHe = grid_name_strippedHe,
+        #                                  path=path, metallicity = metallicity,
+        #                                  matching_method = matching_method,
+        #                                  matching_tolerance=matching_tolerance,
+        #                                  matching_tolerance_hard=matching_tolerance_hard,
+        #                                  list_for_matching_HMS = list_for_matching_HMS,
+        #                                  list_for_matching_HeStar = list_for_matching_HeStar,
+        #                                  list_for_matching_postMS = list_for_matching_postMS,
+        #                                  record_matching = record_matching,
+        #                                  verbose = self.verbose)
+        self.track_matcher = kwargs.get('track_matcher', None)
 
         # create evolution handler object
         self.init_evo_kwargs()
@@ -308,6 +310,7 @@ class detached_step:
         """Return the name of evolution step."""
         return "Detached Step."
 
+    #@profile
     def __call__(self, binary):
         """
             Evolve the binary through detached evolution until RLO or

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -36,6 +36,7 @@ from posydon.binary_evol.DT.magnetic_braking.prescriptions import (
     RVJ83_braking,
 )
 from posydon.binary_evol.DT.tides.default_tides import default_tides
+
 #from posydon.binary_evol.DT.track_match import TrackMatcher
 from posydon.binary_evol.DT.winds.default_winds import (
     default_sep_from_winds,

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -433,7 +433,7 @@ class TrackMatcher:
     def train_scalers(self):
 
        # ...if not, fit a new scaler, and store it for later use
-        
+
         lists_for_matching = [self.list_for_matching_HMS,
                               self.list_for_matching_HeStar,
                               self.list_for_matching_HMS_alternative,
@@ -442,9 +442,9 @@ class TrackMatcher:
                               self.list_for_matching_postHeMS_alternative,
                               self.list_for_matching_postMS,
                               self.list_for_matching_postMS_alternative]
-        
+
         #htracks = [True, False, False, False, False, False, True, False]
-        
+
         for list_for_matching in lists_for_matching:
 
             match_attr_names = list_for_matching[0]
@@ -458,7 +458,7 @@ class TrackMatcher:
             for htrack in [True, False]:
                 grid = self.grid_Hrich if htrack else self.grid_strippedHe
                 self.initial_mass = grid.grid_mass
-                
+
                 # get (or train and get) scalers for attributes
                 # attributes are scaled to range (0, 1)
                 #scalers = []
@@ -484,7 +484,7 @@ class TrackMatcher:
 
     #@profile
     def create_root0_h(self):
-    
+
         # set which grid to search based on htrack condition
         grid = self.grid_Hrich
 
@@ -510,7 +510,7 @@ class TrackMatcher:
 
     #@profile
     def create_root0_he(self):
-    
+
         # set which grid to search based on htrack condition
         grid = self.grid_strippedHe
 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -424,112 +424,6 @@ class TrackMatcher:
 
         self.record_matching = record_matching
 
-        self.create_root0_h()
-        self.create_root0_he()
-        self.train_scalers()
-
-    def train_scalers(self):
-
-       # ...if not, fit a new scaler, and store it for later use
-        
-        lists_for_matching = [self.list_for_matching_HMS,
-                              self.list_for_matching_HeStar,
-                              self.list_for_matching_HMS_alternative,
-                              self.list_for_matching_HeStar_alternative,
-                              self.list_for_matching_postHeMS,
-                              self.list_for_matching_postHeMS_alternative,
-                              self.list_for_matching_postMS,
-                              self.list_for_matching_postMS_alternative]
-        
-        #htracks = [True, False, False, False, False, False, True, False]
-        
-        for list_for_matching in lists_for_matching:
-
-            match_attr_names = list_for_matching[0]
-            rescale_facs = list_for_matching[1]
-            scaler_methods = list_for_matching[2]
-            bnds = list_for_matching[3:]
-
-            if self.verbose:
-                print("Matching parameters and their normalizations:\n",
-                        match_attr_names, rescale_facs)
-            for htrack in [True, False]:
-                grid = self.grid_Hrich if htrack else self.grid_strippedHe
-                self.initial_mass = grid.grid_mass
-                
-                # get (or train and get) scalers for attributes
-                # attributes are scaled to range (0, 1)
-                #scalers = []
-                for attr_name, method in zip(match_attr_names, scaler_methods):
-                    all_attributes = []
-                    # check that attributes are allowed as matching attributes
-                    if attr_name not in self.root_keys:
-                        raise AttributeError("Expected matching attribute "
-                                                f"{attr_name} not "
-                                                "added in root_keys list: "
-                                                f"{self.root_keys}")
-
-                    scaler_options = (attr_name, htrack, method)
-
-                    for mass in self.initial_mass:
-                        for i in grid.get(attr_name, mass):
-                            all_attributes.append(i)
-
-                    all_attributes = np.array(all_attributes)
-                    scaler = DataScaler()
-                    scaler.fit(all_attributes, method=method, lower=0.0, upper=1.0)
-                    self.stored_scalers[scaler_options] = scaler
-
-    def create_root0_h(self):
-    
-        # set which grid to search based on htrack condition
-        grid = self.grid_Hrich
-
-        # initial masses within grid (defined but never used? used in scale())
-        self.initial_mass = grid.grid_mass
-
-        # search across all initial masses and get max track length
-        max_track_length = 0
-        for mass in grid.grid_mass:
-            track_length = len(grid.get("age", mass))
-            max_track_length = max(max_track_length, track_length)
-
-        # intialize root matrix
-        # (DIM = [N(Mi), N(max_track_length), N(root_keys)])
-        self.rootm_h = np.inf * np.ones((len(grid.grid_mass),
-                                    max_track_length, len(self.root_keys)))
-
-        # for each mass, get matching metrics and store in matrix
-        for i, mass in enumerate(grid.grid_mass):
-            for j, key in enumerate(self.root_keys):
-                track = grid.get(key, mass)
-                self.rootm_h[i, : len(track), j] = track
-
-    def create_root0_he(self):
-    
-        # set which grid to search based on htrack condition
-        grid = self.grid_strippedHe
-
-        # initial masses within grid (defined but never used? used in scale())
-        self.initial_mass = grid.grid_mass
-
-        # search across all initial masses and get max track length
-        max_track_length = 0
-        for mass in grid.grid_mass:
-            track_length = len(grid.get("age", mass))
-            max_track_length = max(max_track_length, track_length)
-
-        # intialize root matrix
-        # (DIM = [N(Mi), N(max_track_length), N(root_keys)])
-        self.rootm_he = np.inf * np.ones((len(grid.grid_mass),
-                                    max_track_length, len(self.root_keys)))
-
-        # for each mass, get matching metrics and store in matrix
-        for i, mass in enumerate(grid.grid_mass):
-            for j, key in enumerate(self.root_keys):
-                track = grid.get(key, mass)
-                self.rootm_he[i, : len(track), j] = track
-
     def get_root0(self, attr_names, attr_vals, htrack, rescale_facs=None):
         """
             Get the stellar evolution track in the single star grid with values
@@ -568,8 +462,28 @@ class TrackMatcher:
 
         """
 
-        rootm = self.rootm_h if htrack else self.rootm_he
+        # set which grid to search based on htrack condition
         grid = self.grid_Hrich if htrack else self.grid_strippedHe
+
+        # initial masses within grid (defined but never used? used in scale())
+        self.initial_mass = grid.grid_mass
+
+        # search across all initial masses and get max track length
+        max_track_length = 0
+        for mass in grid.grid_mass:
+            track_length = len(grid.get("age", mass))
+            max_track_length = max(max_track_length, track_length)
+
+        # intialize root matrix
+        # (DIM = [N(Mi), N(max_track_length), N(root_keys)])
+        self.rootm = np.inf * np.ones((len(grid.grid_mass),
+                                    max_track_length, len(self.root_keys)))
+
+        # for each mass, get matching metrics and store in matrix
+        for i, mass in enumerate(grid.grid_mass):
+            for j, key in enumerate(self.root_keys):
+                track = grid.get(key, mass)
+                self.rootm[i, : len(track), j] = track
 
         # rescaling factors
         if rescale_facs is None:
@@ -586,7 +500,7 @@ class TrackMatcher:
         # Slice out just the matching metric data for all stellar tracks
         # grid_attr_vals now has shape
         # (N(Mi), N(max_track_len), N(matching_metrics))
-        grid_attr_vals = rootm[:, :, idx]
+        grid_attr_vals = self.rootm[:, :, idx]
 
         # For all stellar tracks in grid:
         # Take difference btwn. grid track and given star values...
@@ -607,7 +521,7 @@ class TrackMatcher:
 
         # time and initial mass corresp. to track w/ minimum difference
         m0 = grid.grid_mass[mass_i]
-        t0 = rootm[mass_i][age_i][np.argmax("age" == self.root_keys)]
+        t0 = self.rootm[mass_i][age_i][np.argmax("age" == self.root_keys)]
 
         return m0, t0
 
@@ -658,7 +572,6 @@ class TrackMatcher:
 
         return val
 
-    #@profile
     def scale(self, attr_name, htrack, scaler_method):
         """
 
@@ -694,10 +607,22 @@ class TrackMatcher:
 
         # find if the scaler has already been fitted and return it if so...
         scaler = self.stored_scalers.get(scaler_options, None)
-        #if scaler is not None:
-        #    return scaler
-        
-        #print("DEBUG: Training scaler...")
+        if scaler is not None:
+            return scaler
+
+        # ...if not, fit a new scaler, and store it for later use
+        grid = self.grid_Hrich if htrack else self.grid_strippedHe
+        self.initial_mass = grid.grid_mass
+        all_attributes = []
+
+        for mass in self.initial_mass:
+            for i in grid.get(attr_name, mass):
+                all_attributes.append(i)
+
+        all_attributes = np.array(all_attributes)
+        scaler = DataScaler()
+        scaler.fit(all_attributes, method=scaler_method, lower=0.0, upper=1.0)
+        self.stored_scalers[scaler_options] = scaler
 
         return scaler
 
@@ -915,7 +840,6 @@ class TrackMatcher:
 
         return match_vals, sol
 
-    #@profile
     def match_through_minimize(self, star, get_root0, get_track_val):
         """
             Match the star through a minimization method. An initial
@@ -1470,6 +1394,7 @@ class TrackMatcher:
             match_vals = best_sol.x
 
         return match_vals, best_sol
+
 
     def get_star_match_data(self, binary, star,
                             copy_prev_m0=None, copy_prev_t0=None):

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -431,7 +431,7 @@ class TrackMatcher:
     def train_scalers(self):
 
        # ...if not, fit a new scaler, and store it for later use
-        
+
         lists_for_matching = [self.list_for_matching_HMS,
                               self.list_for_matching_HeStar,
                               self.list_for_matching_HMS_alternative,
@@ -440,9 +440,9 @@ class TrackMatcher:
                               self.list_for_matching_postHeMS_alternative,
                               self.list_for_matching_postMS,
                               self.list_for_matching_postMS_alternative]
-        
+
         #htracks = [True, False, False, False, False, False, True, False]
-        
+
         for list_for_matching in lists_for_matching:
 
             match_attr_names = list_for_matching[0]
@@ -456,7 +456,7 @@ class TrackMatcher:
             for htrack in [True, False]:
                 grid = self.grid_Hrich if htrack else self.grid_strippedHe
                 self.initial_mass = grid.grid_mass
-                
+
                 # get (or train and get) scalers for attributes
                 # attributes are scaled to range (0, 1)
                 #scalers = []
@@ -481,7 +481,7 @@ class TrackMatcher:
                     self.stored_scalers[scaler_options] = scaler
 
     def create_root0_h(self):
-    
+
         # set which grid to search based on htrack condition
         grid = self.grid_Hrich
 
@@ -506,7 +506,7 @@ class TrackMatcher:
                 self.rootm_h[i, : len(track), j] = track
 
     def create_root0_he(self):
-    
+
         # set which grid to search based on htrack condition
         grid = self.grid_strippedHe
 
@@ -696,7 +696,7 @@ class TrackMatcher:
         scaler = self.stored_scalers.get(scaler_options, None)
         #if scaler is not None:
         #    return scaler
-        
+
         #print("DEBUG: Training scaler...")
 
         return scaler

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -424,6 +424,112 @@ class TrackMatcher:
 
         self.record_matching = record_matching
 
+        self.create_root0_h()
+        self.create_root0_he()
+        self.train_scalers()
+
+    def train_scalers(self):
+
+       # ...if not, fit a new scaler, and store it for later use
+        
+        lists_for_matching = [self.list_for_matching_HMS,
+                              self.list_for_matching_HeStar,
+                              self.list_for_matching_HMS_alternative,
+                              self.list_for_matching_HeStar_alternative,
+                              self.list_for_matching_postHeMS,
+                              self.list_for_matching_postHeMS_alternative,
+                              self.list_for_matching_postMS,
+                              self.list_for_matching_postMS_alternative]
+        
+        #htracks = [True, False, False, False, False, False, True, False]
+        
+        for list_for_matching in lists_for_matching:
+
+            match_attr_names = list_for_matching[0]
+            rescale_facs = list_for_matching[1]
+            scaler_methods = list_for_matching[2]
+            bnds = list_for_matching[3:]
+
+            if self.verbose:
+                print("Matching parameters and their normalizations:\n",
+                        match_attr_names, rescale_facs)
+            for htrack in [True, False]:
+                grid = self.grid_Hrich if htrack else self.grid_strippedHe
+                self.initial_mass = grid.grid_mass
+                
+                # get (or train and get) scalers for attributes
+                # attributes are scaled to range (0, 1)
+                #scalers = []
+                for attr_name, method in zip(match_attr_names, scaler_methods):
+                    all_attributes = []
+                    # check that attributes are allowed as matching attributes
+                    if attr_name not in self.root_keys:
+                        raise AttributeError("Expected matching attribute "
+                                                f"{attr_name} not "
+                                                "added in root_keys list: "
+                                                f"{self.root_keys}")
+
+                    scaler_options = (attr_name, htrack, method)
+
+                    for mass in self.initial_mass:
+                        for i in grid.get(attr_name, mass):
+                            all_attributes.append(i)
+
+                    all_attributes = np.array(all_attributes)
+                    scaler = DataScaler()
+                    scaler.fit(all_attributes, method=method, lower=0.0, upper=1.0)
+                    self.stored_scalers[scaler_options] = scaler
+
+    def create_root0_h(self):
+    
+        # set which grid to search based on htrack condition
+        grid = self.grid_Hrich
+
+        # initial masses within grid (defined but never used? used in scale())
+        self.initial_mass = grid.grid_mass
+
+        # search across all initial masses and get max track length
+        max_track_length = 0
+        for mass in grid.grid_mass:
+            track_length = len(grid.get("age", mass))
+            max_track_length = max(max_track_length, track_length)
+
+        # intialize root matrix
+        # (DIM = [N(Mi), N(max_track_length), N(root_keys)])
+        self.rootm_h = np.inf * np.ones((len(grid.grid_mass),
+                                    max_track_length, len(self.root_keys)))
+
+        # for each mass, get matching metrics and store in matrix
+        for i, mass in enumerate(grid.grid_mass):
+            for j, key in enumerate(self.root_keys):
+                track = grid.get(key, mass)
+                self.rootm_h[i, : len(track), j] = track
+
+    def create_root0_he(self):
+    
+        # set which grid to search based on htrack condition
+        grid = self.grid_strippedHe
+
+        # initial masses within grid (defined but never used? used in scale())
+        self.initial_mass = grid.grid_mass
+
+        # search across all initial masses and get max track length
+        max_track_length = 0
+        for mass in grid.grid_mass:
+            track_length = len(grid.get("age", mass))
+            max_track_length = max(max_track_length, track_length)
+
+        # intialize root matrix
+        # (DIM = [N(Mi), N(max_track_length), N(root_keys)])
+        self.rootm_he = np.inf * np.ones((len(grid.grid_mass),
+                                    max_track_length, len(self.root_keys)))
+
+        # for each mass, get matching metrics and store in matrix
+        for i, mass in enumerate(grid.grid_mass):
+            for j, key in enumerate(self.root_keys):
+                track = grid.get(key, mass)
+                self.rootm_he[i, : len(track), j] = track
+
     def get_root0(self, attr_names, attr_vals, htrack, rescale_facs=None):
         """
             Get the stellar evolution track in the single star grid with values
@@ -462,28 +568,8 @@ class TrackMatcher:
 
         """
 
-        # set which grid to search based on htrack condition
+        rootm = self.rootm_h if htrack else self.rootm_he
         grid = self.grid_Hrich if htrack else self.grid_strippedHe
-
-        # initial masses within grid (defined but never used? used in scale())
-        self.initial_mass = grid.grid_mass
-
-        # search across all initial masses and get max track length
-        max_track_length = 0
-        for mass in grid.grid_mass:
-            track_length = len(grid.get("age", mass))
-            max_track_length = max(max_track_length, track_length)
-
-        # intialize root matrix
-        # (DIM = [N(Mi), N(max_track_length), N(root_keys)])
-        self.rootm = np.inf * np.ones((len(grid.grid_mass),
-                                    max_track_length, len(self.root_keys)))
-
-        # for each mass, get matching metrics and store in matrix
-        for i, mass in enumerate(grid.grid_mass):
-            for j, key in enumerate(self.root_keys):
-                track = grid.get(key, mass)
-                self.rootm[i, : len(track), j] = track
 
         # rescaling factors
         if rescale_facs is None:
@@ -500,7 +586,7 @@ class TrackMatcher:
         # Slice out just the matching metric data for all stellar tracks
         # grid_attr_vals now has shape
         # (N(Mi), N(max_track_len), N(matching_metrics))
-        grid_attr_vals = self.rootm[:, :, idx]
+        grid_attr_vals = rootm[:, :, idx]
 
         # For all stellar tracks in grid:
         # Take difference btwn. grid track and given star values...
@@ -521,7 +607,7 @@ class TrackMatcher:
 
         # time and initial mass corresp. to track w/ minimum difference
         m0 = grid.grid_mass[mass_i]
-        t0 = self.rootm[mass_i][age_i][np.argmax("age" == self.root_keys)]
+        t0 = rootm[mass_i][age_i][np.argmax("age" == self.root_keys)]
 
         return m0, t0
 
@@ -572,6 +658,7 @@ class TrackMatcher:
 
         return val
 
+    #@profile
     def scale(self, attr_name, htrack, scaler_method):
         """
 
@@ -607,22 +694,10 @@ class TrackMatcher:
 
         # find if the scaler has already been fitted and return it if so...
         scaler = self.stored_scalers.get(scaler_options, None)
-        if scaler is not None:
-            return scaler
-
-        # ...if not, fit a new scaler, and store it for later use
-        grid = self.grid_Hrich if htrack else self.grid_strippedHe
-        self.initial_mass = grid.grid_mass
-        all_attributes = []
-
-        for mass in self.initial_mass:
-            for i in grid.get(attr_name, mass):
-                all_attributes.append(i)
-
-        all_attributes = np.array(all_attributes)
-        scaler = DataScaler()
-        scaler.fit(all_attributes, method=scaler_method, lower=0.0, upper=1.0)
-        self.stored_scalers[scaler_options] = scaler
+        #if scaler is not None:
+        #    return scaler
+        
+        #print("DEBUG: Training scaler...")
 
         return scaler
 
@@ -840,6 +915,7 @@ class TrackMatcher:
 
         return match_vals, sol
 
+    #@profile
     def match_through_minimize(self, star, get_root0, get_track_val):
         """
             Match the star through a minimization method. An initial
@@ -1394,7 +1470,6 @@ class TrackMatcher:
             match_vals = best_sol.x
 
         return match_vals, best_sol
-
 
     def get_star_match_data(self, binary, star,
                             copy_prev_m0=None, copy_prev_t0=None):

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -141,7 +141,8 @@ class MesaGridStep:
             stop_var_name=None,
             stop_value=None,
             stop_interpolate=True,
-            verbose=False):
+            verbose=False,
+            **kwargs):
         """Evolve a binary object given a MESA grid or interpolation object.
 
         Parameters
@@ -290,6 +291,7 @@ class MesaGridStep:
         # if hasattr(self, '_Interp'):
         #     self._Interp.close()
 
+    #@profile
     def get_final_MESA_step_time(self):
         """Infer the maximum MESA step time.
 
@@ -315,6 +317,7 @@ class MesaGridStep:
 
         return max_MESA_sim_time
 
+    #@profile
     def __call__(self, binary):
         """Evolve a binary using the MESA step."""
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -295,7 +295,7 @@ class BinaryStar:
         #elif next_step_name == "step_detached":
         #    next_step(self)
         #elif next_step_name == "step_dco":
-        #    next_step(self) 
+        #    next_step(self)
         #elif next_step_name == "step_merged":
         #    next_step(self)
         #elif next_step_name == "step_disrupted":

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -231,6 +231,7 @@ class BinaryStar:
         else:
             self.properties = SimulationProperties()
 
+    #@profile
     def evolve(self):
         """Evolve a binary from start to finish."""
 
@@ -264,6 +265,7 @@ class BinaryStar:
 
         self.properties.post_evolve(self)
 
+    #@profile
     def run_step(self):
         """Evolve the binary through one evolutionary step."""
         total_state = self.get_total_state()
@@ -280,6 +282,29 @@ class BinaryStar:
                              "SimulationProperties.".format(next_step_name))
 
         self.properties.pre_step(self, next_step_name)
+
+        # breaking up for profiling
+        #if next_step_name == "step_HMS_HMS":
+        #    next_step(self)
+        #elif next_step_name == "step_CO_HeMS":
+        #    next_step(self)
+        #elif next_step_name == "step_CO_HMS_RLO":
+        #    next_step(self)
+        #elif next_step_name == "step_CO_HeMS_RLO":
+        #    next_step(self)
+        #elif next_step_name == "step_detached":
+        #    next_step(self)
+        #elif next_step_name == "step_dco":
+        #    next_step(self) 
+        #elif next_step_name == "step_merged":
+        #    next_step(self)
+        #elif next_step_name == "step_disrupted":
+        #    next_step(self)
+        #elif next_step_name == "step_SN":
+        #    next_step(self)
+        #elif next_step_name == "step_CE":
+        #    next_step(self)
+        #else:
         next_step(self)
 
         self.append_state()

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -231,7 +231,6 @@ class BinaryStar:
         else:
             self.properties = SimulationProperties()
 
-    #@profile
     def evolve(self):
         """Evolve a binary from start to finish."""
 
@@ -265,7 +264,6 @@ class BinaryStar:
 
         self.properties.post_evolve(self)
 
-    #@profile
     def run_step(self):
         """Evolve the binary through one evolutionary step."""
         total_state = self.get_total_state()
@@ -282,29 +280,6 @@ class BinaryStar:
                              "SimulationProperties.".format(next_step_name))
 
         self.properties.pre_step(self, next_step_name)
-
-        # breaking up for profiling
-        #if next_step_name == "step_HMS_HMS":
-        #    next_step(self)
-        #elif next_step_name == "step_CO_HeMS":
-        #    next_step(self)
-        #elif next_step_name == "step_CO_HMS_RLO":
-        #    next_step(self)
-        #elif next_step_name == "step_CO_HeMS_RLO":
-        #    next_step(self)
-        #elif next_step_name == "step_detached":
-        #    next_step(self)
-        #elif next_step_name == "step_dco":
-        #    next_step(self) 
-        #elif next_step_name == "step_merged":
-        #    next_step(self)
-        #elif next_step_name == "step_disrupted":
-        #    next_step(self)
-        #elif next_step_name == "step_SN":
-        #    next_step(self)
-        #elif next_step_name == "step_CE":
-        #    next_step(self)
-        #else:
         next_step(self)
 
         self.append_state()

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -231,6 +231,7 @@ class BinaryStar:
         else:
             self.properties = SimulationProperties()
 
+    #@profile
     def evolve(self):
         """Evolve a binary from start to finish."""
 
@@ -264,6 +265,7 @@ class BinaryStar:
 
         self.properties.post_evolve(self)
 
+    #@profile
     def run_step(self):
         """Evolve the binary through one evolutionary step."""
         total_state = self.get_total_state()
@@ -282,28 +284,28 @@ class BinaryStar:
         self.properties.pre_step(self, next_step_name)
 
         # breaking up for profiling
-        #if next_step_name == "step_HMS_HMS":
-        #    next_step(self)
-        #elif next_step_name == "step_CO_HeMS":
-        #    next_step(self)
-        #elif next_step_name == "step_CO_HMS_RLO":
-        #    next_step(self)
-        #elif next_step_name == "step_CO_HeMS_RLO":
-        #    next_step(self)
-        #elif next_step_name == "step_detached":
-        #    next_step(self)
-        #elif next_step_name == "step_dco":
-        #    next_step(self)
-        #elif next_step_name == "step_merged":
-        #    next_step(self)
-        #elif next_step_name == "step_disrupted":
-        #    next_step(self)
-        #elif next_step_name == "step_SN":
-        #    next_step(self)
-        #elif next_step_name == "step_CE":
-        #    next_step(self)
-        #else:
-        next_step(self)
+        if next_step_name == "step_HMS_HMS":
+            next_step(self)
+        elif next_step_name == "step_CO_HeMS":
+            next_step(self)
+        elif next_step_name == "step_CO_HMS_RLO":
+            next_step(self)
+        elif next_step_name == "step_CO_HeMS_RLO":
+            next_step(self)
+        elif next_step_name == "step_detached":
+            next_step(self)
+        elif next_step_name == "step_dco":
+            next_step(self)
+        elif next_step_name == "step_merged":
+            next_step(self)
+        elif next_step_name == "step_disrupted":
+            next_step(self)
+        elif next_step_name == "step_SN":
+            next_step(self)
+        elif next_step_name == "step_CE":
+            next_step(self)
+        else:
+            next_step(self)
 
         self.append_state()
         self.properties.post_step(self, next_step_name)

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -21,6 +21,8 @@ from posydon.popsyn.io import simprop_kwargs_from_ini
 from posydon.utils.constants import age_of_universe
 from posydon.utils.posydonwarning import Pwarn
 
+from posydon.config import PATH_TO_POSYDON_DATA
+from posydon.binary_evol.DT.track_match import TrackMatcher
 
 class NullStep:
     """An evolution step that does nothing but is used to initialize."""
@@ -245,6 +247,7 @@ class SimulationProperties:
 
         return new_instance
 
+    #@profile
     def load_steps(self, metallicity=None, verbose=False):
         """Instantiate all step classes and set as instance attributes.
 
@@ -266,11 +269,32 @@ class SimulationProperties:
         if verbose:
             print('STEP NAME'.ljust(20) + 'STEP FUNCTION'.ljust(25) + 'KWARGS')
 
+
+        # creating a track matching object
+        self.track_matcher = None
+
         # for every other step, give it a metallicity and load each step
         for name, tup in self.kwargs.items():
             if isinstance(tup, tuple):
                 step_kwargs = tup[1]
                 metallicity = step_kwargs.get('metallicity', metallicity)
+
+                if self.track_matcher is None and metallicity is not None:
+                    self.track_matcher = TrackMatcher(grid_name_Hrich = None,
+                                            grid_name_strippedHe = None,
+                                            path=PATH_TO_POSYDON_DATA, metallicity = metallicity,
+                                            matching_method = "minimize",
+                                            matching_tolerance=1e-2,
+                                            matching_tolerance_hard=1e-1,
+                                            list_for_matching_HMS = None,
+                                            list_for_matching_HeStar = None,
+                                            list_for_matching_postMS = None,
+                                            record_matching = False,
+                                            verbose = False)
+                    
+                if name not in ["flow", "step_SN", "step_end"]:
+                    step_kwargs['track_matcher'] = self.track_matcher
+
                 self.load_a_step(name, tup, metallicity=metallicity, verbose=verbose)
 
         # track that all steps have been loaded

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -17,12 +17,12 @@ __authors__ = [
 import os
 import time
 
+from posydon.binary_evol.DT.track_match import TrackMatcher
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.popsyn.io import simprop_kwargs_from_ini
 from posydon.utils.constants import age_of_universe
 from posydon.utils.posydonwarning import Pwarn
 
-from posydon.config import PATH_TO_POSYDON_DATA
-from posydon.binary_evol.DT.track_match import TrackMatcher
 
 class NullStep:
     """An evolution step that does nothing but is used to initialize."""
@@ -291,7 +291,7 @@ class SimulationProperties:
                                             list_for_matching_postMS = None,
                                             record_matching = False,
                                             verbose = False)
-                    
+
                 if name not in ["flow", "step_SN", "step_end"]:
                     step_kwargs['track_matcher'] = self.track_matcher
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1472,18 +1472,8 @@ class PSyGrid:
         hdf5 = self.hdf5
         # load initial/final_values
         self._say("\tLoading initial/final values...")
-        self.initial_values = hdf5['/grid/initial_values'][()]
-        self.final_values = hdf5['/grid/final_values'][()]
-
-        # change ASCII to UNICODE in termination flags in `final_values`
-        new_dtype = []
-        for dtype in self.final_values.dtype.descr:
-            if (dtype[0].startswith("termination_flag") or
-                (dtype[0] == "mt_history") or ("_type" in dtype[0]) or
-                ("_state" in dtype[0]) or ("_class" in dtype[0])):
-                dtype = (dtype[0], H5_REC_STR_DTYPE.replace("S", "U"))
-            new_dtype.append(dtype)
-        self.final_values = self.final_values.astype(new_dtype)
+        self.initial_values = hdf5['/grid/initial_values']
+        self.final_values = hdf5['/grid/final_values']
 
         # load MESA dirs
         self._say("\tAcquiring paths to MESA directories...")

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -2204,7 +2204,7 @@ class PSyRunView:
             raise IOError("The HDF5 file is not open.")
         fullkey = self._hdf5_key() + "/" + key
         try:
-            return hdf5[fullkey]#[()]
+            return hdf5[fullkey][()]
         except KeyError:
             if key in VALID_KEYS:  # key is valid, so the data is just missing
                 return None

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -2204,7 +2204,7 @@ class PSyRunView:
             raise IOError("The HDF5 file is not open.")
         fullkey = self._hdf5_key() + "/" + key
         try:
-            return hdf5[fullkey][()]
+            return hdf5[fullkey]#[()]
         except KeyError:
             if key in VALID_KEYS:  # key is valid, so the data is just missing
                 return None

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -331,7 +331,9 @@ class GRIDInterpolator():
 
         grid_mass = []
         for i in range(len(grid)):
-            grid_mass.append(grid[i].history1['star_mass'][0])
+            minit = grid[i].history1['star_mass'][0] 
+            grid_mass.append(minit)
+
         self.grid_mass = np.array(grid_mass)
 
         grid_age = []
@@ -501,6 +503,11 @@ class GRIDInterpolator():
             'neutral_fraction_He',
             'avg_charge_He'
         )
+
+        # pre-load the grid data for all masses
+        for i in range(len(grid)):
+            minit = grid[i].history1['star_mass'][0] 
+            self.load_grid(minit)
 
     def load_grid(self, *args):
         """Load the requested data to `grid_data`.

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -502,8 +502,7 @@ class GRIDInterpolator():
             'avg_charge_He'
         )
 
-    #@profile
-    def load_grid(self, *args, hkey=None, fkey=None, pkey=None):
+    def load_grid(self, *args):
         """Load the requested data to `grid_data`.
 
         Parameters
@@ -516,39 +515,24 @@ class GRIDInterpolator():
         grid = self.grid
         for m in args:
             idx = np.argmax(m == self.grid_mass)
-            
-            if hkey:
-                self.grid_data[m] = dict()
-                data = grid[idx].history1
-                self.grid_data[m][hkey] = data[self.translate[hkey]]
-                self.grid_data[m]['log_L'] = data[self.translate['log_L']]
-                self.grid_data[m]['log_LH'] = data[self.translate['log_LH']]
-            if fkey:
-                self.grid_final_values[m] = dict()
-                final_value = grid[idx].final_values
-                self.grid_final_values[m][fkey] = final_value[fkey]
-            if pkey:
-                self.grid_profile[m] = dict()
-                profile = grid[idx].final_profile1
-                self.grid_profile[m][pkey] = profile[pkey]
-                self.grid_profile[m]['mass'] = profile['mass']
-            
-            #self.grid_data[m] = dict()
-            #self.grid_final_values[m] = dict()
-            #self.grid_profile[m] = dict()
-            #for key in self.keys:
-            
-            #for key in self.final_keys:
-            
-            #for key in self.profile_keys:
-
+            data = grid[idx].history1
+            final_value = grid[idx].final_values
+            profile = grid[idx].final_profile1
+            self.grid_data[m] = dict()
+            self.grid_final_values[m] = dict()
+            self.grid_profile[m] = dict()
+            for key in self.keys:
+                self.grid_data[m][key] = data[self.translate[key]]
+            for key in self.final_keys:
+                self.grid_final_values[m][key] = final_value[key]
+            for key in self.profile_keys:
+                self.grid_profile[m][key] = profile[key]
 
     def close(self):
         """Close any loaded psygrids."""
         if hasattr(self, 'grid'):
             self.grid.close()
 
-    #@profile
     def get(self, key, M_new):
         """Perform linear interpolation between specific time-series.
 
@@ -572,7 +556,7 @@ class GRIDInterpolator():
             try:
                 kvalue = self.grid_data[M_new][key]
             except KeyError:
-                self.load_grid(M_new, hkey=key)
+                self.load_grid(M_new)
                 kvalue = self.grid_data[M_new][key]
 
             log_L = self.grid_data[M_new]['log_L']
@@ -586,12 +570,12 @@ class GRIDInterpolator():
             try:
                 kvalue_low = self.grid_data[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low, hkey=key)
+                self.load_grid(mass_low)
                 kvalue_low = self.grid_data[mass_low][key]
             try:
                 kvalue_high = self.grid_data[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high, hkey=key)
+                self.load_grid(mass_high)
                 kvalue_high = self.grid_data[mass_high][key]
 
             i_cut = min(len(kvalue_low), len(kvalue_high))
@@ -619,7 +603,7 @@ class GRIDInterpolator():
             try:
                 kvalue = self.grid_final_values[M_new][key]
             except KeyError:
-                self.load_grid(M_new, fkey=key)
+                self.load_grid(M_new)
                 kvalue = self.grid_final_values[M_new][key]
         else:
             mass_low = np.max(self.grid_mass[M_new > self.grid_mass])
@@ -628,7 +612,7 @@ class GRIDInterpolator():
             try:
                 kvalue_low = self.grid_final_values[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low, fkey=key)
+                self.load_grid(mass_low)
                 kvalue_low = self.grid_final_values[mass_low][key]
 
             while pd.isna(kvalue_low):
@@ -639,13 +623,13 @@ class GRIDInterpolator():
                 try:
                     kvalue_low = self.grid_final_values[mass_low][key]
                 except KeyError:
-                    self.load_grid(mass_low, fkey=key)
+                    self.load_grid(mass_low)
                     kvalue_low = self.grid_final_values[mass_low][key]
 
             try:
                 kvalue_high = self.grid_final_values[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high, fkey=key)
+                self.load_grid(mass_high)
                 kvalue_high = self.grid_final_values[mass_high][key]
 
             while pd.isna(kvalue_high):
@@ -656,7 +640,7 @@ class GRIDInterpolator():
                 try:
                     kvalue_high = self.grid_final_values[mass_high][key]
                 except KeyError:
-                    self.load_grid(mass_high, fkey=key)
+                    self.load_grid(mass_high)
                     kvalue_high = self.grid_final_values[mass_high][key]
 
             weight = (M_new - mass_low) / (mass_high - mass_low)
@@ -674,7 +658,7 @@ class GRIDInterpolator():
             try:
                 kstate = self.grid_final_values[M_new][key]
             except KeyError:
-                self.load_grid(M_new, fkey=key)
+                self.load_grid(M_new)
                 kstate = self.grid_final_values[M_new][key]
         else:
             mass_low = np.max(self.grid_mass[M_new > self.grid_mass])
@@ -683,13 +667,13 @@ class GRIDInterpolator():
             try:
                 kstate_low = self.grid_final_values[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low, fkey=key)
+                self.load_grid(mass_low)
                 kstate_low = self.grid_final_values[mass_low][key]
 
             try:
                 kstate_high = self.grid_final_values[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high, fkey=key)
+                self.load_grid(mass_high)
                 kstate_high = self.grid_final_values[mass_high][key]
 
             mass_center = mass_low + (mass_high - mass_low)/2
@@ -709,7 +693,7 @@ class GRIDInterpolator():
                 idx = np.argmax(M_new == self.grid_mass)
                 profile_old = grid[idx].final_profile1
             except KeyError:
-                self.load_grid(M_new, pkey=key)
+                self.load_grid(M_new)
                 kvalue = self.grid_profile[M_new][key]
                 idx = np.argmax(M_new == self.grid_mass)
                 profile_old = grid[idx].final_profile1
@@ -720,12 +704,12 @@ class GRIDInterpolator():
             try:
                 kvalue_low = self.grid_profile[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low, pkey=key)
+                self.load_grid(mass_low)
                 kvalue_low = self.grid_profile[mass_low][key]
             try:
                 kvalue_high = self.grid_profile[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high, pkey=key)
+                self.load_grid(mass_high)
                 kvalue_high = self.grid_profile[mass_high][key]
 
             m_cor_low = (self.grid_profile[mass_low]['mass']

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -502,7 +502,8 @@ class GRIDInterpolator():
             'avg_charge_He'
         )
 
-    def load_grid(self, *args):
+    #@profile
+    def load_grid(self, *args, hkey=None, fkey=None, pkey=None):
         """Load the requested data to `grid_data`.
 
         Parameters
@@ -515,24 +516,39 @@ class GRIDInterpolator():
         grid = self.grid
         for m in args:
             idx = np.argmax(m == self.grid_mass)
-            data = grid[idx].history1
-            final_value = grid[idx].final_values
-            profile = grid[idx].final_profile1
-            self.grid_data[m] = dict()
-            self.grid_final_values[m] = dict()
-            self.grid_profile[m] = dict()
-            for key in self.keys:
-                self.grid_data[m][key] = data[self.translate[key]]
-            for key in self.final_keys:
-                self.grid_final_values[m][key] = final_value[key]
-            for key in self.profile_keys:
-                self.grid_profile[m][key] = profile[key]
+            
+            if hkey:
+                self.grid_data[m] = dict()
+                data = grid[idx].history1
+                self.grid_data[m][hkey] = data[self.translate[hkey]]
+                self.grid_data[m]['log_L'] = data[self.translate['log_L']]
+                self.grid_data[m]['log_LH'] = data[self.translate['log_LH']]
+            if fkey:
+                self.grid_final_values[m] = dict()
+                final_value = grid[idx].final_values
+                self.grid_final_values[m][fkey] = final_value[fkey]
+            if pkey:
+                self.grid_profile[m] = dict()
+                profile = grid[idx].final_profile1
+                self.grid_profile[m][pkey] = profile[pkey]
+                self.grid_profile[m]['mass'] = profile['mass']
+            
+            #self.grid_data[m] = dict()
+            #self.grid_final_values[m] = dict()
+            #self.grid_profile[m] = dict()
+            #for key in self.keys:
+            
+            #for key in self.final_keys:
+            
+            #for key in self.profile_keys:
+
 
     def close(self):
         """Close any loaded psygrids."""
         if hasattr(self, 'grid'):
             self.grid.close()
 
+    #@profile
     def get(self, key, M_new):
         """Perform linear interpolation between specific time-series.
 
@@ -556,7 +572,7 @@ class GRIDInterpolator():
             try:
                 kvalue = self.grid_data[M_new][key]
             except KeyError:
-                self.load_grid(M_new)
+                self.load_grid(M_new, hkey=key)
                 kvalue = self.grid_data[M_new][key]
 
             log_L = self.grid_data[M_new]['log_L']
@@ -570,12 +586,12 @@ class GRIDInterpolator():
             try:
                 kvalue_low = self.grid_data[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low)
+                self.load_grid(mass_low, hkey=key)
                 kvalue_low = self.grid_data[mass_low][key]
             try:
                 kvalue_high = self.grid_data[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high)
+                self.load_grid(mass_high, hkey=key)
                 kvalue_high = self.grid_data[mass_high][key]
 
             i_cut = min(len(kvalue_low), len(kvalue_high))
@@ -603,7 +619,7 @@ class GRIDInterpolator():
             try:
                 kvalue = self.grid_final_values[M_new][key]
             except KeyError:
-                self.load_grid(M_new)
+                self.load_grid(M_new, fkey=key)
                 kvalue = self.grid_final_values[M_new][key]
         else:
             mass_low = np.max(self.grid_mass[M_new > self.grid_mass])
@@ -612,7 +628,7 @@ class GRIDInterpolator():
             try:
                 kvalue_low = self.grid_final_values[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low)
+                self.load_grid(mass_low, fkey=key)
                 kvalue_low = self.grid_final_values[mass_low][key]
 
             while pd.isna(kvalue_low):
@@ -623,13 +639,13 @@ class GRIDInterpolator():
                 try:
                     kvalue_low = self.grid_final_values[mass_low][key]
                 except KeyError:
-                    self.load_grid(mass_low)
+                    self.load_grid(mass_low, fkey=key)
                     kvalue_low = self.grid_final_values[mass_low][key]
 
             try:
                 kvalue_high = self.grid_final_values[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high)
+                self.load_grid(mass_high, fkey=key)
                 kvalue_high = self.grid_final_values[mass_high][key]
 
             while pd.isna(kvalue_high):
@@ -640,7 +656,7 @@ class GRIDInterpolator():
                 try:
                     kvalue_high = self.grid_final_values[mass_high][key]
                 except KeyError:
-                    self.load_grid(mass_high)
+                    self.load_grid(mass_high, fkey=key)
                     kvalue_high = self.grid_final_values[mass_high][key]
 
             weight = (M_new - mass_low) / (mass_high - mass_low)
@@ -658,7 +674,7 @@ class GRIDInterpolator():
             try:
                 kstate = self.grid_final_values[M_new][key]
             except KeyError:
-                self.load_grid(M_new)
+                self.load_grid(M_new, fkey=key)
                 kstate = self.grid_final_values[M_new][key]
         else:
             mass_low = np.max(self.grid_mass[M_new > self.grid_mass])
@@ -667,13 +683,13 @@ class GRIDInterpolator():
             try:
                 kstate_low = self.grid_final_values[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low)
+                self.load_grid(mass_low, fkey=key)
                 kstate_low = self.grid_final_values[mass_low][key]
 
             try:
                 kstate_high = self.grid_final_values[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high)
+                self.load_grid(mass_high, fkey=key)
                 kstate_high = self.grid_final_values[mass_high][key]
 
             mass_center = mass_low + (mass_high - mass_low)/2
@@ -693,7 +709,7 @@ class GRIDInterpolator():
                 idx = np.argmax(M_new == self.grid_mass)
                 profile_old = grid[idx].final_profile1
             except KeyError:
-                self.load_grid(M_new)
+                self.load_grid(M_new, pkey=key)
                 kvalue = self.grid_profile[M_new][key]
                 idx = np.argmax(M_new == self.grid_mass)
                 profile_old = grid[idx].final_profile1
@@ -704,12 +720,12 @@ class GRIDInterpolator():
             try:
                 kvalue_low = self.grid_profile[mass_low][key]
             except KeyError:
-                self.load_grid(mass_low)
+                self.load_grid(mass_low, pkey=key)
                 kvalue_low = self.grid_profile[mass_low][key]
             try:
                 kvalue_high = self.grid_profile[mass_high][key]
             except KeyError:
-                self.load_grid(mass_high)
+                self.load_grid(mass_high, pkey=key)
                 kvalue_high = self.grid_profile[mass_high][key]
 
             m_cor_low = (self.grid_profile[mass_low]['mass']

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -516,7 +516,7 @@ class GRIDInterpolator():
         grid = self.grid
         for m in args:
             idx = np.argmax(m == self.grid_mass)
-            
+
             if hkey:
                 self.grid_data[m] = dict()
                 data = grid[idx].history1
@@ -532,14 +532,14 @@ class GRIDInterpolator():
                 profile = grid[idx].final_profile1
                 self.grid_profile[m][pkey] = profile[pkey]
                 self.grid_profile[m]['mass'] = profile['mass']
-            
+
             #self.grid_data[m] = dict()
             #self.grid_final_values[m] = dict()
             #self.grid_profile[m] = dict()
             #for key in self.keys:
-            
+
             #for key in self.final_keys:
-            
+
             #for key in self.profile_keys:
 
 

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -331,7 +331,7 @@ class GRIDInterpolator():
 
         grid_mass = []
         for i in range(len(grid)):
-            minit = grid[i].history1['star_mass'][0] 
+            minit = grid[i].history1['star_mass'][0]
             grid_mass.append(minit)
 
         self.grid_mass = np.array(grid_mass)
@@ -506,7 +506,7 @@ class GRIDInterpolator():
 
         # pre-load the grid data for all masses
         for i in range(len(grid)):
-            minit = grid[i].history1['star_mass'][0] 
+            minit = grid[i].history1['star_mass'][0]
             self.load_grid(minit)
 
     def load_grid(self, *args):

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -271,6 +271,7 @@ class BinaryPopulation:
             self.kwargs.update(params)
             self._safe_evolve(**self.kwargs)
 
+    #@profile
     def _safe_evolve(self, **kwargs):
         """Evolve binaries in a population, catching warnings/exceptions."""
         if not self.population_properties.steps_loaded:


### PR DESCRIPTION
Testing a potential solution to reduce some of the RAM used during population synthesis.

Right now we load entire data array for the initial and final values into RAM. About 5 GB of memory is allocated in total. If we instead use lazy access (storing the memory reference and not the entire array), we can save some RAM. With lazy access, we instead allocate only ~1.5 GB in total. Looking into further optimizations and still testing this one.

Also looking into RAM usage of binary evolution, although @maxbriel has looked into this quite a bit already (see [Issue#224](https://github.com/POSYDON-code/POSYDON/issues/224)).