### PR TITLE
[enhancement] Add power law mass ratio options for reweighting

### DIFF
--- a/posydon/popsyn/distributions.py
+++ b/posydon/popsyn/distributions.py
@@ -669,7 +669,7 @@ class PowerLawPeriod():
 
         return pdf_values
 
-    def rvs(self, size=1, rng=None):
+    def rvs(self, size=1, n_points=1000, rng=None):
         """Draw random samples from the power law period distribution.
 
         Parameters
@@ -691,7 +691,6 @@ class PowerLawPeriod():
         from posydon.utils.common_functions import inverse_sampler
 
         # Create discretized PDF for inverse sampling
-        n_points = 1000
         logp_grid = np.linspace(np.log10(self.p_min), np.log10(self.p_max), n_points)
         pdf_values = self.power_law_period(logp_grid)
 

--- a/posydon/popsyn/distributions.py
+++ b/posydon/popsyn/distributions.py
@@ -270,7 +270,7 @@ class PowerLawMassRatio:
         pdf_values[valid] = self.power_law_mass_ratio(q[valid]) * self.norm
         return pdf_values
 
-    def rvs(self, size=1, rng=None):
+    def rvs(self, size=1, n_points=1000, rng=None):
         """Draw random samples from the power law mass ratio distribution.
 
         Parameters
@@ -289,8 +289,6 @@ class PowerLawMassRatio:
             rng = np.random.default_rng()
 
         from posydon.utils.common_functions import inverse_sampler
-
-        n_points = 1000
         q_grid = np.linspace(self.q_min, self.q_max, n_points)
         pdf_values = self.power_law_mass_ratio(q_grid)
         return inverse_sampler(q_grid, pdf_values, size=size, rng=rng)

--- a/posydon/popsyn/distributions.py
+++ b/posydon/popsyn/distributions.py
@@ -151,6 +151,151 @@ class FlatMassRatio:
         return rng.uniform(self.q_min, self.q_max, size=size)
 
 
+class PowerLawMassRatio:
+    """Power law mass ratio distribution for binary star systems.
+
+    A distribution where the PDF follows q^alpha within specified bounds
+    (q_min, q_max], exclusive bottom, inclusive top.
+
+    Parameters
+    ----------
+    alpha : float, optional
+        Power law exponent (default: 0.0, i.e. flat). Can be any real number.
+    q_min : float, optional
+        Minimum mass ratio (default: 0.05). Must be in [0, 1).
+    q_max : float, optional
+        Maximum mass ratio (default: 1.0). Must be in (0, 1].
+
+    Raises
+    ------
+    ValueError
+        If q_min or q_max are not in valid range, or if q_min >= q_max.
+
+    Examples
+    --------
+    >>> dist = PowerLawMassRatio(alpha=-1.0, q_min=0.1, q_max=1.0)
+    >>> pdf_value = dist.pdf(0.5)
+    """
+
+    def __init__(self, alpha=0.0, q_min=0.05, q_max=1.0):
+        """Initialize the power law mass ratio distribution.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            Power law exponent (default: 0.0).
+        q_min : float, optional
+            Minimum mass ratio (default: 0.05). Must be in [0, 1).
+        q_max : float, optional
+            Maximum mass ratio (default: 1.0). Must be in (0, 1].
+
+        Raises
+        ------
+        ValueError
+            If q_min or q_max are not in valid range, or if q_min >= q_max.
+        """
+        if not (0 <= q_min < 1):
+            raise ValueError("q_min must be in [0, 1)")
+        if not (0 < q_max <= 1):
+            raise ValueError("q_max must be in (0, 1]")
+        if q_min >= q_max:
+            raise ValueError("q_min must be less than q_max")
+        if alpha <= -1 and q_min == 0:
+            raise ValueError("q_min must be > 0 for alpha <= -1 "
+                             "to avoid divergent integral")
+
+        self.alpha = alpha
+        self.q_min = q_min
+        self.q_max = q_max
+        self.norm = self._calculate_normalization()
+
+    def __repr__(self):
+        """Return string representation of the distribution."""
+        return (f"PowerLawMassRatio(alpha={self.alpha}, "
+                f"q_min={self.q_min}, q_max={self.q_max})")
+
+    def _repr_html_(self):
+        """Return HTML representation for Jupyter notebooks."""
+        return (f"<h3>Power Law Mass Ratio Distribution</h3>"
+                f"<p>alpha = {self.alpha}</p>"
+                f"<p>q_min = {self.q_min}</p>"
+                f"<p>q_max = {self.q_max}</p>")
+
+    def _calculate_normalization(self):
+        """Calculate the normalization constant for the power law mass ratio
+        distribution.
+
+        Returns
+        -------
+        float
+            The normalization constant ensuring the PDF integrates to 1.
+        """
+        integral, _ = quad(self.power_law_mass_ratio, self.q_min, self.q_max)
+        if integral == 0:  # pragma: no cover
+            raise ValueError("Normalization integral is zero. "
+                             "Check mass ratio parameters.")
+        return 1.0 / integral
+
+    def power_law_mass_ratio(self, q):
+        """Compute the power law mass ratio distribution value.
+
+        Parameters
+        ----------
+        q : float or array_like
+            Mass ratio.
+
+        Returns
+        -------
+        float or ndarray
+            Distribution value q^alpha.
+        """
+        return np.asarray(q, dtype=float)**self.alpha
+
+    def pdf(self, q):
+        """Probability density function of the power law mass ratio distribution.
+
+        Parameters
+        ----------
+        q : float or array_like
+            Mass ratio(s).
+
+        Returns
+        -------
+        float or ndarray
+            Probability density at mass ratio q.
+        """
+        q = np.asarray(q)
+        valid = (q > self.q_min) & (q <= self.q_max)
+        pdf_values = np.zeros_like(q, dtype=float)
+        pdf_values[valid] = self.power_law_mass_ratio(q[valid]) * self.norm
+        return pdf_values
+
+    def rvs(self, size=1, rng=None):
+        """Draw random samples from the power law mass ratio distribution.
+
+        Parameters
+        ----------
+        size : int, optional
+            Number of samples to draw (default: 1).
+        rng : numpy.random.Generator, optional
+            Random number generator. If None, uses np.random.default_rng().
+
+        Returns
+        -------
+        ndarray
+            Random samples from the distribution.
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+
+        from posydon.utils.common_functions import inverse_sampler
+
+        n_points = 1000
+        q_grid = np.linspace(self.q_min, self.q_max, n_points)
+        pdf_values = self.power_law_mass_ratio(q_grid)
+        return inverse_sampler(q_grid, pdf_values, size=size, rng=rng)
+
+
 class Sana12Period():
     """Period distribution from Sana et al. (2012).
 

