### PR TITLE
[v2.3] Uncomment binary test run code

### DIFF
--- a/dev-tools/run_test_suite.sh
+++ b/dev-tools/run_test_suite.sh
@@ -138,27 +138,27 @@ for Z in $METALLICITIES; do
     echo "  Log:    $LOG_FILE"
     echo "============================================================"
 
-    #python "$SUITE_SCRIPT" \
-    #    --metallicity "$Z" \
-    #    --output "$OUTPUT_FILE" \
-    #    --branch "$BRANCH" \
-    #    --sha "$ACTUAL_SHA" \
-    #    2>&1 | tee "$LOG_FILE"
-    #EXIT_CODE=${PIPESTATUS[0]}
+    python "$SUITE_SCRIPT" \
+        --metallicity "$Z" \
+        --output "$OUTPUT_FILE" \
+        --branch "$BRANCH" \
+        --sha "$ACTUAL_SHA" \
+        2>&1 | tee "$LOG_FILE"
+    EXIT_CODE=${PIPESTATUS[0]}
 
-    #if [ $EXIT_CODE -eq 137 ]; then
-    #    echo "ERROR: Process killed (likely OOM) for Z=${Z}. Exit code 137 (SIGKILL)." >&2
-    #    echo "  Consider increasing job memory." >&2
-    #    FAILED=$((FAILED + 1))
-    #elif [ $EXIT_CODE -ne 0 ]; then
-    #    echo "WARNING: Suite failed for Z=${Z} (exit code $EXIT_CODE). Check $LOG_FILE" >&2
-    #    FAILED=$((FAILED + 1))
-    #elif [ ! -f "$OUTPUT_FILE" ]; then
-    #    echo "WARNING: Output file not created for Z=${Z}" >&2
-    #    FAILED=$((FAILED + 1))
-    #else
-    #    echo "  Z=${Z} Zsun complete."
-    #fi
+    if [ $EXIT_CODE -eq 137 ]; then
+        echo "ERROR: Process killed (likely OOM) for Z=${Z}. Exit code 137 (SIGKILL)." >&2
+        echo "  Consider increasing job memory." >&2
+        FAILED=$((FAILED + 1))
+    elif [ $EXIT_CODE -ne 0 ]; then
+        echo "WARNING: Suite failed for Z=${Z} (exit code $EXIT_CODE). Check $LOG_FILE" >&2
+        FAILED=$((FAILED + 1))
+    elif [ ! -f "$OUTPUT_FILE" ]; then
+        echo "WARNING: Output file not created for Z=${Z}" >&2
+        FAILED=$((FAILED + 1))
+    else
+        echo "  Z=${Z} Zsun complete."
+    fi
 
 done
 


### PR DESCRIPTION
The binary test suite code was commented out for debug purposes in [PR#817](https://github.com/POSYDON-code/POSYDON/pull/817) before that was merged to `v2.3`. This just undoes the comments.