### PR TITLE
[v2.3] New grid paths section for `.ini` file

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -196,7 +196,7 @@ class MesaGridStep:
                 and self.interpolation_method != 'nearest_neighbour'):
             raise ValueError('Track interpolation is currently supported only '
                              'by the nearest neighbour interpolation method!')
-        
+
         z_str = convert_metallicity_to_string(self.metallicity)
         self.grid_name = os.path.join(self.grid_path, f"{z_str}_Zsun.h5")
 
@@ -1358,7 +1358,7 @@ class MS_MS_step(MesaGridStep):
                              'binary.event = %s and not H-rich_Core_H_burning '
                              '- H-rich_Core_H_burning - * - ZAMS'
                              % (state_1, state_2, event))
-        
+
     def __repr__(self):
         """Return the name of evolution step and settings."""
         return "MS_MS_step:\n" + \
@@ -1473,7 +1473,7 @@ class CO_HMS_RLO_step(MesaGridStep):
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HMS_RLO"
             return
-        
+
     def __repr__(self):
         """Return the name of evolution step and settings."""
         return "CO_HMS_RLO_step:\n" + \
@@ -1588,7 +1588,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HeMS_RLO"
             return
-        
+
     def __repr__(self):
         """Return the name of evolution step and settings."""
         return "CO_HeMS_RLO_step:\n" + \
@@ -1684,7 +1684,7 @@ class CO_HeMS_step(MesaGridStep):
             self.binary.state = 'detached'
             self.binary.event = 'redirect_from_CO_HeMS'
             return
-        
+
     def __repr__(self):
         """Return the name of evolution step and settings."""
         return "CO_HeMS_step:\n" + \
@@ -1834,7 +1834,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
             self.binary.state = "detached"
             self.binary.event = "redirect_from_HMS_HMS_RLO"
             return
-        
+
     def __repr__(self):
         """Return the name of evolution step and settings."""
         return "HMS_HMS_RLO_step:\n" + \

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -127,8 +127,7 @@ class MesaGridStep:
     """Superclass for steps using the POSYDON grids."""
 
     DEFAULT_KWARGS = {'metallicity': None,
-                      'grid_name': None,
-                      'path': PATH_TO_POSYDON_DATA,
+                      'grid_path': None,
                       'interpolation_path': None,
                       'interpolation_filename': None,
                       'interpolation_method': 'nearest_neighbour',
@@ -197,12 +196,15 @@ class MesaGridStep:
                 and self.interpolation_method != 'nearest_neighbour'):
             raise ValueError('Track interpolation is currently supported only '
                              'by the nearest neighbour interpolation method!')
+        
+        z_str = convert_metallicity_to_string(self.metallicity)
+        self.grid_name = os.path.join(self.grid_path, f"{z_str}_Zsun.h5")
 
         # we load NN any time stop_at_max_time requested - regardless
         # of interp method
         if (self.stop_method == 'stop_at_max_time'
                 or self.interpolation_method == 'nearest_neighbour'):
-            self.load_psyTrackInterp(self.grid_name)
+            self.load_psyTrackInterp()
 
         self.grid_name = self.grid_name.replace('_%d', '')
 
@@ -213,14 +215,13 @@ class MesaGridStep:
 
             # Set the interpolation path
             if self.interpolation_path is None:
-                self.interpolation_path = os.path.join(self.path,
-                    os.path.split(self.grid_name)[0],
+                self.interpolation_path = os.path.join(self.grid_path,
                     'interpolators/%s' % self.interpolation_method)
 
             # Set the interpolation filename
             if self.interpolation_filename is None:
                 self.interpolation_filename = os.path.join(self.interpolation_path,
-                    os.path.split(self.grid_name)[1].replace('h5', 'pkl'))
+                    os.path.basename(self.grid_name).replace('h5', 'pkl'))
             else:
                 self.interpolation_filename = os.path.join(self.interpolation_path,
                                                       self.interpolation_filename)
@@ -258,17 +259,16 @@ class MesaGridStep:
         self.m2_min, self.m2_max = initial_values_min_max('star_2_mass')
         self.p_min, self.p_max = initial_values_min_max('period_days')
 