--- a/posydon/popsyn/norm_pop.py
+++ b/posydon/popsyn/norm_pop.py
@@ -12,6 +12,7 @@ from posydon.popsyn import independent_sample
 from posydon.popsyn.distributions import (
     FlatMassRatio,
     LogUniform,
+    PowerLawMassRatio,
     PowerLawPeriod,
     Sana12Period,
 )
@@ -75,6 +76,11 @@ def get_mass_ratio_pdf(kwargs):
         Requires the following parameters:
         - `secondary_mass_min`
         - `secondary_mass_max`
+    - `power_law_mass_ratio` for `secondary_mass_scheme`
+        Requires the following parameters:
+        - `mass_ratio_slope`: exponent alpha in q^alpha
+        - `q_min` (optional, default 0.05)
+        - `q_max` (optional, default 1.0)
 
     Parameters
     ----------
@@ -110,6 +116,15 @@ def get_mass_ratio_pdf(kwargs):
         # flat mass ratio, where bounds are given
         from posydon.popsyn.distributions import FlatMassRatio
         q_dist = FlatMassRatio(q_min=kwargs['q_min'], q_max=kwargs['q_max'])
+        q_pdf = lambda q, m1=None: q_dist.pdf(q)
+
+    elif kwargs['secondary_mass_scheme'] == 'power_law_mass_ratio':
+        from posydon.popsyn.distributions import PowerLawMassRatio
+        q_dist = PowerLawMassRatio(
+            alpha=kwargs['mass_ratio_slope'],
+            q_min=kwargs.get('q_min', 0.05),
+            q_max=kwargs.get('q_max', 1.0),
+        )
         q_pdf = lambda q, m1=None: q_dist.pdf(q)
 
     else:

