### PR TITLE
[fix] Corrected/enhanced merger process

### DIFF
--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -176,7 +176,7 @@ class MergedStep(IsolatedStep):
                 M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
             else:
                 M2 = getattr(star2, mass_weight2)
-            
+
             try:
             	mass_weighted_avg_value=(A1*M1+A2*M2)/(M1+M2)
             except TypeError:
@@ -193,7 +193,7 @@ class MergedStep(IsolatedStep):
         if ( s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
                 #these stellar attributes change value
-                
+
                 #TODO for key in ["center_h1", "center_he4", "center_c12", "center_n14","center_o16"]:
                 merged_star.center_h1 = mass_weighted_avg()
                 merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4")
@@ -210,7 +210,7 @@ class MergedStep(IsolatedStep):
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16")
 
                 # The change of masses occurs after the calculation of weighted averages
-                merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS) 
+                merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
@@ -234,7 +234,7 @@ class MergedStep(IsolatedStep):
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
 
                 # The change of masses occurs after the calculation of weighted averages
-                merged_star.mass = star_base.mass + comp.mass 
+                merged_star.mass = star_base.mass + comp.mass
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -269,8 +269,7 @@ class MergedStep(IsolatedStep):
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
 
                 merged_star.log_LHe = comp.log_LHe

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -208,7 +208,8 @@ class MergedStep(IsolatedStep):
                 merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14")
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16")
 
-                merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
+                # The change of masses occurs after the calculation of weighted averages
+                merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS) 
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
@@ -224,8 +225,6 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
 
-                merged_star.mass = star_base.mass + comp.mass #TODO: in step_CEE we need to eject part of the (common) envelope
-
                 # weigheted mixing on the surface abundances of the whole comp with the envelope of star_base
                 merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
                 merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
@@ -233,13 +232,15 @@ class MergedStep(IsolatedStep):
                 merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
 
+                # The change of masses occurs after the calculation of weighted averages
+                merged_star.mass = star_base.mass + comp.mass 
+
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
 
                 merged_star.log_LHe = star_base.log_LHe

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -93,12 +93,13 @@ class MergedStep(IsolatedStep):
         if self.verbose:
             print("Before Merger", binary.star_1.state, binary.star_2.state,
                   binary.state, binary.event)
-            print("M1 , M2, he_core_mass1, he_core_mass2: ",
+            print("M1 , M2, he_core_mass1, he_core_mass2, co_core_mass1, co_core_mass2: ",
                   binary.star_1.mass, binary.star_2.mass,
-                  binary.star_1.he_core_mass, binary.star_2.he_core_mass)
-            print("star_1.center_he4, star_2.center_he4, star_1.surface_he4, "
-                  "star_2.surface_he4: ", binary.star_1.center_he4,
-                  binary.star_2.center_he4, binary.star_1.surface_he4,
+                  binary.star_1.he_core_mass, binary.star_2.he_core_mass, binary.star_1.co_core_mass, binary.star_2.co_core_mass)
+            print("star_1.center_h1, star_2.center_h1, star_1.center_he4, star_1.center_c12, star_2.center_c12, "
+                  "star_2.center_he4, star_1.surface_he4, star_2.surface_he4: ",
+                  binary.star_1.center_h1, binary.star_2.center_h1, binary.star_1.center_he4,
+                  binary.star_2.center_he4, binary.star_1.center_c12, binary.star_2.center_c12, binary.star_1.surface_he4,
                   binary.star_2.surface_he4)
 
         if binary.state == "merged":
@@ -126,10 +127,16 @@ class MergedStep(IsolatedStep):
         if self.verbose:
             print("After Merger", binary.star_1.state, binary.star_2.state,
                   binary.state, binary.event)
-            print("M_merged , he_core_mass merged: ", binary.star_1.mass,
-                  binary.star_1.he_core_mass)
-            print("star_1.center_he4, star_1.surface_he4: ",
-                  binary.star_1.center_he4, binary.star_1.surface_he4)
+            if binary.event == 'oMerging1':
+                print("M_merged , he_core_mass merged, co_core_mass merged: ", binary.star_1.mass,
+                  binary.star_1.he_core_mass, binary.star_1.co_core_mass)
+                print("star_1.center_h1, star_1.center_he4, star_1.center_c12, star_1.surface_he4: ",
+                  binary.star_1.center_h1, binary.star_1.center_he4, binary.star_1.center_c12, binary.star_1.surface_he4)
+            elif binary.event=='oMerging2':
+                print("M_merged , he_core_mass merged, co_core_mass merged: ", binary.star_2.mass,
+                  binary.star_2.he_core_mass, binary.star_2.co_core_mass)
+                print("star_2.center_h1, star_2.center_he4, star_2.center_c12, star_2.surface_he4: ",
+                  binary.star_2.center_h1, binary.star_2.center_he4, binary.star_2.center_c12, binary.star_2.surface_he4)
 
         super().__call__(binary)
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -175,13 +175,24 @@ class MergedStep(IsolatedStep):
                 M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
             else:
                 M2 = getattr(star2, mass_weight2)
-            return (A1*M1 + A2*M2 ) / (M1+M2)
+            
+            try:
+            	mass_weighted_avg_value=(A1*M1+A2*M2)/(M1+M2)
+            except TypeError:
+            	mass_weighted_avg_value= np.nan
+
+            if self.verbose:
+                print(abundance_name, mass_weight1, mass_weight2)
+                print("A_base, M_base_abundance, A_comp, M_comp_abundanc", A1, M1, A2, M2)
+                print("mass_weighted_avg= ", mass_weighted_avg_value)
+
+            return mass_weighted_avg_value
 
         # MS + MS
         if ( s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
                 #these stellar attributes change value
-                merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
+                
                 #TODO for key in ["center_h1", "center_he4", "center_c12", "center_n14","center_o16"]:
                 merged_star.center_h1 = mass_weighted_avg()
                 merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4")
@@ -196,6 +207,8 @@ class MergedStep(IsolatedStep):
                 merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12")
                 merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14")
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16")
+
+                merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -253,13 +253,16 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
-                merged_star.mass = star_base.mass + comp.mass
+                merged_star = comp
 
                 merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
                 merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
                 merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
                 merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+
+                # The change of masses occurs after the calculation of weighted averages
+                merged_star.mass = star_base.mass + comp.mass
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
@@ -274,7 +277,7 @@ class MergedStep(IsolatedStep):
                 merged_star.log_LZ = comp.log_LZ
 
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
-                massless_remnant = convert_star_to_massless_remnant(comp)
+                massless_remnant = convert_star_to_massless_remnant(star_base)
 
         #postMS + postMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -402,7 +402,7 @@ class MergedStep(IsolatedStep):
                             setattr(merged_star, key, np.nan)
 
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
-                massless_remnant = convert_star_to_massless_remnant(comp)
+                massless_remnant = convert_star_to_massless_remnant(star_base)
 
         #postMS + HeStar that is not in HeMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -388,7 +388,7 @@ class MergedStep(IsolatedStep):
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
                 # surface abundances from comp
 
-                # add total and core masses after weighted averages
+                # add total and core masses after weighted averages above
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
@@ -408,42 +408,47 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS):
 
-                # add total and core masses
-                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
-
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
                     pass # the central abundances are kept as the ones of star_base
                 elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
                     merged_star.center_h1 = comp.center_h1
                     merged_star.center_he4 = comp.center_he4
                     merged_star.center_c12 = comp.center_c12
+                    merged_star.avg_c_in_c_core = comp.avg_c_in_c_core
                     merged_star.center_n14 = comp.center_n14
                     merged_star.center_o16 = comp.center_o16
+                    merged_star.center_gamma =  comp.center_gamma
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+
+                # add total and core masses
+                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
+                    current = getattr(star_base, key) + getattr(comp, key)
+                    setattr(merged_star, key,current)
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(comp)
@@ -452,25 +457,25 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
-                # add total and core masses
-                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
+                merged_star = comp
+
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
-                    pass # the central abundances are kept as the ones of star_base
+                    merged_star.center_h1 = star_base.center_h1
+                    merged_star.center_he4 = star_base.center_he4
+                    merged_star.center_c12 = star_base.center_c12
+                    merged_star.center_n14 = star_base.center_n14
+                    merged_star.center_o16 = star_base.center_o16
                 elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
-                    merged_star.center_h1 = comp.center_h1
-                    merged_star.center_he4 = comp.center_he4
-                    merged_star.center_c12 = comp.center_c12
-                    merged_star.center_n14 = comp.center_n14
-                    merged_star.center_o16 = comp.center_o16
+                    pass # the central abundances are kept as the ones of comp
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
@@ -480,13 +485,17 @@ class MergedStep(IsolatedStep):
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
 
+                # add total and core masses
+                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
+                    current = getattr(star_base, key) + getattr(comp, key)
+                    setattr(merged_star, key,current)
+
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(comp)

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -157,6 +157,7 @@ class MergedStep(IsolatedStep):
 
         s1 = star_base.state
         s2 = comp.state
+
         def mass_weighted_avg(star1=star_base,star2=comp, abundance_name="center_h1", mass_weight1="mass", mass_weight2=None):
             A1 = getattr(star1, abundance_name)
             A2 = getattr(star2, abundance_name)
@@ -282,32 +283,33 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
-                # add total and core masses
-                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
-
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
                     pass # the central abundances are kept as the ones of star_base
                 elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
                     merged_star.center_h1 = comp.center_h1
                     merged_star.center_he4 = comp.center_he4
                     merged_star.center_c12 = comp.center_c12
+                    merged_star.avg_c_in_c_core = comp.avg_c_in_c_core
                     merged_star.center_n14 = comp.center_n14
                     merged_star.center_o16 = comp.center_o16
+                    merged_star.center_gamma =  comp.center_gamma
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass") #TODO : maybe he_core_mass makes more sense?
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
 
@@ -318,14 +320,17 @@ class MergedStep(IsolatedStep):
                 merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
                 merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
 
+                # add total and core masses after calculations of weighter average
+                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
+                    current = getattr(star_base, key) + getattr(comp, key)
+                    setattr(merged_star, key,current)
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(comp)
@@ -334,30 +339,32 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HeMS):
 
