### PR TITLE
[fix] Use `metallicities` instead of `metallicity` in popsyn CLI

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.2.3" %}
+{% set version = "2.2.4" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/CLI/popsyn/check.py
+++ b/posydon/CLI/popsyn/check.py
@@ -128,7 +128,7 @@ def get_binary_params(ini_file):
     '''
     # Read the population synthesis parameters
     synpop_params = binarypop_kwargs_from_ini(ini_file)
-    metallicities = synpop_params.get('metallicity', [])
+    metallicities = synpop_params.get('metallicities', [])
     num_metallicities = len(metallicities)
     number_of_binaries = synpop_params.get('number_of_binaries', 0)
     return num_metallicities, number_of_binaries, metallicities, synpop_params

--- a/posydon/CLI/popsyn/setup.py
+++ b/posydon/CLI/popsyn/setup.py
@@ -86,7 +86,7 @@ def setup_popsyn_function(args):
     validate_ini_file(args.ini_file)
 
     synpop_params = binarypop_kwargs_from_ini(args.ini_file)
-    metallicities = synpop_params['metallicity']
+    metallicities = synpop_params['metallicities']
     if synpop_params['number_of_binaries'] / args.job_array < 1:
         raise ValueError("The number of binaries is less than the job array"
                          " length. Please increase the number of binaries or"

--- a/posydon/unit_tests/CLI/popsyn/test_check.py
+++ b/posydon/unit_tests/CLI/popsyn/test_check.py
@@ -134,7 +134,7 @@ class TestGetBinaryParams:
     def test_get_binary_params(self, mock_binarypop):
         """Test that binary parameters are extracted correctly."""
         mock_binarypop.return_value = {
-            'metallicity': [0.01, 1.0, 2.0],
+            'metallicities': [0.01, 1.0, 2.0],
             'number_of_binaries': 1000,
             'other_param': 'value'
         }

--- a/posydon/unit_tests/CLI/popsyn/test_setup.py
+++ b/posydon/unit_tests/CLI/popsyn/test_setup.py
@@ -124,7 +124,7 @@ class TestSetupPopsynFunction:
     def test_setup_popsyn_function_too_few_binaries(self, mock_binarypop, mock_validate, mock_args):
         """Test that ValueError is raised when number of binaries is too small."""
         mock_binarypop.return_value = {
-            'metallicity': [1.0],
+            'metallicities': [1.0],
             'number_of_binaries': 5  # Less than job_array (10)
         }
 
@@ -146,7 +146,7 @@ class TestSetupPopsynFunction:
         # Setup mocks
         metallicities = [0.01, 1.0]
         mock_binarypop.return_value = {
-            'metallicity': metallicities,
+            'metallicities': metallicities,
             'number_of_binaries': 1000
         }
 
@@ -173,7 +173,7 @@ class TestSetupPopsynFunction:
         """Test that log directories are created for each metallicity."""
         metallicities = [0.1, 1.0]
         mock_binarypop.return_value = {
-            'metallicity': metallicities,
+            'metallicities': metallicities,
             'number_of_binaries': 1000
         }
 
@@ -210,7 +210,7 @@ class TestIntegration:
             'step_SN': (None, {'use_interp_values': False})
         }
         mock_binarypop.return_value = {
-            'metallicity': [1.0],
+            'metallicities': [1.0],
             'number_of_binaries': 100
         }
 


### PR DESCRIPTION
This corrects the popsyn CLI to look for `metallicities` in the .ini file, rather than `metallicity`, in line with the changes brought by [PR#777](https://github.com/POSYDON-code/POSYDON/pull/777).