--- a/posydon/unit_tests/popsyn/test_distributions.py
+++ b/posydon/unit_tests/popsyn/test_distributions.py
@@ -12,6 +12,7 @@ from posydon.popsyn.distributions import (
     FlatMassRatio,
     LogNormalSeparation,
     LogUniform,
+    PowerLawMassRatio,
     PowerLawPeriod,
     Sana12Period,
     ThermalEccentricity,
@@ -1181,3 +1182,150 @@ class TestLogNormalSeparation:
 
         with pytest.raises(ValueError, match="max must be greater than min"):
             LogUniform(min=100.0, max=100.0)
+
+
+class TestPowerLawMassRatio:
+    """Test class for PowerLawMassRatio distribution."""
+
+    @pytest.fixture
+    def default_power_law_mass_ratio(self):
+        """Fixture for default PowerLawMassRatio instance."""
+        return PowerLawMassRatio()
+
+    @pytest.fixture
+    def custom_power_law_mass_ratio(self):
+        """Fixture for custom PowerLawMassRatio instance."""
+        return PowerLawMassRatio(alpha=-1.0, q_min=0.1, q_max=0.9)
+
+    def test_initialization_default(self, default_power_law_mass_ratio):
+        """Test default initialization of PowerLawMassRatio."""
+        assert default_power_law_mass_ratio.alpha == 0.0
+        assert default_power_law_mass_ratio.q_min == 0.05
+        assert default_power_law_mass_ratio.q_max == 1.0
+        assert hasattr(default_power_law_mass_ratio, 'norm')
+        assert default_power_law_mass_ratio.norm > 0
+
+    def test_initialization_custom(self, custom_power_law_mass_ratio):
+        """Test custom initialization of PowerLawMassRatio."""
+        assert custom_power_law_mass_ratio.alpha == -1.0
+        assert custom_power_law_mass_ratio.q_min == 0.1
+        assert custom_power_law_mass_ratio.q_max == 0.9
+        assert hasattr(custom_power_law_mass_ratio, 'norm')
+        assert custom_power_law_mass_ratio.norm > 0
+
+    def test_initialization_invalid_parameters(self):
+        """Test that initialization raises ValueError for invalid parameters."""
+        with pytest.raises(ValueError, match="q_min must be in \\[0, 1\\)"):
+            PowerLawMassRatio(q_min=-0.1)
+
+        with pytest.raises(ValueError, match="q_min must be in \\[0, 1\\)"):
+            PowerLawMassRatio(q_min=1.0)
+
+        with pytest.raises(ValueError, match="q_max must be in \\(0, 1\\]"):
+            PowerLawMassRatio(q_max=0.0)
+
+        with pytest.raises(ValueError, match="q_max must be in \\(0, 1\\]"):
+            PowerLawMassRatio(q_max=1.5)
+
+        with pytest.raises(ValueError, match="q_min must be less than q_max"):
+            PowerLawMassRatio(q_min=0.8, q_max=0.5)
+
+        with pytest.raises(ValueError, match="q_min must be > 0 for alpha <= -1"):
+            PowerLawMassRatio(alpha=-1.0, q_min=0.0)
+
+    def test_repr(self, custom_power_law_mass_ratio):
+        """Test string representation of the distribution."""
+        repr_str = custom_power_law_mass_ratio.__repr__()
+        assert "PowerLawMassRatio(" in repr_str
+        assert "alpha=-1.0" in repr_str
+        assert "q_min=0.1" in repr_str
+        assert "q_max=0.9" in repr_str
+
+    def test_repr_html(self, default_power_law_mass_ratio):
+        """Test HTML representation for Jupyter notebooks."""
+        html_str = default_power_law_mass_ratio._repr_html_()
+        assert "<h3>Power Law Mass Ratio Distribution</h3>" in html_str
+        assert "alpha = 0.0" in html_str
+        assert "q_min = 0.05" in html_str
+        assert "q_max = 1.0" in html_str
+
+    def test_calculate_normalization(self, custom_power_law_mass_ratio):
+        """Test that normalization constant is the reciprocal of the integral."""
+        integral, _ = quad(
+            custom_power_law_mass_ratio.power_law_mass_ratio,
+            custom_power_law_mass_ratio.q_min,
+            custom_power_law_mass_ratio.q_max,
+        )
+        expected_norm = 1.0 / integral
+        np.testing.assert_allclose(custom_power_law_mass_ratio.norm, expected_norm)
+
+    def test_power_law_mass_ratio_method(self, custom_power_law_mass_ratio):
+        """Test the power_law_mass_ratio method returns q^alpha."""
+        q = np.array([0.2, 0.5, 0.8])
+        result = custom_power_law_mass_ratio.power_law_mass_ratio(q)
+        expected = q ** custom_power_law_mass_ratio.alpha
+        np.testing.assert_allclose(result, expected)
+
+    def test_pdf_within_range(self, custom_power_law_mass_ratio):
+        """Test PDF returns correct values within the mass ratio range."""
+        q_values = np.linspace(
+            custom_power_law_mass_ratio.q_min + 1e-6,
+            custom_power_law_mass_ratio.q_max,
+            10,
+        )
+        pdf_values = custom_power_law_mass_ratio.pdf(q_values)
+        expected = (
+            custom_power_law_mass_ratio.power_law_mass_ratio(q_values)
+            * custom_power_law_mass_ratio.norm
+        )
+        np.testing.assert_allclose(pdf_values, expected)
+
+    def test_pdf_outside_range(self, custom_power_law_mass_ratio):
+        """Test PDF returns zero outside the mass ratio range."""
+        q_below = np.array([0.05, 0.09])
+        np.testing.assert_array_equal(
+            custom_power_law_mass_ratio.pdf(q_below), np.zeros_like(q_below)
+        )
+
+        q_above = np.array([0.95, 1.0])
+        np.testing.assert_array_equal(
+            custom_power_law_mass_ratio.pdf(q_above), np.zeros_like(q_above)
+        )
+
+    def test_pdf_at_q_min_excluded(self, custom_power_law_mass_ratio):
+        """Test that q_min itself is excluded (open lower bound)."""
+        pdf_at_qmin = custom_power_law_mass_ratio.pdf(
+            np.array([custom_power_law_mass_ratio.q_min])
+        )
+        assert pdf_at_qmin[0] == 0.0
+
+    def test_normalization_integral(self, custom_power_law_mass_ratio):
+        """Test that the PDF integrates to 1 over the valid range."""
+        integral, _ = quad(
+            custom_power_law_mass_ratio.pdf,
+            custom_power_law_mass_ratio.q_min,
+            custom_power_law_mass_ratio.q_max,
+        )
+        np.testing.assert_allclose(integral, 1.0, rtol=1e-6)
+
+    def test_rvs(self, custom_power_law_mass_ratio):
+        """Test random sampling stays within bounds."""
+        rng = np.random.default_rng(42)
+        samples = custom_power_law_mass_ratio.rvs(size=1000, rng=rng)
+        assert len(samples) == 1000
+        assert np.all(samples >= custom_power_law_mass_ratio.q_min)
+        assert np.all(samples <= custom_power_law_mass_ratio.q_max)
+
+    def test_rvs_without_rng(self, custom_power_law_mass_ratio):
+        """Test random sampling without providing an RNG."""
+        samples = custom_power_law_mass_ratio.rvs(size=100)
+        assert len(samples) == 100
+        assert np.all(samples >= custom_power_law_mass_ratio.q_min)
+        assert np.all(samples <= custom_power_law_mass_ratio.q_max)
+
+    @pytest.mark.parametrize("alpha", [2.0, 0.0, -0.5])
+    def test_different_alpha_values(self, alpha):
+        """Test PowerLawMassRatio with different valid alpha exponents."""
+        dist = PowerLawMassRatio(alpha=alpha, q_min=0.1, q_max=1.0)
+        integral, _ = quad(dist.pdf, dist.q_min, dist.q_max)
+        np.testing.assert_allclose(integral, 1.0, rtol=1e-6)

--- a/posydon/unit_tests/popsyn/test_norm_pop.py
+++ b/posydon/unit_tests/popsyn/test_norm_pop.py
@@ -146,6 +146,32 @@ class TestGetMassRatioPdf:
         results = q_pdf(0.4)
         assert np.all(results == 1)
 
+    def test_power_law_mass_ratio_pdf(self):
+        """Test that power_law_mass_ratio scheme returns correct PDF values."""
+        kwargs = {
+            'secondary_mass_scheme': 'power_law_mass_ratio',
+            'mass_ratio_slope': 0.0,
+            'q_min': 0.1,
+            'q_max': 0.9,
+        }
+        q_pdf = norm_pop.get_mass_ratio_pdf(kwargs)
+        # alpha=0 gives a flat distribution over (0.1, 0.9]
+        result_in = q_pdf(0.5, None)
+        assert result_in > 0
+        result_out = q_pdf(0.05, None)
+        assert result_out == 0
+
+    def test_power_law_mass_ratio_pdf_default_bounds(self):
+        """Test power_law_mass_ratio uses default q_min/q_max when absent."""
+        kwargs = {
+            'secondary_mass_scheme': 'power_law_mass_ratio',
+            'mass_ratio_slope': 1.0,
+        }
+        q_pdf = norm_pop.get_mass_ratio_pdf(kwargs)
+        # Default q_min=0.05, q_max=1.0; value inside range should be positive
+        result = q_pdf(0.5, None)
+        assert result > 0
+
 class TestGetBinaryFractionPdf:
 
     def test_const_binary_fraction_pdf(self):


### PR DESCRIPTION
Allows the user to request a mass ratio distribution following a (requested) power law slope.
Usage example:

```
params = {
    'secondary_mass_scheme': 'power_law_mass_ratio',
    'mass_ratio_slope': -1.0,  # alpha in q^alpha
    'q_min': 0.0,
    'q_max': 1.0,
    ...
}
```