### PR TITLE
Automate conda version by extracting it from setup.py

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "posydon" %}
-{% set version = "2.2.3" %}
+{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
 
 package:
   name: "{{ name|lower }}"
-  version: "{{ version }}"
+  version: "{{ data.version }}"
 
 source:
   path: ..

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: "{{ name|lower }}"
-  version: "{{ data.version }}"
+  version: "{{ data.get('version') }}"
 
 source:
   path: ..


### PR DESCRIPTION
Extracts the versioneer version using conda's build in function to add it inside `meta.yaml`. 
I wasn't able to test properly, because my local `conda` build fails (also without this change). 

See here for an example: https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#loading-data-from-other-files
