### PR TITLE
Correct spelling of 'remnant' in step_SN.py

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -115,7 +115,7 @@ class StepSN(object):
         to describe the collapse of the star.
 
     engine : str
-        Engine used for supernova remnanrt outcome propierties for the
+        Engine used for supernova remnant outcome propierties for the
         Sukhbold+16-engineand and Patton&Sukhbold20-engine mechanisms.
         Available options:
 


### PR DESCRIPTION
Fix typo in docstring for engine parameter.