### PR TITLE
[v2.3] Add `to_df()` method for `LazyHDF5`

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -461,7 +461,7 @@ class LazyHDF5:
     def __len__(self): # pragma: no cover
         return len(self._dataset)
     
-    def to_df(self):
+    def to_df(self): # pragma: no cover
         return pd.DataFrame(self.__array__())
 
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -460,6 +460,9 @@ class LazyHDF5:
 
     def __len__(self): # pragma: no cover
         return len(self._dataset)
+    
+    def to_df(self):
+        return pd.DataFrame(self.__array__())
 
 
 class PSyGrid:

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -460,7 +460,7 @@ class LazyHDF5:
 
     def __len__(self): # pragma: no cover
         return len(self._dataset)
-    
+
     def to_df(self):
         return pd.DataFrame(self.__array__())
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -460,7 +460,7 @@ class LazyHDF5:
 
     def __len__(self): # pragma: no cover
         return len(self._dataset)
-    
+
     def to_df(self): # pragma: no cover
         return pd.DataFrame(self.__array__())
 


### PR DESCRIPTION
In that past you could do

```python
import pandas as pd
from posydon.grids.psygrid import PSyGrid

g = PSyGrid("grid.h5")
iv = pd.DataFrame(g.initial_values)
fv = pd.DataFrame(g.final_values)
```

to turn the initial (or final) values into a `pandas` `DataFrame`. However, now because `initial_values` (and `final_values`) are `LazyHDF5` objects, `pandas` no longer knows how to handle them in the same way. This adds a helper method to the `LazyHDF5` class that allows you to instead call

```python
from posydon.grids.psygrid import PSyGrid

g = PSyGrid("grid.h5")
iv = g.initial_values.to_df()
fv = g.final_values.to_df()
```

restoring this functionality in a user friendly way.