-                # add total and core masses
-                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
-
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has just a He core (is a HeMS star)
                     pass # the central abundances are kept as the ones of star_base
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                # surface abundances from star_base
+
+                # add total and core masses after abundance mass weighted calculations
+                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
+                    current = getattr(star_base, key) + getattr(comp, key)
+                    setattr(merged_star, key,current)
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(comp)
@@ -366,12 +373,9 @@ class MergedStep(IsolatedStep):
         elif (s1 in  LIST_ACCEPTABLE_STATES_FOR_HeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
-                # add total and core masses
-                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
+                merged_star = comp
 
-                # weighted central abundances if merging cores. Else only from star_base
+                # weighted central abundances if merging cores. Else only from comp
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
@@ -382,14 +386,19 @@ class MergedStep(IsolatedStep):
                     pass # the central abundances are kept as the ones of star_base
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                # surface abundances from comp
+
+                # add total and core masses after weighted averages
+                for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
+                    current = getattr(star_base, key) + getattr(comp, key)
+                    setattr(merged_star, key,current)
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
                     for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
                         if (substring in key) :
                             setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
+                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
 
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -125,8 +125,12 @@ class MergedStep(IsolatedStep):
         binary.event = None
 
         if self.verbose:
-            print("After Merger", binary.star_1.state, binary.star_2.state,
-                  binary.state, binary.event)
+            print("After Merger:\n"
+                  f"_____________\n"
+                  f"star_1.state = {binary.star_1.state}\n"
+                  f"star_2.state = {binary.star_2.state}\n"
+                  f"binary.state = {binary.state}\n"
+                  f"binary.event = {binary.event}\n")
             if binary.event == 'oMerging1':
                 print(f"M_merged = {binary.star_1.mass}\n"
                       f"he_core_mass merged = {binary.star_1.he_core_mass}\n"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -92,7 +92,7 @@ class MergedStep(IsolatedStep):
 
         if self.verbose:
             print("Before Merger:\n"
-                  f"_____________\n"
+                  f"_____________\n")
             print(f"M1 = {binary.star_1.mass}\n"
                   f"M2 = {binary.star_2.mass}\n"
                   f"he_core_mass1 = {binary.star_1.he_core_mass}\n"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -159,8 +159,9 @@ class MergedStep(IsolatedStep):
         mass_weight2 : str or None
             Mass attribute for star2.
         """
-        A1 = getattr(star1, abundance_name)
-        A2 = getattr(star2, abundance_name)
+        # give NaN if the abundance is not defined for one of the stars
+        A1 = getattr(star1, abundance_name, np.nan)
+        A2 = getattr(star2, abundance_name, np.nan)
 
         if mass_weight1 == "mass":
             M1 = getattr(star1, "mass")

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -162,6 +162,10 @@ class MergedStep(IsolatedStep):
         # give NaN if the abundance is not defined for one of the stars
         A1 = getattr(star1, abundance_name, np.nan)
         A2 = getattr(star2, abundance_name, np.nan)
+        if A1 is None:
+            A1 = np.nan
+        if A2 is None:
+            A2 = np.nan
 
         if mass_weight1 == "mass":
             M1 = getattr(star1, "mass", np.nan)
@@ -172,6 +176,9 @@ class MergedStep(IsolatedStep):
         else:
             M1 = getattr(star1, mass_weight1, np.nan)
 
+        if M1 is None:
+            M1 = np.nan
+
         if mass_weight2 == "mass":
             M2 = getattr(star2, "mass", np.nan)
         elif mass_weight2 == "H-rich_envelope_mass":
@@ -180,6 +187,9 @@ class MergedStep(IsolatedStep):
             M2 = getattr(star2, "he_core_mass", np.nan) - getattr(star2, "co_core_mass", np.nan)
         else:
             M2 = getattr(star2, mass_weight2, np.nan)
+
+        if M2 is None:
+            M2 = np.nan
 
         den = M1 + M2
         if not (np.isfinite(A1) and np.isfinite(A2) and np.isfinite(M1) and np.isfinite(M2)):

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -129,7 +129,7 @@ class MergedStep(IsolatedStep):
         else:
             raise ValueError("step_merged initiated but binary is not in valid merging state!")
 
-        binary.event = None
+        #binary.event = None
 
         if self.verbose:
             print("After Merger:\n"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -164,22 +164,22 @@ class MergedStep(IsolatedStep):
         A2 = getattr(star2, abundance_name, np.nan)
 
         if mass_weight1 == "mass":
-            M1 = getattr(star1, "mass")
+            M1 = getattr(star1, "mass", np.nan)
         elif mass_weight1 == "H-rich_envelope_mass":
-            M1 = getattr(star1, "mass") - getattr(star1, "he_core_mass")
+            M1 = getattr(star1, "mass", np.nan) - getattr(star1, "he_core_mass", np.nan)
         elif mass_weight1 == "He-rich_envelope_mass":
-            M1 = getattr(star1, "he_core_mass") - getattr(star1, "co_core_mass")
+            M1 = getattr(star1, "he_core_mass", np.nan) - getattr(star1, "co_core_mass", np.nan)
         else:
-            M1 = getattr(star1, mass_weight1)
+            M1 = getattr(star1, mass_weight1, np.nan)
 
         if mass_weight2 == "mass":
-            M2 = getattr(star2, "mass")
+            M2 = getattr(star2, "mass", np.nan)
         elif mass_weight2 == "H-rich_envelope_mass":
-            M2 = getattr(star2, "mass") - getattr(star2, "he_core_mass")
+            M2 = getattr(star2, "mass", np.nan) - getattr(star2, "he_core_mass", np.nan)
         elif mass_weight2 == "He-rich_envelope_mass":
-            M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
+            M2 = getattr(star2, "he_core_mass", np.nan) - getattr(star2, "co_core_mass", np.nan)
         else:
-            M2 = getattr(star2, mass_weight2)
+            M2 = getattr(star2, mass_weight2, np.nan)
 
         den = M1 + M2
         if not (np.isfinite(A1) and np.isfinite(A2) and np.isfinite(M1) and np.isfinite(M2)):

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -91,8 +91,12 @@ class MergedStep(IsolatedStep):
         merged_star_properties = self.merged_star_properties
 
         if self.verbose:
-            print("Before Merger", binary.star_1.state, binary.star_2.state,
-                  binary.state, binary.event)
+            print("Before Merger:\n"
+                  f"_____________\n"
+                  f"star_1.state = {binary.star_1.state}\n"
+                  f"star_2.state = {binary.star_2.state}\n"
+                  f"binary.state = {binary.state}\n"
+                  f"binary.event = {binary.event}\n")
             print("M1 , M2, he_core_mass1, he_core_mass2, co_core_mass1, co_core_mass2: ",
                   binary.star_1.mass, binary.star_2.mass,
                   binary.star_1.he_core_mass, binary.star_2.he_core_mass, binary.star_1.co_core_mass, binary.star_2.co_core_mass)

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -217,9 +217,14 @@ class MergedStep(IsolatedStep):
             mass_weighted_avg_value = (A1 * M1 + A2 * M2) / den
 
         if self.verbose:
-            print(abundance_name, mass_weight1, mass_weight2)
-            print("A_base, M_base_abundance, A_comp, M_comp_abundance", A1, M1, A2, M2)
-            print("mass_weighted_avg= ", mass_weighted_avg_value)
+            print(f"Mass weighted average for {abundance_name}:\n"
+                  f"weight 1: {mass_weight1}\n"
+                  f"weight 2: {mass_weight2}\n"
+                  f"A_base = {A1}\n"
+                  f"M_base_abundance = {M1}\n"
+                  f"A_comp = {A2}\n"
+                  f"M_comp_abundance = {M2}\n"
+                  f"mass_weighted_avg = {mass_weighted_avg_value}\n")
 
         return mass_weighted_avg_value
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -195,7 +195,7 @@ class MergedStep(IsolatedStep):
 
         return mass_weighted_avg_value
 
-    def _apply_nan_attributes(self, star, extra_nan_keys=set()):
+    def _apply_nan_attributes(self, star, extra_nan_keys=None):
         """Set to np.nan the attributes of the star that are not expected to be meaningful after a merger event.
 
         Parameters set to np.nan are:
@@ -211,6 +211,9 @@ class MergedStep(IsolatedStep):
         extra_nan_keys: set of str
             Set of keys to be set to np.nan in addition to the default ones.
         """
+        if extra_nan_keys is None:
+            extra_nan_keys = set()
+
         _NAN_SUBSTRINGS = ("log_", "lg_", "surf_", "conv_", "lambda", "profile")
         _NAN_KEYS = set(["c12_c12", "total_moment_of_inertia", "spin"])
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -128,10 +128,13 @@ class MergedStep(IsolatedStep):
             print("After Merger", binary.star_1.state, binary.star_2.state,
                   binary.state, binary.event)
             if binary.event == 'oMerging1':
-                print("M_merged , he_core_mass merged, co_core_mass merged: ", binary.star_1.mass,
-                  binary.star_1.he_core_mass, binary.star_1.co_core_mass)
-                print("star_1.center_h1, star_1.center_he4, star_1.center_c12, star_1.surface_he4: ",
-                  binary.star_1.center_h1, binary.star_1.center_he4, binary.star_1.center_c12, binary.star_1.surface_he4)
+                print(f"M_merged = {binary.star_1.mass}\n"
+                      f"he_core_mass merged = {binary.star_1.he_core_mass}\n"
+                      f"co_core_mass merged = {binary.star_1.co_core_mass}\n")
+                print(f"star_1.center_h1 = {binary.star_1.center_h1}\n"
+                      f"star_1.center_he4 = {binary.star_1.center_he4}\n"
+                      f"star_1.center_c12 = {binary.star_1.center_c12}\n"
+                      f"star_1.surface_he4 = {binary.star_1.surface_he4}\n")
             elif binary.event=='oMerging2':
                 print(f"M_merged = {binary.star_2.mass}\n"
                       f"he_core_mass merged = {binary.star_2.he_core_mass}\n"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -133,10 +133,13 @@ class MergedStep(IsolatedStep):
                 print("star_1.center_h1, star_1.center_he4, star_1.center_c12, star_1.surface_he4: ",
                   binary.star_1.center_h1, binary.star_1.center_he4, binary.star_1.center_c12, binary.star_1.surface_he4)
             elif binary.event=='oMerging2':
-                print("M_merged , he_core_mass merged, co_core_mass merged: ", binary.star_2.mass,
-                  binary.star_2.he_core_mass, binary.star_2.co_core_mass)
-                print("star_2.center_h1, star_2.center_he4, star_2.center_c12, star_2.surface_he4: ",
-                  binary.star_2.center_h1, binary.star_2.center_he4, binary.star_2.center_c12, binary.star_2.surface_he4)
+                print(f"M_merged = {binary.star_2.mass}\n"
+                      f"he_core_mass merged = {binary.star_2.he_core_mass}\n"
+                      f"co_core_mass merged = {binary.star_2.co_core_mass}\n")
+                print(f"star_2.center_h1 = {binary.star_2.center_h1}\n"
+                      f"star_2.center_he4 = {binary.star_2.center_he4}\n"
+                      f"star_2.center_c12 = {binary.star_2.center_c12}\n"
+                      f"star_2.surface_he4 = {binary.star_2.surface_he4}\n")
 
         super().__call__(binary)
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -250,7 +250,11 @@ class MergedStep(IsolatedStep):
 
                 for abundance_name in parameters_to_mix:
                     #TODO: should I check if the abundaces above end up in ~1 (?)
-                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="mass", mass_weight2='mass'))
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                comp,
+                                                                                abundance_name=abundance_name,
+                                                                                mass_weight1="mass",
+                                                                                mass_weight2='mass'))
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
@@ -272,7 +276,11 @@ class MergedStep(IsolatedStep):
                 # companion with the envelope of star_base
                 parameters_to_mix = ["surface_h1", "surface_he4", "surface_c12", "surface_n14", "surface_o16"]
                 for abundance_name in parameters_to_mix:
-                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="H-rich_envelope_mass", mass_weight2="mass"))
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                comp,
+                                                                                abundance_name=abundance_name,
+                                                                                mass_weight1="H-rich_envelope_mass",
+                                                                                mass_weight2="mass"))
 
                 # The change of masses occurs after the calculation of weighted averages
                 # Note that the he core mass is unchanged, which means that
@@ -297,7 +305,11 @@ class MergedStep(IsolatedStep):
 
                 parameters_to_mix = ["surface_h1", "surface_he4", "surface_c12", "surface_n14", "surface_o16"]
                 for abundance_name in parameters_to_mix:
-                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight2="H-rich_envelope_mass", mass_weight1="mass"))
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                comp,
+                                                                                abundance_name=abundance_name,
+                                                                                mass_weight1="mass",
+                                                                                mass_weight2="H-rich_envelope_mass",))
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = star_base.mass + comp.mass
@@ -326,7 +338,11 @@ class MergedStep(IsolatedStep):
                     mass_weight2 = 'he_core_mass'
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1=mass_weight1, mass_weight2=mass_weight2))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                    comp,
+                                                                                    abundance_name = abundance_name,
+                                                                                    mass_weight1 = mass_weight1,
+                                                                                    mass_weight2 = mass_weight2))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -350,7 +366,11 @@ class MergedStep(IsolatedStep):
                     mass_weight2='co_core_mass'
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1=mass_weight1, mass_weight2=mass_weight2))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                    comp,
+                                                                                    abundance_name=abundance_name,
+                                                                                    mass_weight1=mass_weight1,
+                                                                                    mass_weight2=mass_weight2))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -361,7 +381,11 @@ class MergedStep(IsolatedStep):
 
                 # Weighted mixing on the surface abundances based on the envelopes of the two stars
                 for abundance_name in additional_parameter_to_mix:
-                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass"))
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                comp,
+                                                                                abundance_name=abundance_name,
+                                                                                mass_weight1="H-rich_envelope_mass",
+                                                                                mass_weight2="H-rich_envelope_mass"))
 
                 # Add total and core masses after calculations of weighted average
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
@@ -387,7 +411,11 @@ class MergedStep(IsolatedStep):
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                    comp,
+                                                                                    abundance_name=abundance_name,
+                                                                                    mass_weight1="he_core_mass",
+                                                                                    mass_weight2="he_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -402,7 +430,7 @@ class MergedStep(IsolatedStep):
                 # add total and core masses after abundance mass weighted calculations
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
+                    setattr(merged_star, key, current)
 
                 # Set parameters that are not expected to be meaningful after a merger to np.nan
                 self._apply_nan_attributes(merged_star)
@@ -422,7 +450,11 @@ class MergedStep(IsolatedStep):
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                    comp,
+                                                                                    abundance_name=abundance_name,
+                                                                                    mass_weight1="he_core_mass",
+                                                                                    mass_weight2="he_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -436,7 +468,7 @@ class MergedStep(IsolatedStep):
                 # add total and core masses after weighted averages above
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
+                    setattr(merged_star, key, current)
 
                 # Set parameters that are not expected to be meaningful after a merger to np.nan
                 self._apply_nan_attributes(merged_star)
@@ -457,7 +489,11 @@ class MergedStep(IsolatedStep):
 
                     for abundance_name in parameters_to_mix:
                         setattr(merged_star, abundance_name,
-                                self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass"))
+                                self.mass_weighted_avg(star_base,
+                                                       comp,
+                                                       abundance_name=abundance_name,
+                                                       mass_weight1="he_core_mass",
+                                                       mass_weight2="he_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -479,7 +515,11 @@ class MergedStep(IsolatedStep):
 
                     for abundance_name in parameters_to_mix:
                         setattr(merged_star, abundance_name,
-                                self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass"))
+                                self.mass_weighted_avg(star_base,
+                                                       comp,
+                                                       abundance_name=abundance_name,
+                                                       mass_weight1="co_core_mass",
+                                                       mass_weight2="co_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -489,7 +529,7 @@ class MergedStep(IsolatedStep):
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
-                    setattr(merged_star, key,current)
+                    setattr(merged_star, key, current)
 
                 # Set parameters that are not expected to be meaningful after a merger to np.nan
                 self._apply_nan_attributes(merged_star)
@@ -511,7 +551,11 @@ class MergedStep(IsolatedStep):
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                    comp,
+                                                                                    abundance_name=abundance_name,
+                                                                                    mass_weight1="he_core_mass",
+                                                                                    mass_weight2="he_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -561,7 +605,11 @@ class MergedStep(IsolatedStep):
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                     comp,
+                                                                                     abundance_name=abundance_name,
+                                                                                     mass_weight1="he_core_mass",
+                                                                                     mass_weight2="he_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -582,7 +630,11 @@ class MergedStep(IsolatedStep):
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass", mass_weight2="co_core_mass"))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                    comp,
+                                                                                    abundance_name=abundance_name,
+                                                                                    mass_weight1="co_core_mass",
+                                                                                    mass_weight2="co_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 
@@ -597,7 +649,11 @@ class MergedStep(IsolatedStep):
                 # weigheted mixing on the surface abundances based on the He-rich envelopes of the two stars
                 additional_parameter_to_mix = ['surface_h1', 'surface_he4', 'surface_c12', 'surface_n14', 'surface_o16']
                 for abundance_name in additional_parameter_to_mix:
-                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass"))
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                comp,
+                                                                                abundance_name=abundance_name,
+                                                                                mass_weight1="He-rich_envelope_mass",
+                                                                                mass_weight2="He-rich_envelope_mass"))
 
                 # Set parameters that are not expected to be meaningful after a merger to np.nan
                 self._apply_nan_attributes(merged_star)
@@ -628,7 +684,11 @@ class MergedStep(IsolatedStep):
                 elif (comp.co_core_mass is not None and star_base.co_core_mass > 0):
 
                     for abundance_name in parameters_to_mix:
-                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass", mass_weight2="co_core_mass"))
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base,
+                                                                                     comp,
+                                                                                     abundance_name=abundance_name,
+                                                                                     mass_weight1="co_core_mass",
+                                                                                     mass_weight2="co_core_mass"))
 
                     setattr(merged_star, "center_gamma", np.nan)
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -96,11 +96,15 @@ class MergedStep(IsolatedStep):
             print("M1 , M2, he_core_mass1, he_core_mass2, co_core_mass1, co_core_mass2: ",
                   binary.star_1.mass, binary.star_2.mass,
                   binary.star_1.he_core_mass, binary.star_2.he_core_mass, binary.star_1.co_core_mass, binary.star_2.co_core_mass)
-            print("star_1.center_h1, star_2.center_h1, star_1.center_he4, star_1.center_c12, star_2.center_c12, "
-                  "star_2.center_he4, star_1.surface_he4, star_2.surface_he4: ",
-                  binary.star_1.center_h1, binary.star_2.center_h1, binary.star_1.center_he4,
-                  binary.star_2.center_he4, binary.star_1.center_c12, binary.star_2.center_c12, binary.star_1.surface_he4,
-                  binary.star_2.surface_he4)
+            print(f"star_1.center_h1 = {binary.star_1.center_h1}\n"
+                  f"star_2.center_h1 = {binary.star_2.center_h1}\n"
+                  f"star_1.center_he4 = {binary.star_1.center_he4}\n"
+                  f"star_2.center_he4 = {binary.star_2.center_he4}\n"
+                  f"star_1.center_c12 = {binary.star_1.center_c12}\n"
+                  f"star_2.center_c12 = {binary.star_2.center_c12}\n"
+                  f"star_1.surface_he4 = {binary.star_1.surface_he4}\n"
+                  f"star_2.surface_he4 = {binary.star_2.surface_he4}\n"
+                  f"_____________\n")
 
         if binary.state == "merged":
             if binary.event == 'oMerging1':

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -93,13 +93,12 @@ class MergedStep(IsolatedStep):
         if self.verbose:
             print("Before Merger:\n"
                   f"_____________\n"
-                  f"star_1.state = {binary.star_1.state}\n"
-                  f"star_2.state = {binary.star_2.state}\n"
-                  f"binary.state = {binary.state}\n"
-                  f"binary.event = {binary.event}\n")
-            print("M1 , M2, he_core_mass1, he_core_mass2, co_core_mass1, co_core_mass2: ",
-                  binary.star_1.mass, binary.star_2.mass,
-                  binary.star_1.he_core_mass, binary.star_2.he_core_mass, binary.star_1.co_core_mass, binary.star_2.co_core_mass)
+            print(f"M1 = {binary.star_1.mass}\n"
+                  f"M2 = {binary.star_2.mass}\n"
+                  f"he_core_mass1 = {binary.star_1.he_core_mass}\n"
+                  f"he_core_mass2 = {binary.star_2.he_core_mass}\n"
+                  f"co_core_mass1 = {binary.star_1.co_core_mass}\n"
+                  f"co_core_mass2 = {binary.star_2.co_core_mass}\n")
             print(f"star_1.center_h1 = {binary.star_1.center_h1}\n"
                   f"star_2.center_h1 = {binary.star_2.center_h1}\n"
                   f"star_1.center_he4 = {binary.star_1.center_he4}\n"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -176,14 +176,17 @@ class MergedStep(IsolatedStep):
             else:
                 M2 = getattr(star2, mass_weight2)
 
-            try:
-            	mass_weighted_avg_value=(A1*M1+A2*M2)/(M1+M2)
-            except (TypeError, ZeroDivisionError):
-            	mass_weighted_avg_value= np.nan
+            den = M1 + M2
+            if not (np.isfinite(A1) and np.isfinite(A2) and np.isfinite(M1) and np.isfinite(M2)):
+                mass_weighted_avg_value = np.nan
+            elif den == 0:
+                mass_weighted_avg_value = np.nan
+            else:
+                mass_weighted_avg_value = (A1 * M1 + A2 * M2) / den
 
             if self.verbose:
                 print(abundance_name, mass_weight1, mass_weight2)
-                print("A_base, M_base_abundance, A_comp, M_comp_abundanc", A1, M1, A2, M2)
+                print("A_base, M_base_abundance, A_comp, M_comp_abundance", A1, M1, A2, M2)
                 print("mass_weighted_avg= ", mass_weighted_avg_value)
 
             return mass_weighted_avg_value
@@ -378,8 +381,10 @@ class MergedStep(IsolatedStep):
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
                     merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
                     merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
                     merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass == 0 and comp.co_core_mass > 0): # star_base is the HeMS Star and comp has a CO core
                     pass # the central abundances are kept as the ones of comp
                 else:
@@ -579,7 +584,7 @@ class MergedStep(IsolatedStep):
                     merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -140,6 +140,59 @@ class MergedStep(IsolatedStep):
 
         super().__call__(binary)
 
+    def mass_weighted_avg(self, star1, star2, abundance_name, mass_weight1="mass", mass_weight2=None):
+        """Compute the mass-weighted average of an abundance between two stars.
+
+        Parameters
+        ----------
+        star1 : SingleStar
+            The first star (base/engulfing star).
+        star2 : SingleStar
+            The second star (companion/engulfed star).
+        abundance_name : str
+            Name of the stellar attribute to average.
+        mass_weight1 : str
+            Mass attribute to use as weight for star1.  Special values
+            ``"H-rich_envelope_mass"`` and ``"He-rich_envelope_mass"`` are
+            computed on the fly; any other value is looked up directly on the
+            star object.
+        mass_weight2 : str or None
+            Mass attribute for star2.  Defaults to ``mass_weight1`` when
+            ``None``.
+        """
+        A1 = getattr(star1, abundance_name)
+        A2 = getattr(star2, abundance_name)
+        if mass_weight1 == "H-rich_envelope_mass":
+            M1 = getattr(star1, "mass") - getattr(star1, "he_core_mass")
+        elif mass_weight1 == "He-rich_envelope_mass":
+            M1 = getattr(star1, "he_core_mass") - getattr(star1, "co_core_mass")
+        else:
+            M1 = getattr(star1, mass_weight1)
+
+        if mass_weight2 is None:
+            mass_weight2 = mass_weight1
+        if mass_weight2 == "H-rich_envelope_mass":
+            M2 = getattr(star2, "mass") - getattr(star2, "he_core_mass")
+        elif mass_weight2 == "He-rich_envelope_mass":
+            M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
+        else:
+            M2 = getattr(star2, mass_weight2)
+
+        den = M1 + M2
+        if not (np.isfinite(A1) and np.isfinite(A2) and np.isfinite(M1) and np.isfinite(M2)):
+            mass_weighted_avg_value = np.nan
+        elif den == 0:
+            mass_weighted_avg_value = np.nan
+        else:
+            mass_weighted_avg_value = (A1 * M1 + A2 * M2) / den
+
+        if self.verbose:
+            print(abundance_name, mass_weight1, mass_weight2)
+            print("A_base, M_base_abundance, A_comp, M_comp_abundance", A1, M1, A2, M2)
+            print("mass_weighted_avg= ", mass_weighted_avg_value)
+
+        return mass_weighted_avg_value
+
     def merged_star_properties(self, star_base, comp):
         """
         Make assumptions about the core/total mass, and abundances of the star of a merged product.
@@ -151,64 +204,30 @@ class MergedStep(IsolatedStep):
         comp: Single Star
             is the star that is engulfed
         """
-        #by default the stellar attributes that keep the same value from the
+        #by default the stellar attributes that keep the same values from the base
         merged_star = star_base
 
         s1 = star_base.state
         s2 = comp.state
-
-        def mass_weighted_avg(star1=star_base,star2=comp, abundance_name="center_h1", mass_weight1="mass", mass_weight2=None):
-            A1 = getattr(star1, abundance_name)
-            A2 = getattr(star2, abundance_name)
-            if mass_weight1 == "H-rich_envelope_mass":
-                M1 = getattr(star1, "mass") - getattr(star1, "he_core_mass")
-            elif mass_weight1 == "He-rich_envelope_mass":
-                M1 = getattr(star1, "he_core_mass") - getattr(star1, "co_core_mass")
-            else:
-                M1 = getattr(star1, mass_weight1)
-
-            if mass_weight2 is None:
-                mass_weight2 = mass_weight1
-            if mass_weight2 == "H-rich_envelope_mass":
-                M2 = getattr(star2, "mass") - getattr(star2, "he_core_mass")
-            elif mass_weight2 == "He-rich_envelope_mass":
-                M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
-            else:
-                M2 = getattr(star2, mass_weight2)
-
-            den = M1 + M2
-            if not (np.isfinite(A1) and np.isfinite(A2) and np.isfinite(M1) and np.isfinite(M2)):
-                mass_weighted_avg_value = np.nan
-            elif den == 0:
-                mass_weighted_avg_value = np.nan
-            else:
-                mass_weighted_avg_value = (A1 * M1 + A2 * M2) / den
-
-            if self.verbose:
-                print(abundance_name, mass_weight1, mass_weight2)
-                print("A_base, M_base_abundance, A_comp, M_comp_abundance", A1, M1, A2, M2)
-                print("mass_weighted_avg= ", mass_weighted_avg_value)
-
-            return mass_weighted_avg_value
 
         # MS + MS
         if ( s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
                 #these stellar attributes change value
 
-                merged_star.center_h1 = mass_weighted_avg()
-                merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4")
-                merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12")
-                merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14")
-                merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16")
+                merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1")
+                merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4")
+                merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12")
+                merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14")
+                merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16")
                 #TODO: should I check if the abundaces above end up in ~1 (?)
 
                 # weigheted mixing on the surface abundances
-                merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1")
-                merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4")
-                merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12")
-                merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14")
-                merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16")
+                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1")
+                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4")
+                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12")
+                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14")
+                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16")
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
@@ -223,16 +242,17 @@ class MergedStep(IsolatedStep):
                             setattr(merged_star, key, np.nan)
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
-        #postMS + MS
+        # postMS + MS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
 
-                # weigheted mixing on the surface abundances of the whole comp with the envelope of star_base
-                merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
+                # weighted mixing on the surface abundances of the whole
+                # companion with the envelope of star_base
+                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
+                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
+                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
+                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
+                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = star_base.mass + comp.mass
@@ -251,17 +271,17 @@ class MergedStep(IsolatedStep):
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
-        # as above but opposite stars
+        # MS + postMS (the opposite of above)
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
                 merged_star = comp
 
-                merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = star_base.mass + comp.mass
@@ -286,12 +306,12 @@ class MergedStep(IsolatedStep):
 
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
                     pass # the central abundances are kept as the ones of star_base
@@ -304,22 +324,22 @@ class MergedStep(IsolatedStep):
                     merged_star.center_o16 = comp.center_o16
                     merged_star.center_gamma =  comp.center_gamma
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass") #TODO : maybe he_core_mass makes more sense?
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass") #TODO : maybe he_core_mass makes more sense?
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
 
                 # weigheted mixing on the surface abundances based on the envelopes of the two stars
-                merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
+                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
+                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
+                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
+                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
+                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
 
                 # add total and core masses after calculations of weighter average
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
@@ -342,12 +362,12 @@ class MergedStep(IsolatedStep):
 
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has just a He core (is a HeMS star)
                     pass # the central abundances are kept as the ones of star_base
@@ -378,12 +398,12 @@ class MergedStep(IsolatedStep):
 
                 # weighted central abundances if merging cores. Else only from comp
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass == 0 and comp.co_core_mass > 0): # star_base is the HeMS Star and comp has a CO core
                     pass # the central abundances are kept as the ones of comp
@@ -413,12 +433,12 @@ class MergedStep(IsolatedStep):
 
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
                     pass # the central abundances are kept as the ones of star_base
@@ -431,12 +451,12 @@ class MergedStep(IsolatedStep):
                     merged_star.center_o16 = comp.center_o16
                     merged_star.center_gamma =  comp.center_gamma
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
@@ -464,12 +484,12 @@ class MergedStep(IsolatedStep):
 
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
                     merged_star.center_h1 = star_base.center_h1
@@ -480,11 +500,11 @@ class MergedStep(IsolatedStep):
                 elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
                     pass # the central abundances are kept as the ones of comp
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
 
@@ -509,12 +529,12 @@ class MergedStep(IsolatedStep):
 
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="he_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
                     pass # the central abundances are kept as the ones of star_base
@@ -527,12 +547,12 @@ class MergedStep(IsolatedStep):
                     merged_star.center_o16 = comp.center_o16
                     merged_star.center_gamma =  comp.center_gamma
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 else:
                     Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
@@ -543,11 +563,11 @@ class MergedStep(IsolatedStep):
                     setattr(merged_star, key,current)
 
                 # weigheted mixing on the surface abundances based on the He-rich envelopes of the two stars
-                merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_he4 = mass_weighted_avg(abundance_name = "surface_he4", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_c12 = mass_weighted_avg(abundance_name = "surface_c12", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_n14 = mass_weighted_avg(abundance_name = "surface_n14", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_o16 = mass_weighted_avg(abundance_name = "surface_o16", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
+                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
+                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
+                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
+                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
+                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
 
                 for key in STARPROPERTIES:
                     # these stellar attributes become np.nan
@@ -576,12 +596,12 @@ class MergedStep(IsolatedStep):
                     merged_star.center_o16 = comp.center_o16
                     merged_star.center_gamma =  comp.center_gamma
                 elif (comp.co_core_mass is not None and star_base.co_core_mass > 0):
-                    merged_star.center_h1 = mass_weighted_avg(mass_weight1="co_core_mass")
-                    merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = mass_weighted_avg(abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = mass_weighted_avg(abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = mass_weighted_avg(abundance_name = "center_o16", mass_weight1="co_core_mass")
+                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
+                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
+                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
+                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
+                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
+                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
                     setattr(merged_star, "center_gamma", np.nan)
                 else:
                     Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -152,7 +152,6 @@ class MergedStep(IsolatedStep):
             is the star that is engulfed
         """
         #by default the stellar attributes that keep the same value from the
-        #merged_star = copy.copy(star_base)
         merged_star = star_base
 
         s1 = star_base.state

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -445,7 +445,7 @@ class MergedStep(IsolatedStep):
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(star_base)
 
-        #postMS + PostHeMS
+        # postMS + postHeMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS):
 
@@ -498,7 +498,7 @@ class MergedStep(IsolatedStep):
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
-        # PostHeMS + postMS (the opposite of above)
+        # postHeMS + postMS (the opposite of above)
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
@@ -551,7 +551,7 @@ class MergedStep(IsolatedStep):
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(star_base)
 
-        # HeStar + HeStar
+        # He star + He star
         elif (s1 in STAR_STATES_HE_RICH
             and s2 in STAR_STATES_HE_RICH):
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -193,7 +193,6 @@ class MergedStep(IsolatedStep):
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
                 #these stellar attributes change value
 
-                #TODO for key in ["center_h1", "center_he4", "center_c12", "center_n14","center_o16"]:
                 merged_star.center_h1 = mass_weighted_avg()
                 merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4")
                 merged_star.center_c12 = mass_weighted_avg(abundance_name = "center_c12")

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -178,7 +178,7 @@ class MergedStep(IsolatedStep):
 
             try:
             	mass_weighted_avg_value=(A1*M1+A2*M2)/(M1+M2)
-            except TypeError:
+            except (TypeError, ZeroDivisionError):
             	mass_weighted_avg_value= np.nan
 
             if self.verbose:

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -140,38 +140,40 @@ class MergedStep(IsolatedStep):
 
         super().__call__(binary)
 
-    def mass_weighted_avg(self, star1, star2, abundance_name, mass_weight1="mass", mass_weight2=None):
+    def mass_weighted_avg(self, star1, star2, abundance_name, mass_weight1="mass", mass_weight2='mass'):
         """Compute the mass-weighted average of an abundance between two stars.
 
         Parameters
         ----------
         star1 : SingleStar
-            The first star (base/engulfing star).
+            Primary star
         star2 : SingleStar
-            The second star (companion/engulfed star).
+            Companion star
         abundance_name : str
-            Name of the stellar attribute to average.
+            Name of the SingleStar attribute to average.
         mass_weight1 : str
             Mass attribute to use as weight for star1.  Special values
             ``"H-rich_envelope_mass"`` and ``"He-rich_envelope_mass"`` are
             computed on the fly; any other value is looked up directly on the
             star object.
         mass_weight2 : str or None
-            Mass attribute for star2.  Defaults to ``mass_weight1`` when
-            ``None``.
+            Mass attribute for star2.
         """
         A1 = getattr(star1, abundance_name)
         A2 = getattr(star2, abundance_name)
-        if mass_weight1 == "H-rich_envelope_mass":
+
+        if mass_weight1 == "mass":
+            M1 = getattr(star1, "mass")
+        elif mass_weight1 == "H-rich_envelope_mass":
             M1 = getattr(star1, "mass") - getattr(star1, "he_core_mass")
         elif mass_weight1 == "He-rich_envelope_mass":
             M1 = getattr(star1, "he_core_mass") - getattr(star1, "co_core_mass")
         else:
             M1 = getattr(star1, mass_weight1)
 
-        if mass_weight2 is None:
-            mass_weight2 = mass_weight1
-        if mass_weight2 == "H-rich_envelope_mass":
+        if mass_weight2 == "mass":
+            M2 = getattr(star2, "mass")
+        elif mass_weight2 == "H-rich_envelope_mass":
             M2 = getattr(star2, "mass") - getattr(star2, "he_core_mass")
         elif mass_weight2 == "He-rich_envelope_mass":
             M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
@@ -193,18 +195,46 @@ class MergedStep(IsolatedStep):
 
         return mass_weighted_avg_value
 
-    def merged_star_properties(self, star_base, comp):
-        """
-        Make assumptions about the core/total mass, and abundances of the star of a merged product.
+    def _apply_nan_attributes(self, star, extra_nan_keys=set()):
+        """Set to np.nan the attributes of the star that are not expected to be meaningful after a merger event.
 
-        Similar to the table of merging in BSE
+        Parameters set to np.nan are:
+        - all attributes containing the substrings
+            {"log_", "lg_", "surf_", "conv_", "lambda", "profile"}
+        - all attributes in the set:
+            {"c12_c12", "total_moment_of_inertia", "spin",}
+
+        Parameters
+        ----------
+        star: SingleStar
+            The star for which the attributes will be set to np.nan
+        extra_nan_keys: set of str
+            Set of keys to be set to np.nan in addition to the default ones.
+        """
+        _NAN_SUBSTRINGS = ("log_", "lg_", "surf_", "conv_", "lambda", "profile")
+        _NAN_KEYS = set(["c12_c12", "total_moment_of_inertia", "spin"])
+
+        for key in STARPROPERTIES:
+            if any(sub in key for sub in _NAN_SUBSTRINGS) or (key in extra_nan_keys) or (key in _NAN_KEYS):
+                setattr(star, key, np.nan)
+
+    def merged_star_properties(self, star_base, comp):
+        """Set the properties of the merged star after a merger event.
+
+        Generally, the Roche lobe overflowing star becomes star_base, except
+        when the companion is further evolved than star_base, in which
+        case the comp becomes the base for the merged star.
+
+        Abundances are mass-weighted averages of the two stars, with the
+        weights depending on the type of merger and the abundance considered.
 
         star_base: Single Star
-            is our base star that engulfs its companion. The merged star will have this star as a base
+            The star that engulfs its companion.
+            (generally the base for the merged_star)
         comp: Single Star
-            is the star that is engulfed
+            The star that is engulfed by star_base.
         """
-        #by default the stellar attributes that keep the same values from the base
+        # By default the stellar attributes are kept from star_base.
         merged_star = star_base
 
         s1 = star_base.state
@@ -213,33 +243,25 @@ class MergedStep(IsolatedStep):
         # MS + MS
         if ( s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
-                #these stellar attributes change value
+                # Mix central and surface abundances of the two stars with
+                # mass-weighted averages based on the total masses of the two stars.
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16",
+                                    "surface_h1", "surface_he4", "surface_c12", "surface_n14", "surface_o16"]
 
-                merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1")
-                merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4")
-                merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12")
-                merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14")
-                merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16")
-                #TODO: should I check if the abundaces above end up in ~1 (?)
-
-                # weigheted mixing on the surface abundances
-                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1")
-                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4")
-                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12")
-                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14")
-                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16")
+                for abundance_name in parameters_to_mix:
+                    #TODO: should I check if the abundaces above end up in ~1 (?)
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="mass", mass_weight2='mass'))
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "center_gamma",
-                                   "avg_c_in_c_core", "total_moment_of_inertia", "spin", "envelope_binding_energy"]:
-                            setattr(merged_star, key, np.nan)
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star,
+                                           extra_nan_keys=set(["center_gamma",
+                                                               "avg_c_in_c_core",
+                                                               "envelope_binding_energy"]))
+
+                # Set companion to a massless remnant.
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
         # postMS + MS
@@ -248,27 +270,23 @@ class MergedStep(IsolatedStep):
 
                 # weighted mixing on the surface abundances of the whole
                 # companion with the envelope of star_base
-                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
-                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="mass")
+                parameters_to_mix = ["surface_h1", "surface_he4", "surface_c12", "surface_n14", "surface_o16"]
+                for abundance_name in parameters_to_mix:
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="H-rich_envelope_mass", mass_weight2="mass"))
 
                 # The change of masses occurs after the calculation of weighted averages
+                # Note that the he core mass is unchanged, which means that
+                # adding the mass changes the envelope mass only.
                 merged_star.mass = star_base.mass + comp.mass
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
 
+                # Set burning luminosities and star state.
                 merged_star.log_LHe = star_base.log_LHe
                 merged_star.log_LZ = star_base.log_LZ
-
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
         # MS + postMS (the opposite of above)
@@ -277,285 +295,299 @@ class MergedStep(IsolatedStep):
 
                 merged_star = comp
 
-                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
-                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
+                parameters_to_mix = ["surface_h1", "surface_he4", "surface_c12", "surface_n14", "surface_o16"]
+                for abundance_name in parameters_to_mix:
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight2="H-rich_envelope_mass", mass_weight1="mass"))
 
                 # The change of masses occurs after the calculation of weighted averages
                 merged_star.mass = star_base.mass + comp.mass
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
 
+                # Set burning luminosities and star state.
                 merged_star.log_LHe = comp.log_LHe
                 merged_star.log_LZ = comp.log_LZ
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
 
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(star_base)
 
-        #postMS + postMS
+        # postMS + postMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
+                # Weighted central abundances if merging cores.
 
-                # weighted central abundances if merging cores. Else only from star_base
-                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16",
+                                     'avg_c_in_c_core']
+
+                # two stars with Helium cores
+                if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
+                    mass_weight1 = 'he_core_mass'
+                    mass_weight2 = 'he_core_mass'
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1=mass_weight1, mass_weight2=mass_weight2))
+
                     setattr(merged_star, "center_gamma", np.nan)
-                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
+
+                # star_base with CO core and the comp has a He core
+                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0):
                     pass # the central abundances are kept as the ones of star_base
-                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
-                    merged_star.center_h1 = comp.center_h1
-                    merged_star.center_he4 = comp.center_he4
-                    merged_star.center_c12 = comp.center_c12
-                    merged_star.avg_c_in_c_core = comp.avg_c_in_c_core
-                    merged_star.center_n14 = comp.center_n14
-                    merged_star.center_o16 = comp.center_o16
-                    merged_star.center_gamma =  comp.center_gamma
+
+                # Companion with CO core and the star_base has a He core
+                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0):
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, getattr(comp, abundance_name))
+
+                    setattr(merged_star, "center_gamma", comp.center_gamma)
+
+                # both stars have CO cores
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass") #TODO : maybe he_core_mass makes more sense?
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
+
+                    #TODO : maybe he_core_mass makes more sense?
+                    mass_weight1='co_core_mass'
+                    mass_weight2='co_core_mass'
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1=mass_weight1, mass_weight2=mass_weight2))
+
                     setattr(merged_star, "center_gamma", np.nan)
+
                 else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
-                # weigheted mixing on the surface abundances based on the envelopes of the two stars
-                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
-                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass")
+                additional_parameter_to_mix = ['surface_h1', 'surface_he4', 'surface_c12', 'surface_n14', 'surface_o16']
 
-                # add total and core masses after calculations of weighter average
+                # Weighted mixing on the surface abundances based on the envelopes of the two stars
+                for abundance_name in additional_parameter_to_mix:
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="H-rich_envelope_mass", mass_weight2="H-rich_envelope_mass"))
+
+                # Add total and core masses after calculations of weighted average
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
+
+                # TODO for sure this needs testing!
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
-        #postMS + HeMSStar
+        # postMS + HeMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HeMS):
+                # Keep surface abundances from star_base.
 
-                # weighted central abundances if merging cores. Else only from star_base
-                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16", "avg_c_in_c_core"]
+
+                # Weighted central abundances if merging cores.
+                # two stars with only Helium cores, not CO cores
+                if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
-                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has just a He core (is a HeMS star)
-                    pass # the central abundances are kept as the ones of star_base
+
+                # star_base with CO core and the comp has just a He core (is a HeMS star)
+                # Keep central abundances as those from star_base.
+                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0):
+                    pass
+
                 else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
-                # surface abundances from star_base
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
                 # add total and core masses after abundance mass weighted calculations
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
+
+                # TODO for sure this needs testing!
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
-        # as above but opposite stars
+        # HeMS + postMS (the opposite of above)
         elif (s1 in  LIST_ACCEPTABLE_STATES_FOR_HeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
-
-                merged_star = comp
-
-                # weighted central abundances if merging cores. Else only from comp
-                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
-                    setattr(merged_star, "center_gamma", np.nan)
-                elif (star_base.co_core_mass == 0 and comp.co_core_mass > 0): # star_base is the HeMS Star and comp has a CO core
-                    pass # the central abundances are kept as the ones of comp
-                else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
                 # surface abundances from comp
+                merged_star = comp
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16", "avg_c_in_c_core"]
+
+                # Weighted central abundances if merging cores. Else only from comp
+                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with only Helium cores, not CO cores
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+
+                    setattr(merged_star, "center_gamma", np.nan)
+
+                # star_base is the HeMS Star and comp has a CO core
+                # the central abundances are kept from comp
+                elif (star_base.co_core_mass == 0 and comp.co_core_mass > 0):
+                    pass
+                else:
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
                 # add total and core masses after weighted averages above
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
 
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+                # TODO for sure this needs testing!
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(star_base)
 
-        #postMS + HeStar that is not in HeMS
+        #postMS + PostHeMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS):
 
-                # weighted central abundances if merging cores. Else only from star_base
-                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16", "avg_c_in_c_core"]
+
+                # Weighted central abundances if merging cores
+                # Two stars with Helium cores
+                if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name,
+                                self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
-                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
-                    pass # the central abundances are kept as the ones of star_base
-                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
-                    merged_star.center_h1 = comp.center_h1
-                    merged_star.center_he4 = comp.center_he4
-                    merged_star.center_c12 = comp.center_c12
-                    merged_star.avg_c_in_c_core = comp.avg_c_in_c_core
-                    merged_star.center_n14 = comp.center_n14
-                    merged_star.center_o16 = comp.center_o16
-                    merged_star.center_gamma =  comp.center_gamma
+
+                # Star_base with CO core and the comp has a He core
+                # the central abundances are kept as the ones of star_base
+                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0):
+                    pass
+
+                # comp with CO core and the star_base has a He core
+                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0):
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, getattr(comp, abundance_name))
+
+                    setattr(merged_star, "center_gamma", comp.center_gamma)
+
+                # both stars have CO cores
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name,
+                                self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
+
                 else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
+
+                # TODO for sure this needs testing!
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
-        # as above but the opposite stars
+        # PostHeMS + postMS (the opposite of above)
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
                 merged_star = comp
 
-                # weighted central abundances if merging cores. Else only from star_base
-                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16", "avg_c_in_c_core"]
+
+                # weighted central abundances if merging cores
+                # two stars with Helium cores
+                if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
-                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
-                    merged_star.center_h1 = star_base.center_h1
-                    merged_star.center_he4 = star_base.center_he4
-                    merged_star.center_c12 = star_base.center_c12
-                    merged_star.center_n14 = star_base.center_n14
-                    merged_star.center_o16 = star_base.center_o16
-                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
-                    pass # the central abundances are kept as the ones of comp
+
+                # star_base with CO core and the comp has a He core
+                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0):
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, getattr(star_base, abundance_name))
+
+                    setattr(merged_star, "center_gamma", star_base.center_gamma)
+
+                # comp with CO core and the star_base has a He core
+                # the central abundances are kept as the ones of comp
+                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0):
+                    pass
+
+                # both stars have CO cores
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass", mass_weight2="co_core_mass"))
+
+                    setattr(merged_star, "center_gamma", np.nan)
+
                 else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
+
+                # TODO for sure this needs testing!
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(star_base)
 
         # HeStar + HeStar
         elif (s1 in STAR_STATES_HE_RICH
             and s2 in STAR_STATES_HE_RICH):
 
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16", "avg_c_in_c_core"]
                 # weighted central abundances if merging cores. Else only from star_base
-                if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="he_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="he_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="he_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="he_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="he_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="he_core_mass")
+                # two stars with Helium cores
+                if star_base.co_core_mass == 0 and comp.co_core_mass == 0:
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="he_core_mass", mass_weight2="he_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
-                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0): # star_base with CO core and the comp has a He core
-                    pass # the central abundances are kept as the ones of star_base
-                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has a He core
-                    merged_star.center_h1 = comp.center_h1
-                    merged_star.center_he4 = comp.center_he4
-                    merged_star.center_c12 = comp.center_c12
-                    merged_star.avg_c_in_c_core = comp.avg_c_in_c_core
-                    merged_star.center_n14 = comp.center_n14
-                    merged_star.center_o16 = comp.center_o16
-                    merged_star.center_gamma =  comp.center_gamma
+
+                # star_base with CO core and the comp has a He core
+                # the central abundances are kept as the ones of star_base
+                elif (star_base.co_core_mass > 0 and comp.co_core_mass == 0):
+                    pass
+
+                # comp with CO core and the star_base has a He core
+                elif (comp.co_core_mass > 0 and star_base.co_core_mass == 0):
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, getattr(comp, abundance_name))
+
+                    setattr(merged_star, "center_gamma", comp.center_gamma)
+
+                # both stars have CO cores
                 elif (star_base.co_core_mass > 0 and comp.co_core_mass > 0):
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass", mass_weight2="co_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
+
                 else:
-                    Pwarn("weird compbination of CO core masses during merging", "EvolutionWarning")
+                    Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
@@ -563,46 +595,43 @@ class MergedStep(IsolatedStep):
                     setattr(merged_star, key,current)
 
                 # weigheted mixing on the surface abundances based on the He-rich envelopes of the two stars
-                merged_star.surface_h1 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_h1", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_he4", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_c12", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_n14", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
-                merged_star.surface_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "surface_o16", mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass")
+                additional_parameter_to_mix = ['surface_h1', 'surface_he4', 'surface_c12', 'surface_n14', 'surface_o16']
+                for abundance_name in additional_parameter_to_mix:
+                    setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="He-rich_envelope_mass", mass_weight2="He-rich_envelope_mass"))
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
-                merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
+
+                # TODO for sure this needs testing!
+                merged_star.state = check_state_of_star(merged_star, star_CO=False)
                 massless_remnant = convert_star_to_massless_remnant(comp)
 
         # Star + WD
         elif (s1 in STAR_STATES_NOT_CO
             and s2 in ["WD"]):
 
+                parameters_to_mix = ["center_h1", "center_he4",  "center_c12",  "center_n14",  "center_o16", "avg_c_in_c_core"]
                 # WD is considered a stripped CO core
                 # WD would always be the comp, it cannot be the engulfing star (so no need to do the opposite stars case below)
 
                 # weighted central abundances if merging cores. Else only from star_base
-                if (comp.co_core_mass is not None and star_base.co_core_mass == 0): # comp with CO core and the star_base has not
-                    merged_star.center_h1 = comp.center_h1
-                    merged_star.center_he4 = comp.center_he4
-                    merged_star.center_c12 = comp.center_c12
-                    merged_star.avg_c_in_c_core = comp.avg_c_in_c_core
-                    merged_star.center_n14 = comp.center_n14
-                    merged_star.center_o16 = comp.center_o16
-                    merged_star.center_gamma =  comp.center_gamma
+                # comp with CO core and the star_base has not
+                if (comp.co_core_mass is not None and star_base.co_core_mass == 0):
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, getattr(comp, abundance_name))
+
+                    setattr(merged_star, "center_gamma", comp.center_gamma)
+
+
+                # Star_base with CO core and the comp is a WD (so has a CO core)
                 elif (comp.co_core_mass is not None and star_base.co_core_mass > 0):
-                    merged_star.center_h1 = self.mass_weighted_avg(star_base, comp, abundance_name="center_h1", mass_weight1="co_core_mass")
-                    merged_star.center_he4 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_he4", mass_weight1="co_core_mass")
-                    merged_star.center_c12 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_c12", mass_weight1="co_core_mass")
-                    merged_star.avg_c_in_c_core = self.mass_weighted_avg(star_base, comp, abundance_name = "avg_c_in_c_core", mass_weight1="co_core_mass")
-                    merged_star.center_n14 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_n14", mass_weight1="co_core_mass")
-                    merged_star.center_o16 = self.mass_weighted_avg(star_base, comp, abundance_name = "center_o16", mass_weight1="co_core_mass")
+
+                    for abundance_name in parameters_to_mix:
+                        setattr(merged_star, abundance_name, self.mass_weighted_avg(star_base, comp, abundance_name=abundance_name, mass_weight1="co_core_mass", mass_weight2="co_core_mass"))
+
                     setattr(merged_star, "center_gamma", np.nan)
+
                 else:
                     Pwarn("Unexpected combination of CO core masses during merging", "EvolutionWarning")
 
@@ -611,13 +640,9 @@ class MergedStep(IsolatedStep):
                     current = getattr(star_base, key) + getattr(comp, "mass")
                     setattr(merged_star, key,current)
 
-                for key in STARPROPERTIES:
-                    # these stellar attributes become np.nan
-                    for substring in ["log_", "lg_", "surf_", "conv_", "lambda", "profile"]:
-                        if (substring in key) :
-                            setattr(merged_star, key, np.nan)
-                        if key in [ "c12_c12", "total_moment_of_inertia", "spin"]:
-                            setattr(merged_star, key, np.nan)
+                # Set parameters that are not expected to be meaningful after a merger to np.nan
+                self._apply_nan_attributes(merged_star)
+
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
                 massless_remnant = convert_star_to_massless_remnant(comp)
 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -52,10 +52,10 @@ MATCHING_WITH_RELATIVE_DIFFERENCE = ["center_he4"]
 
 val_names = [" ", "mass", "log_R", "center_h1", "surface_h1",
                 "he_core_mass", "center_he4", "surface_he4",
-                "center_c12"]
+                "center_c12", "co_core_mass"]
 str_fmts = ["{:>14}", "{:>9}","{:>9}",
             "{:>9}",  "{:>10}",  "{:>12}",
-            "{:>10}",  "{:>11}",  "{:>10}"]
+            "{:>10}",  "{:>11}",  "{:>10}", "{:>12}"]
 row_str = " ".join(str_fmts)
 DIVIDER_STR = "_"*len(row_str.format(*[""]*len(str_fmts)))
 # MAJOR.MINOR version of imported scipy package
@@ -285,7 +285,8 @@ class TrackMatcher:
                 "surface_he4",
                 "surface_h1",
                 "log_R",
-                "center_c12"
+                "center_c12",
+                "co_core_mass"
             ]
         )
 
@@ -743,7 +744,8 @@ class TrackMatcher:
                     f'surface_he4 = {star.surface_he4:.4f}, ',
                     f'surface_h1 = {star.surface_h1:.4f}, ',
                     f'he_core_mass = {star.he_core_mass:.3f}, ',
-                    f'center_c12 = {star.center_c12:.4f}'
+                    f'center_c12 = {star.center_c12:.4f},',
+                    f'co_core_mass = {star.co_core_mass:.3f}'
                 )
 
             # done with matching attempts


### PR DESCRIPTION
Implementing and solving issues already discussed in a previous PR version #311 which is now deprecated.

- No deepcopy during merger (which was working, but led to memory and speed issues)
- However, correct caclulations of the mass weighted averages of abundances BEFORE mass changes.
- calculating center_gamma and avg_c_in_c_core for mergers whenever possible (as the core value if the cores do not merge and np.nap and mass-weighted average respectively, if the cores merge).
- added co_core_mass as a potential option in the matching criteria at track_match (mostly for mergers)

Reminder : The resulting merger product is continuing as a singlestar instance at the place of the engulfing star (i.e. if oMerging1, then star_1 would be the merged product) UNLESS a NS/BH is involved, where the latter is the only one surviving (potential Thorne-Zytkov object).