### PR TITLE
[feat] add `max_concurrent_jobs` and `exclude` to popsyn CLI

### DIFF
--- a/bin/posydon-popsyn
+++ b/bin/posydon-popsyn
@@ -71,6 +71,16 @@ if __name__ == '__main__':
         '--account',
         help='the account you would like to use',
         default=None)
+    setup_parser.add_argument(
+        '--max_concurrent_jobs',
+        help='the maximum number of concurrent jobs to run in the job array',
+        type=int,
+        default=None)
+    setup_parser.add_argument(
+        '--exclude',
+        help='a comma-separated list of nodes to exclude when submitting the job',
+        type=str,
+        default=None)
     setup_parser.set_defaults(func=setup_popsyn_function)
 
     # Check the run subcommand
@@ -110,6 +120,16 @@ if __name__ == '__main__':
         '--account',
         help='the account you would like to use',
         default=None)
+    check_parser.add_argument(
+        '--max_concurrent_jobs',
+        help='the maximum number of concurrent jobs to run in the job array',
+        type=int,
+        default=None)
+    check_parser.add_argument(
+        '--exclude',
+        help='a comma-separated list of nodes to exclude when submitting the job',
+        type=str,
+        default=None)
     check_parser.set_defaults(func=check_popsyn_function)
 
     # Rescue the run subcommand (DEPRECATED)
@@ -148,6 +168,16 @@ if __name__ == '__main__':
     rescue_parser.add_argument(
         '--account',
         help='the account you would like to use',
+        default=None)
+    rescue_parser.add_argument(
+        '--max_concurrent_jobs',
+        help='the maximum number of concurrent jobs to run in the job array',
+        type=int,
+        default=None)
+    rescue_parser.add_argument(
+        '--exclude',
+        help='a comma-separated list of nodes to exclude when submitting the job',
+        type=str,
         default=None)
     rescue_parser.set_defaults(func=rescue_popsyn_function)
 

--- a/posydon/CLI/io.py
+++ b/posydon/CLI/io.py
@@ -165,6 +165,8 @@ def create_slurm_array(metallicity,
                         walltime,
                         account,
                         mem_per_cpu,
+                        max_concurrent_jobs,
+                        exclude,
                         path_to_posydon,
                         path_to_posydon_data):
     '''Creates the slurm array script for population synthesis job arrays.
@@ -208,10 +210,15 @@ def create_slurm_array(metallicity,
             "#SBATCH --mail-type=FAIL",
             f"#SBATCH --mail-user={email}"
         ])
+    if exclude is not None:
+        optional_directives.append(f"#SBATCH --exclude={exclude}")
 
     optional_section = "\n".join(optional_directives)
     if optional_section:
         optional_section += "\n"
+
+    if max_concurrent_jobs is not None:
+        job_array_length = f"{job_array_length}%{max_concurrent_jobs}"
 
     text_pre = textwrap.dedent(f'''\
         #!/bin/bash
@@ -322,6 +329,8 @@ def create_slurm_rescue(metallicity,
                         walltime,
                         account,
                         mem_per_cpu,
+                        max_concurrent_jobs,
+                        exclude,
                         path_to_posydon,
                         path_to_posydon_data):
     '''Creates the slurm rescue script for resubmitting failed population synthesis jobs.
@@ -369,10 +378,15 @@ def create_slurm_rescue(metallicity,
             "#SBATCH --mail-type=FAIL",
             f"#SBATCH --mail-user={email}"
         ])
+    if exclude is not None:
+        optional_directives.append(f"#SBATCH --exclude={exclude}")
 
     optional_section = "\n".join(optional_directives)
     if optional_section:
         optional_section += "\n"
+
+    if max_concurrent_jobs is not None:
+        job_array_str = f"{job_array_str}%{max_concurrent_jobs}"
 
     text_pre = textwrap.dedent(f'''\
         #!/bin/bash