-    def load_psyTrackInterp(self, grid_name):
+    def load_psyTrackInterp(self):
         """Load the interpolator that has been trained on the grid."""
         # Check if interpolation files exist
-        filename = os.path.join(self.path,grid_name)
-        if not (os.path.exists(filename.replace('%d','0')) or
-                os.path.exists(filename.replace('_%d',''))):
+        if not (os.path.exists(self.grid_name.replace('%d','0')) or
+                os.path.exists(self.grid_name.replace('_%d',''))):
             data_download()
 
         if self.verbose:
-            print("loading psyTrackInterp: {}".format(filename))
-        self._psyTrackInterp = psyTrackInterp(filename,
+            print("loading psyTrackInterp: {}".format(self.grid_name))
+        self._psyTrackInterp = psyTrackInterp(self.grid_name,
                                               interp_in_q=self.interp_in_q,
                                               verbose=self.verbose)
         self._psyTrackInterp.train()
@@ -1266,16 +1266,11 @@ class MesaGridStep:
 class MS_MS_step(MesaGridStep):
     """Class for performing the MESA step for a MS-MS binary."""
 
-    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Initialize a MS_MS_step instance."""
         self.grid_type = 'HMS_HMS'
         self.interp_in_q = True
-        if grid_name is None:
-            metallicity = convert_metallicity_to_string(metallicity)
-            grid_name = 'HMS-HMS/' + metallicity + '_Zsun.h5'
-        super().__init__(metallicity=metallicity,
-                         grid_name=grid_name,
-                         *args, **kwargs)
+        super().__init__(*args, **kwargs)
         # special stuff for my step goes here
 
         # set mass ratio
@@ -1363,21 +1358,21 @@ class MS_MS_step(MesaGridStep):
                              'binary.event = %s and not H-rich_Core_H_burning '
                              '- H-rich_Core_H_burning - * - ZAMS'
                              % (state_1, state_2, event))
+        
+    def __repr__(self):
+        """Return the name of evolution step and settings."""
+        return "MS_MS_step:\n" + \
+            "\n".join([f"{key} = {getattr(self, key)}" for key in self.__dict__])
 
 
 class CO_HMS_RLO_step(MesaGridStep):
     """Class for performing the MESA step for a CO-HMS_RLO binary."""
 
-    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Initialize a CO_HMS_RLO_step instance."""
         self.grid_type = 'CO_HMS_RLO'
         self.interp_in_q = False
-        if grid_name is None:
-            metallicity = convert_metallicity_to_string(metallicity)
-            grid_name = 'CO-HMS_RLO/' + metallicity + '_Zsun.h5'
-        super().__init__(metallicity=metallicity,
-                         grid_name=grid_name,
-                         *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(self, binary):
         """Evolve a binary using the MESA step."""
@@ -1478,21 +1473,21 @@ class CO_HMS_RLO_step(MesaGridStep):
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HMS_RLO"
             return
+        
+    def __repr__(self):
+        """Return the name of evolution step and settings."""
+        return "CO_HMS_RLO_step:\n" + \
+            "\n".join([f"{key} = {getattr(self, key)}" for key in self.__dict__])
 
 
 class CO_HeMS_RLO_step(MesaGridStep):
     """Class for performing the MESA step for a CO-HeMS_RLO binary."""
 
-    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Initialize a CO_HeMS_RLO_step instance."""
         self.grid_type = 'CO_HeMS_RLO'
         self.interp_in_q = False
-        if grid_name is None:
-            metallicity = convert_metallicity_to_string(metallicity)
-            grid_name = 'CO-HeMS_RLO/' + metallicity + '_Zsun.h5'
-        super().__init__(metallicity=metallicity,
-                         grid_name=grid_name,
-                         *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(self, binary):
         """Evolve a binary using the MESA step."""
@@ -1593,21 +1588,21 @@ class CO_HeMS_RLO_step(MesaGridStep):
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HeMS_RLO"
             return
+        
+    def __repr__(self):
+        """Return the name of evolution step and settings."""
+        return "CO_HeMS_RLO_step:\n" + \
+            "\n".join([f"{key} = {getattr(self, key)}" for key in self.__dict__])
 
 
 class CO_HeMS_step(MesaGridStep):
     """Class for performing the MESA step for a CO-HeMS binary."""
 
-    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Initialize a CO_HeMS_step instance."""
         self.grid_type = 'CO_HeMS'
         self.interp_in_q = False
-        if grid_name is None:
-            metallicity = convert_metallicity_to_string(metallicity)
-            grid_name = 'CO-HeMS/' + metallicity + '_Zsun.h5'
-        super().__init__(metallicity=metallicity,
-                         grid_name=grid_name,
-                         *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(self, binary):
         """Apply the CO_HeMS step to a BinaryStar object."""
@@ -1689,6 +1684,11 @@ class CO_HeMS_step(MesaGridStep):
             self.binary.state = 'detached'
             self.binary.event = 'redirect_from_CO_HeMS'
             return
+        
+    def __repr__(self):
+        """Return the name of evolution step and settings."""
+        return "CO_HeMS_step:\n" + \
+            "\n".join([f"{key} = {getattr(self, key)}" for key in self.__dict__])
 
 
 class HMS_HMS_RLO_step(MesaGridStep):
@@ -1697,16 +1697,11 @@ class HMS_HMS_RLO_step(MesaGridStep):
     we evolve them first with step detached and map to the HMS-HMS RLO grid
     using `initial_eccentricity_flow_chart`."""
 
-    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Initialize a HMS_HMS_RLO_step instance."""
         self.grid_type = 'HMS_HMS_RLO'
         self.interp_in_q = True
-        if grid_name is None:
-            metallicity = convert_metallicity_to_string(metallicity)
-            grid_name = 'HMS-HMS_RLO/' + metallicity + '_Zsun.h5'
-        super().__init__(metallicity=metallicity,
-                         grid_name=grid_name,
-                         *args, **kwargs)
+        super().__init__(*args, **kwargs)
         # special stuff for my step goes here
         # If nothing to do, no init necessary
 
@@ -1839,3 +1834,8 @@ class HMS_HMS_RLO_step(MesaGridStep):
             self.binary.state = "detached"
             self.binary.event = "redirect_from_HMS_HMS_RLO"
             return
+        
+    def __repr__(self):
+        """Return the name of evolution step and settings."""
+        return "HMS_HMS_RLO_step:\n" + \
+            "\n".join([f"{key} = {getattr(self, key)}" for key in self.__dict__])

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -225,6 +225,45 @@ class SimulationProperties:
         self.grids_strippedHe = {}
 
     def set_path(self, path_name, path_str):
+        """
+        Set and normalize a grid path attribute that points to one of the 
+        MESA grids needed for binary evolution. By default, these are the 
+        grids inside of the directory name held in $PATH_TO_POSYDON_DATA.
+
+        For example, for the step_HMS_HMS, the grid would be 
+
+            $PATH_TO_POSYDON_DATA/HMS-HMS/<metallicity>_Zsun.h5
+
+        by default. The grid HDF5 file names themselves are expected to 
+        follow formats like so: 1e+00_Zsun.h5, 1e-04_Zsun.h5, etc.
+
+        If ``path_str`` is ``None``, a default path is assigned based on
+        ``path_name`` using ``self.default_grid_paths``. If ``path_name`` is not
+        recognized, a ``GridError`` is raised listing the valid options.
+
+        The resulting path is converted to an absolute path before being stored
+        as an attribute of the instance.
+
+        Parameters
+        ----------
+        path_name : str
+            Name of the grid path attribute to set. Must be a key in
+            ``self.default_grid_paths`` if ``path_str`` is ``None``.
+
+        path_str : str or None
+            Path to assign. If ``None``, a default path corresponding to
+            ``path_name`` is used.
+
+        Raises
+        ------
+        GridError
+            If ``path_name`` is not recognized and no default path can be assigned.
+
+        Notes
+        -----
+        The path is not validated for existence here; only normalization to an
+        absolute path is performed.
+        """
 
         # construct path to *_Zsun.h5 files if not specified
         if path_str is None:
@@ -239,10 +278,6 @@ class SimulationProperties:
                                 f"{valid_names}\n")
 
         path_str = os.path.abspath(path_str)
-
-        #if not os.path.exists(path_str) and path_str is not None:
-        #    # should trigger data download if someone happened to put the default path manually?
-        #    raise GridError(f"Path does not exist: {path_str}")
 
         setattr(self, path_name, path_str)
 

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -26,6 +26,7 @@ from posydon.popsyn.io import simprop_kwargs_from_ini
 from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.constants import age_of_universe
 from posydon.utils.posydonwarning import Pwarn
+from posydon.utils.posydonerror import GridError
 
 
 class NullStep:
@@ -34,6 +35,17 @@ class NullStep:
 
 class SimulationProperties:
     """Class describing the properties of a population synthesis simulation."""
+
+    # each value in this dict represents the expected path for the respective grid. 
+    # A user may specify their own full path to a custom grid in the [grid_paths]
+    # section of their .ini file. I.e., HMS-HMS_path = 'path/to/my_own_grid/' to 
+    # override these defaults.
+    default_grid_paths = {"single_HMS_path": os.path.join(PATH_TO_POSYDON_DATA, "single_HMS"),
+                          "single_HeMS_path": os.path.join(PATH_TO_POSYDON_DATA, "single_HeMS"),
+                          "HMS_HMS_path": os.path.join(PATH_TO_POSYDON_DATA, "HMS-HMS"),
+                          "CO_HMS_RLO_path": os.path.join(PATH_TO_POSYDON_DATA, "CO-HMS_RLO"),
+                          "CO_HeMS_path": os.path.join(PATH_TO_POSYDON_DATA, "CO-HeMS"),
+                          "CO_HeMS_RLO_path": os.path.join(PATH_TO_POSYDON_DATA, "CO-HeMS_RLO")}
 
     def __init__(self, flow=({}, {}),
                        step_HMS_HMS = (NullStep(), {}),
@@ -169,12 +181,6 @@ class SimulationProperties:
                     "(i) a class deriving from EvolveHooks and a kwargs dict, "
                     "or (ii) the name of the extra function and the callable.")
 
-        # Binary parameters and parameterizations
-        self.initial_rotation = 0.0
-        self.mass_transfer_efficiency = 1.0
-
-        self.common_envelope_efficiency = 1.0
-
         # Limits on simulation
         if not hasattr(self, 'max_simulation_time'):
             self.max_simulation_time = age_of_universe
@@ -202,15 +208,43 @@ class SimulationProperties:
         # maybe get rid of this
         self.track_matchers = {}
 
-        # Should possibly be a section in sim props .ini file
-        self.grid_path = PATH_TO_POSYDON_DATA
+        for grid_name in self.default_grid_paths:
+            try:
+                self.set_path(grid_name, self.kwargs[grid_name])
+            except KeyError as e:
+                Pwarn(f"{grid_name} is not set in the kwargs passed to SimulationProperties. "
+                      f"Falling back to the default: {self.default_grid_paths[grid_name]}", 
+                      "ReplaceValueWarning")
+                
+                self.set_path(grid_name, self.default_grid_paths[grid_name])
+
         # These hold GRIDInterpolator objects
         # and associated grid names for ea. metallicity
         # (intended keys are metallicities):
-        self.grid_names_Hrich = {}
         self.grids_Hrich = {}
-        self.grid_names_strippedHe = {}
         self.grids_strippedHe = {}
+
+    def set_path(self, path_name, path_str):
+
+        # construct path to *_Zsun.h5 files if not specified
+        if path_str is None:
+            if path_name in self.default_grid_paths:
+                path_str = self.default_grid_paths[path_name]
+            else:
+                valid_names = "\n".join(f"{k} = <your-path-or-None>" for k in self.default_grid_paths)
+                raise GridError(f'Trying to assign a grid path for "{path_name}".\n'
+                                "This is an unrecognized path name. Please check "
+                                "the [grid_paths] section of your .ini file.\n\n"
+                                "Valid path variable names are:\n"
+                                f"{valid_names}\n")
+            
+        path_str = os.path.abspath(path_str)
+            
+        if not os.path.exists(path_str):
+            # should trigger data download if someone happened to put the default path manually?
+            raise GridError(f"Path does not exist: {path_str}")
+
+        setattr(self, path_name, path_str)
 
     def preload_imports(self):
         """
@@ -453,9 +487,18 @@ class SimulationProperties:
             if metallicity is None:
                 Pwarn(f"{step_name} not assigned a metallicity. "
                     "Defaulting to Z = Zsun (solar).",
-                    "MissingValueWarning")
+                    "ReplaceValueWarning")
                 metallicity = 1.0
             step_kwargs['metallicity'] = float(metallicity)
+            print(step_name, step_kwargs['metallicity'])
+
+        # These steps need these grids:
+        step_grid_map = {"step_HMS_HMS": self.HMS_HMS_path,
+                         "step_CO_HMS_RLO": self.CO_HMS_RLO_path,
+                         "step_CO_HeMS": self.CO_HeMS_path,
+                         "step_CO_HeMS_RLO": self.CO_HeMS_RLO_path}
+        if step_name in step_grid_map:
+            step_kwargs['grid_path'] = step_grid_map[step_name]
 
         # each metallicity/step combo could require
         # a unique TrackMatcher, so check for that
@@ -508,19 +551,13 @@ class SimulationProperties:
         """
 
         z_str = convert_metallicity_to_string(metallicity)
-        # set up GRIDInterpolator objects
+        # set up GRIDInterpolator objects (for HMS and HeMS)
         # (only if one hasn't been created already for a given metallicity)
         if metallicity not in self.grids_Hrich:
-            self.grid_names_Hrich[metallicity] = os.path.join('single_HMS',
-                                                        z_str+'_Zsun.h5')
-            grid_path_Hrich = os.path.join(self.grid_path,
-                                            self.grid_names_Hrich[metallicity])
+            grid_path_Hrich = os.path.join(self.single_HMS_path, f"{z_str}_Zsun.h5")
             self.grids_Hrich[metallicity] = GRIDInterpolator(grid_path_Hrich)
         if metallicity not in self.grids_strippedHe:
-            self.grid_names_strippedHe[metallicity] = os.path.join('single_HeMS',
-                                                        z_str+'_Zsun.h5')
-            grid_path_strippedHe = os.path.join(self.grid_path,
-                                                self.grid_names_strippedHe[metallicity])
+            grid_path_strippedHe = os.path.join(self.single_HeMS_path, f"{z_str}_Zsun.h5")
             self.grids_strippedHe[metallicity] = GRIDInterpolator(grid_path_strippedHe)
 
         # Create TrackMatcher object as needed, passing GRIDInterpolator references

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -525,7 +525,6 @@ class SimulationProperties:
                     "ReplaceValueWarning")
                 metallicity = 1.0
             step_kwargs['metallicity'] = float(metallicity)
-            print(step_name, step_kwargs['metallicity'])
 
         # These steps need these grids:
         step_grid_map = {"step_HMS_HMS": self.HMS_HMS_path,

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -240,9 +240,9 @@ class SimulationProperties:
 
         path_str = os.path.abspath(path_str)
             
-        if not os.path.exists(path_str) and path_str is not None:
-            # should trigger data download if someone happened to put the default path manually?
-            raise GridError(f"Path does not exist: {path_str}")
+        #if not os.path.exists(path_str) and path_str is not None:
+        #    # should trigger data download if someone happened to put the default path manually?
+        #    raise GridError(f"Path does not exist: {path_str}")
 
         setattr(self, path_name, path_str)
 

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -239,7 +239,7 @@ class SimulationProperties:
                                 f"{valid_names}\n")
 
         path_str = os.path.abspath(path_str)
-            
+
         if not os.path.exists(path_str) and path_str is not None:
             # should trigger data download if someone happened to put the default path manually?
             raise GridError(f"Path does not exist: {path_str}")

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -226,15 +226,15 @@ class SimulationProperties:
 
     def set_path(self, path_name, path_str):
         """
-        Set and normalize a grid path attribute that points to one of the 
-        MESA grids needed for binary evolution. By default, these are the 
+        Set and normalize a grid path attribute that points to one of the
+        MESA grids needed for binary evolution. By default, these are the
         grids inside of the directory name held in $PATH_TO_POSYDON_DATA.
 
-        For example, for the step_HMS_HMS, the grid would be 
+        For example, for the step_HMS_HMS, the grid would be
 
             $PATH_TO_POSYDON_DATA/HMS-HMS/<metallicity>_Zsun.h5
 
-        by default. The grid HDF5 file names themselves are expected to 
+        by default. The grid HDF5 file names themselves are expected to
         follow formats like so: 1e+00_Zsun.h5, 1e-04_Zsun.h5, etc.
 
         If ``path_str`` is ``None``, a default path is assigned based on

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -239,7 +239,7 @@ class SimulationProperties:
                                 f"{valid_names}\n")
 
         path_str = os.path.abspath(path_str)
-            
+
         #if not os.path.exists(path_str) and path_str is not None:
         #    # should trigger data download if someone happened to put the default path manually?
         #    raise GridError(f"Path does not exist: {path_str}")

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -25,8 +25,8 @@ from posydon.interpolation.interpolation import GRIDInterpolator
 from posydon.popsyn.io import simprop_kwargs_from_ini
 from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.constants import age_of_universe
-from posydon.utils.posydonwarning import Pwarn
 from posydon.utils.posydonerror import GridError
+from posydon.utils.posydonwarning import Pwarn
 
 
 class NullStep:
@@ -36,9 +36,9 @@ class NullStep:
 class SimulationProperties:
     """Class describing the properties of a population synthesis simulation."""
 
-    # each value in this dict represents the expected path for the respective grid. 
+    # each value in this dict represents the expected path for the respective grid.
     # A user may specify their own full path to a custom grid in the [grid_paths]
-    # section of their .ini file. I.e., HMS-HMS_path = 'path/to/my_own_grid/' to 
+    # section of their .ini file. I.e., HMS-HMS_path = 'path/to/my_own_grid/' to
     # override these defaults.
     default_grid_paths = {"single_HMS_path": os.path.join(PATH_TO_POSYDON_DATA, "single_HMS"),
                           "single_HeMS_path": os.path.join(PATH_TO_POSYDON_DATA, "single_HeMS"),
@@ -213,9 +213,9 @@ class SimulationProperties:
                 self.set_path(grid_name, self.kwargs[grid_name])
             except KeyError as e:
                 Pwarn(f"{grid_name} is not set in the kwargs passed to SimulationProperties. "
-                      f"Falling back to the default: {self.default_grid_paths[grid_name]}", 
+                      f"Falling back to the default: {self.default_grid_paths[grid_name]}",
                       "ReplaceValueWarning")
-                
+
                 self.set_path(grid_name, self.default_grid_paths[grid_name])
 
         # These hold GRIDInterpolator objects
@@ -237,9 +237,9 @@ class SimulationProperties:
                                 "the [grid_paths] section of your .ini file.\n\n"
                                 "Valid path variable names are:\n"
                                 f"{valid_names}\n")
-            
+
         path_str = os.path.abspath(path_str)
-            
+
         if not os.path.exists(path_str):
             # should trigger data download if someone happened to put the default path manually?
             raise GridError(f"Path does not exist: {path_str}")

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -240,7 +240,7 @@ class SimulationProperties:
             
         path_str = os.path.abspath(path_str)
             
-        if not os.path.exists(path_str):
+        if not os.path.exists(path_str) and path_str is not None:
             # should trigger data download if someone happened to put the default path manually?
             raise GridError(f"Path does not exist: {path_str}")
 

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -494,6 +494,10 @@ def simprop_kwargs_from_ini(path, only=None, verbose=False):
 
             parser_dict[section] = hooks_list
 
+        if section == "grid_paths":
+
+            parser_dict.update(sect_dict)
+
     return parser_dict
 
 

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -434,6 +434,31 @@
   kwargs_2 = {}
     # dict
 
+[grid_paths]
+  # You shouldn't need to edit these paths unless you want to specify paths to
+  # your own custom MESA grids. Leaving these as None will tell POSYDON to use
+  # the default paths inside of your $PATH_TO_POSYDON_DATA environment variable.
+
+  HMS_HMS_path = None
+  # A string representing the path to your grid HDF5 files for HMS-HMS evolution.
+  # If None, the default $PATH_TO_POSYDON_DATA/HMS-HMS/*_Zsun.h5 files will be used
+  CO_HMS_RLO_path = None
+  # A string representing the path to your grid HDF5 files for CO-HMS evolution.
+  # If None, the default $PATH_TO_POSYDON_DATA/CO-HMS_RLO/*_Zsun.h5 files will be used
+  CO_HeMS_path = None
+  # A string representing the path to your grid HDF5 files for CO-HeMS evolution.
+  # If None, the default $PATH_TO_POSYDON_DATA/CO-HeMS/*_Zsun.h5 files will be used
+  CO_HeMS_RLO_path = None
+  # A string representing the path to your grid HDF5 files for CO-HeMS evolution.
+  # If None, the default $PATH_TO_POSYDON_DATA/CO-HeMS_RLO/*_Zsun.h5 files will be used
+  single_HMS_path = None
+  # A string representing the path to your grid HDF5 files for single star HMS evolution.
+  # If None, the default $PATH_TO_POSYDON_DATA/single_HMS/*_Zsun.h5 files will be used. 
+  # These are used by detached binaries and single stars in your population.
+  single_HeMS_path = None
+  # A string representing the path to your grid HDF5 files for single star HeMS evolution.
+  # If None, the default $PATH_TO_POSYDON_DATA/single_HeMS/*_Zsun.h5 files will be used.
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;  BinaryPopulation  ;;;;;;;;;;

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -453,7 +453,7 @@
   # If None, the default $PATH_TO_POSYDON_DATA/CO-HeMS_RLO/*_Zsun.h5 files will be used
   single_HMS_path = None
   # A string representing the path to your grid HDF5 files for single star HMS evolution.
-  # If None, the default $PATH_TO_POSYDON_DATA/single_HMS/*_Zsun.h5 files will be used. 
+  # If None, the default $PATH_TO_POSYDON_DATA/single_HMS/*_Zsun.h5 files will be used.
   # These are used by detached binaries and single stars in your population.
   single_HeMS_path = None
   # A string representing the path to your grid HDF5 files for single star HeMS evolution.


### PR DESCRIPTION
This adds a section to the `.ini` file that allows users to set the path to MESA grids in a centralized way.

It looks like this in the `.ini` file:
```bash
...

[grid_paths]
  # You shouldn't need to edit these paths unless you want to specify paths to
  # your own custom MESA grids. Leaving these as None will tell POSYDON to use
  # the default paths inside of your $PATH_TO_POSYDON_DATA environment variable.

  HMS_HMS_path = None
  # A string representing the path to your grid HDF5 files for HMS-HMS evolution.
  # If None, the default $PATH_TO_POSYDON_DATA/HMS-HMS/*_Zsun.h5 files will be used
  CO_HMS_RLO_path = None
  # A string representing the path to your grid HDF5 files for CO-HMS evolution.
  # If None, the default $PATH_TO_POSYDON_DATA/CO-HMS_RLO/*_Zsun.h5 files will be used
  CO_HeMS_path = None
  # A string representing the path to your grid HDF5 files for CO-HeMS evolution.
  # If None, the default $PATH_TO_POSYDON_DATA/CO-HeMS/*_Zsun.h5 files will be used
  CO_HeMS_RLO_path = None
  # A string representing the path to your grid HDF5 files for CO-HeMS evolution.
  # If None, the default $PATH_TO_POSYDON_DATA/CO-HeMS_RLO/*_Zsun.h5 files will be used
  single_HMS_path = None
  # A string representing the path to your grid HDF5 files for single star HMS evolution.
  # If None, the default $PATH_TO_POSYDON_DATA/single_HMS/*_Zsun.h5 files will be used. 
  # These are used by detached binaries and single stars in your population.
  single_HeMS_path = None
  # A string representing the path to your grid HDF5 files for single star HeMS evolution.
  # If None, the default $PATH_TO_POSYDON_DATA/single_HeMS/*_Zsun.h5 files will be used.

...
```

These paths are passed to the respective steps. The `single_*` paths are used by any steps that use `TrackMatcher` objects, the rest are used by the MESA grid steps.