@@ -427,6 +441,7 @@ def create_slurm_scripts(metallicity, args): # pragma: no cover
     '''
     create_slurm_array(metallicity, args.job_array, args.partition, args.email,
                        args.walltime, args.account, args.mem_per_cpu,
+                       args.max_concurrent_jobs, args.exclude,
                        PATH_TO_POSYDON,
                        os.path.dirname(PATH_TO_POSYDON_DATA))
 
@@ -508,12 +523,19 @@ def create_batch_rescue_script(args, batch_status):
     mem_per_cpu = None
     path_to_posydon = None
     path_to_posydon_data = None
+    max_concurrent_jobs = None
+    exclude = None
 
     for line in lines:
         if line.startswith('#SBATCH --array='):
             array_range = line.split('=')[1].strip()
-            if '-' in array_range:
-                start, end = map(int, array_range.split('-'))
+            if '%' in array_range:
+                tmp_array_range = array_range.split('%')[0]
+                max_concurrent_jobs = int(array_range.split('%')[1])
+            else:
+                tmp_array_range = array_range
+            if '-' in tmp_array_range:
+                start, end = map(int, tmp_array_range.split('-'))
                 job_array_length = end - start + 1
         elif line.startswith("#SBATCH --time="):
             walltime = line.split('=')[1].strip()
@@ -525,6 +547,8 @@ def create_batch_rescue_script(args, batch_status):
             account = line.split('=')[1].strip()
         elif line.startswith("#SBATCH --mail-user="):
             email = line.split('=')[1].strip()
+        elif line.startswith("#SBATCH --exclude="):
+            exclude = line.split('=')[1].strip()
         elif line.startswith("export PATH_TO_POSYDON="):
             path_to_posydon = line.split('=')[1].strip()
         elif line.startswith("export PATH_TO_POSYDON_DATA="):
@@ -541,6 +565,10 @@ def create_batch_rescue_script(args, batch_status):
         account = args.account
     if args.email is not None:
         email = args.email
+    if args.max_concurrent_jobs is not None:
+        max_concurrent_jobs = args.max_concurrent_jobs
+    if args.exclude is not None:
+        exclude = args.exclude
 
     # Create the rescue script
     create_slurm_rescue(
@@ -552,6 +580,8 @@ def create_batch_rescue_script(args, batch_status):
         walltime=walltime,
         account=account,
         mem_per_cpu=mem_per_cpu,
+        max_concurrent_jobs=max_concurrent_jobs,
+        exclude=exclude,
         path_to_posydon=path_to_posydon,
         path_to_posydon_data=path_to_posydon_data
     )

--- a/posydon/CLI/popsyn/check.py
+++ b/posydon/CLI/popsyn/check.py
@@ -324,6 +324,9 @@ def get_expected_batch_count(run_folder, str_met):
         for line in f:
             if line.startswith('#SBATCH --array='):
                 array_range = line.split('=')[1].strip()
+                # remove any job limit specifiers
+                if '%' in array_range:
+                    array_range = array_range.split('%')[0]
                 if '-' in array_range:
                     start, end = map(int, array_range.split('-'))
                     return end - start + 1

--- a/posydon/unit_tests/CLI/popsyn/test_check.py
+++ b/posydon/unit_tests/CLI/popsyn/test_check.py
@@ -397,6 +397,22 @@ class TestGetExpectedBatchCount:
 
         result = totest.get_expected_batch_count(str(tmp_path), str_met)
         assert result is None  # Should return None when array doesn't have dash
+
+    def test_get_expected_batch_count_with_max_concurrent_jobs(self, tmp_path):
+        """Test get_expected_batch_count with % (max concurrent jobs) in array range."""
+        metallicity = 1.0
+        str_met = convert_metallicity_to_string(metallicity)
+        slurm_file = tmp_path / f"{str_met}_Zsun_slurm_array.slurm"
+        slurm_content = """#!/bin/bash
+#SBATCH --array=0-9%5
+#SBATCH --job-name=test
+"""
+        slurm_file.write_text(slurm_content)
+
+        result = totest.get_expected_batch_count(str(tmp_path), str_met)
+        # Should strip %5 and return 10 (0-9 inclusive)
+        assert result == 10
+
 class TestFindMissingBatchIndices:
     """Test class for find_missing_batch_indices function."""
 

--- a/posydon/unit_tests/CLI/test_io.py
+++ b/posydon/unit_tests/CLI/test_io.py
@@ -175,7 +175,9 @@ class TestSlurmScriptCreation:
             totest.create_slurm_array(
                 metallicity, job_array_length, partition, email,
                 walltime, account, mem_per_cpu,
-                path_to_posydon, path_to_posydon_data
+                max_concurrent_jobs=None, exclude=None,
+                path_to_posydon=path_to_posydon,
+                path_to_posydon_data=path_to_posydon_data
             )
 
             # Check that the file was created
@@ -212,6 +214,7 @@ class TestSlurmScriptCreation:
                 partition=None, email=None,
                 walltime="12:00:00", account=None,
                 mem_per_cpu="2G",
+                max_concurrent_jobs=None, exclude=None,
                 path_to_posydon="/posydon",
                 path_to_posydon_data="/data"
             )
@@ -224,6 +227,67 @@ class TestSlurmScriptCreation:
                 assert "#SBATCH --partition" not in content
                 assert "#SBATCH --mail-user" not in content
                 assert "#SBATCH --account" not in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_slurm_array_with_max_concurrent_jobs(self, tmp_path):
+        """Test create_slurm_array with max_concurrent_jobs set."""
+        original_dir = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            metallicity = 1.0
+            job_array_length = 10
+            max_concurrent_jobs = 5
+
+            totest.create_slurm_array(
+                metallicity, job_array_length,
+                partition=None, email=None,
+                walltime="24:00:00", account=None,
+                mem_per_cpu="4G",
+                max_concurrent_jobs=max_concurrent_jobs,
+                exclude=None,
+                path_to_posydon="/posydon",
+                path_to_posydon_data="/data"
+            )
+            str_met = convert_metallicity_to_string(metallicity)
+            filename = f"{str_met}_Zsun_slurm_array.slurm"
+            assert os.path.exists(filename)
+
+            with open(filename, "r") as f:
+                content = f.read()
+                # Array should include the %N max concurrent jobs specifier
+                assert f"#SBATCH --array=0-{job_array_length - 1}%{max_concurrent_jobs}" in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_slurm_array_with_exclude(self, tmp_path):
+        """Test create_slurm_array with exclude set."""
+        original_dir = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            metallicity = 1.0
+            job_array_length = 10
+            exclude = "node01,node02"
+
+            totest.create_slurm_array(
+                metallicity, job_array_length,
+                partition=None, email=None,
+                walltime="24:00:00", account=None,
+                mem_per_cpu="4G",
+                max_concurrent_jobs=None,
+                exclude=exclude,
+                path_to_posydon="/posydon",
+                path_to_posydon_data="/data"
+            )
+            str_met = convert_metallicity_to_string(metallicity)
+            filename = f"{str_met}_Zsun_slurm_array.slurm"
+            assert os.path.exists(filename)
+
+            with open(filename, "r") as f:
+                content = f.read()
+                assert f"#SBATCH --exclude={exclude}" in content
         finally:
             os.chdir(original_dir)
 
@@ -343,6 +407,8 @@ class TestSlurmScriptCreation:
                 walltime="20:00:00",
                 account="test_account",
                 mem_per_cpu="4G",
+                max_concurrent_jobs=None,
+                exclude=None,
                 path_to_posydon="/posydon",
                 path_to_posydon_data="/data"
             )
@@ -379,6 +445,8 @@ class TestSlurmScriptCreation:
                 walltime="20:00:00",
                 account=None,     # No account
                 mem_per_cpu="4G",
+                max_concurrent_jobs=None,
+                exclude=None,
                 path_to_posydon="/posydon",
                 path_to_posydon_data="/data"
             )
@@ -396,6 +464,78 @@ class TestSlurmScriptCreation:
                 # But required directives should be there
                 assert "#SBATCH --array=2,4" in content
                 assert "#SBATCH --job-name=1e+00_popsyn_rescue" in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_slurm_rescue_with_max_concurrent_jobs(self, tmp_path):
+        """Test create_slurm_rescue with max_concurrent_jobs set."""
+        original_dir = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            metallicity = 1.0
+            missing_indices = [1, 3]
+            job_array_length = 10
+            max_concurrent_jobs = 4
+
+            totest.create_slurm_rescue(
+                metallicity=metallicity,
+                missing_indices=missing_indices,
+                job_array_length=job_array_length,
+                partition=None,
+                email=None,
+                walltime="20:00:00",
+                account=None,
+                mem_per_cpu="4G",
+                max_concurrent_jobs=max_concurrent_jobs,
+                exclude=None,
+                path_to_posydon="/posydon",
+                path_to_posydon_data="/data"
+            )
+
+            str_met = convert_metallicity_to_string(metallicity)
+            filename = f"{str_met}_Zsun_rescue.slurm"
+            assert os.path.exists(filename)
+
+            with open(filename, "r") as f:
+                content = f.read()
+                assert f"#SBATCH --array=1,3%{max_concurrent_jobs}" in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_slurm_rescue_with_exclude(self, tmp_path):
+        """Test create_slurm_rescue with exclude set."""
+        original_dir = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            metallicity = 1.0
+            missing_indices = [2, 4]
+            job_array_length = 10
+            exclude = "node01,node02"
+
+            totest.create_slurm_rescue(
+                metallicity=metallicity,
+                missing_indices=missing_indices,
+                job_array_length=job_array_length,
+                partition=None,
+                email=None,
+                walltime="20:00:00",
+                account=None,
+                mem_per_cpu="4G",
+                max_concurrent_jobs=None,
+                exclude=exclude,
+                path_to_posydon="/posydon",
+                path_to_posydon_data="/data"
+            )
+
+            str_met = convert_metallicity_to_string(metallicity)
+            filename = f"{str_met}_Zsun_rescue.slurm"
+            assert os.path.exists(filename)
+
+            with open(filename, "r") as f:
+                content = f.read()
+                assert f"#SBATCH --exclude={exclude}" in content
         finally:
             os.chdir(original_dir)
 
@@ -471,6 +611,8 @@ class TestRescueScriptFunctions:
         args.partition = "normal"
         args.account = "test_account"
         args.email = "test@example.com"
+        args.max_concurrent_jobs = None
+        args.exclude = None
         return args
 
     @pytest.fixture
@@ -595,6 +737,8 @@ class TestRescueScriptFunctions:
         args.partition = None      # Don't override
         args.account = None        # Don't override
         args.email = None          # Don't override
+        args.max_concurrent_jobs = None  # Don't override
+        args.exclude = None              # Don't override
 
         # Create a mock SLURM array script
         slurm_script = run_folder / "1e+00_Zsun_slurm_array.slurm"
@@ -647,6 +791,8 @@ class TestRescueScriptFunctions:
         args.partition = None      # Don't override
         args.account = None        # Don't override
         args.email = None          # Don't override
+        args.max_concurrent_jobs = None  # Don't override
+        args.exclude = None              # Don't override
 
         # Create a mock SLURM array script
         slurm_script = run_folder / "1e+00_Zsun_slurm_array.slurm"
@@ -696,6 +842,8 @@ class TestRescueScriptFunctions:
         args.partition = None
         args.account = None
         args.email = None
+        args.max_concurrent_jobs = None
+        args.exclude = None
 
         # Create a mock SLURM array script with array format that doesn't have a dash
         # (e.g., just a single number or comma-separated list)
@@ -721,5 +869,174 @@ class TestRescueScriptFunctions:
             # Verify script was still created
             rescue_script = run_folder / "1e+00_Zsun_rescue.slurm"
             assert rescue_script.exists()
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_batch_rescue_script_with_exclude_in_slurm(self, tmp_path, mock_batch_status):
+        """Test create_batch_rescue_script parses --exclude from existing SLURM script."""
+        run_folder = tmp_path / "run"
+        run_folder.mkdir()
+
+        args = MagicMock()
+        args.run_folder = str(run_folder)
+        args.walltime = None
+        args.mem_per_cpu = None
+        args.partition = None
+        args.account = None
+        args.email = None
+        args.max_concurrent_jobs = None
+        args.exclude = None
+
+        # SLURM script with --exclude= directive
+        slurm_script = run_folder / "1e+00_Zsun_slurm_array.slurm"
+        slurm_content = textwrap.dedent("""\
+            #!/bin/bash
+            #SBATCH --array=0-9
+            #SBATCH --time=24:00:00
+            #SBATCH --mem-per-cpu=4G
+            #SBATCH --exclude=node01,node02
+            export PATH_TO_POSYDON=/path/to/posydon
+            export PATH_TO_POSYDON_DATA=/path/to/data
+            srun python ./run_metallicity.py 1.0
+        """)
+        slurm_script.write_text(slurm_content)
+
+        original_dir = os.getcwd()
+        os.chdir(run_folder)
+
+        try:
+            result = totest.create_batch_rescue_script(args, mock_batch_status)
+
+            rescue_script = run_folder / "1e+00_Zsun_rescue.slurm"
+            content = rescue_script.read_text()
+            # Verify exclude was parsed from SLURM and passed to rescue script
+            assert "#SBATCH --exclude=node01,node02" in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_batch_rescue_script_with_max_concurrent_in_slurm(
+        self, tmp_path, mock_batch_status
+    ):
+        """Test create_batch_rescue_script parses % (max concurrent) from SLURM array."""
+        run_folder = tmp_path / "run"
+        run_folder.mkdir()
+
+        args = MagicMock()
+        args.run_folder = str(run_folder)
+        args.walltime = None
+        args.mem_per_cpu = None
+        args.partition = None
+        args.account = None
+        args.email = None
+        args.max_concurrent_jobs = None
+        args.exclude = None
+
+        # SLURM script with %N in array (max concurrent jobs)
+        slurm_script = run_folder / "1e+00_Zsun_slurm_array.slurm"
+        slurm_content = textwrap.dedent("""\
+            #!/bin/bash
+            #SBATCH --array=0-9%5
+            #SBATCH --time=24:00:00
+            #SBATCH --mem-per-cpu=4G
+            export PATH_TO_POSYDON=/path/to/posydon
+            export PATH_TO_POSYDON_DATA=/path/to/data
+            srun python ./run_metallicity.py 1.0
+        """)
+        slurm_script.write_text(slurm_content)
+
+        original_dir = os.getcwd()
+        os.chdir(run_folder)
+
+        try:
+            result = totest.create_batch_rescue_script(args, mock_batch_status)
+
+            rescue_script = run_folder / "1e+00_Zsun_rescue.slurm"
+            content = rescue_script.read_text()
+            # Verify max_concurrent_jobs was parsed from SLURM and included in rescue script
+            assert "%5" in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_batch_rescue_script_with_max_concurrent_arg(
+        self, tmp_path, mock_batch_status
+    ):
+        """Test create_batch_rescue_script with max_concurrent_jobs override from args."""
+        run_folder = tmp_path / "run"
+        run_folder.mkdir()
+
+        args = MagicMock()
+        args.run_folder = str(run_folder)
+        args.walltime = None
+        args.mem_per_cpu = None
+        args.partition = None
+        args.account = None
+        args.email = None
+        args.max_concurrent_jobs = 3
+        args.exclude = None
+
+        slurm_script = run_folder / "1e+00_Zsun_slurm_array.slurm"
+        slurm_content = textwrap.dedent("""\
+            #!/bin/bash
+            #SBATCH --array=0-9
+            #SBATCH --time=24:00:00
+            #SBATCH --mem-per-cpu=4G
+            export PATH_TO_POSYDON=/path/to/posydon
+            export PATH_TO_POSYDON_DATA=/path/to/data
+            srun python ./run_metallicity.py 1.0
+        """)
+        slurm_script.write_text(slurm_content)
+
+        original_dir = os.getcwd()
+        os.chdir(run_folder)
+
+        try:
+            result = totest.create_batch_rescue_script(args, mock_batch_status)
+
+            rescue_script = run_folder / "1e+00_Zsun_rescue.slurm"
+            content = rescue_script.read_text()
+            # Verify max_concurrent_jobs from args is used in rescue script
+            assert "%3" in content
+        finally:
+            os.chdir(original_dir)
+
+    def test_create_batch_rescue_script_with_exclude_arg(
+        self, tmp_path, mock_batch_status
+    ):
+        """Test create_batch_rescue_script with exclude override from args."""
+        run_folder = tmp_path / "run"
+        run_folder.mkdir()
+
+        args = MagicMock()
+        args.run_folder = str(run_folder)
+        args.walltime = None
+        args.mem_per_cpu = None
+        args.partition = None
+        args.account = None
+        args.email = None
+        args.max_concurrent_jobs = None
+        args.exclude = "badnode01"
+
+        slurm_script = run_folder / "1e+00_Zsun_slurm_array.slurm"
+        slurm_content = textwrap.dedent("""\
+            #!/bin/bash
+            #SBATCH --array=0-9
+            #SBATCH --time=24:00:00
+            #SBATCH --mem-per-cpu=4G
+            export PATH_TO_POSYDON=/path/to/posydon
+            export PATH_TO_POSYDON_DATA=/path/to/data
+            srun python ./run_metallicity.py 1.0
+        """)
+        slurm_script.write_text(slurm_content)
+
+        original_dir = os.getcwd()
+        os.chdir(run_folder)
+
+        try:
+            result = totest.create_batch_rescue_script(args, mock_batch_status)
+
+            rescue_script = run_folder / "1e+00_Zsun_rescue.slurm"
+            content = rescue_script.read_text()
+            # Verify exclude from args is used in rescue script
+            assert "#SBATCH --exclude=badnode01" in content
         finally:
             os.chdir(original_dir)


### PR DESCRIPTION
Adds two additional options to the population synthesis CLI interface.
I originally implemented these on the #mb_model_paper branch, but had forgotten to add them to main version.

`--max_concurrent_jobs` allows the user to set a maximum number of jobs to run concurrently. This is per job array.

`--exclude` allows the user to exclude specific nodes/cpus from the population synthesis run. This is for all job arrays created. This was needed because there were some "bad" nodes on yggdrasil for a while.