### PR TITLE
[fix] comments to explain that metallicity is in Z/Zsun ratio

### DIFF
--- a/docs/_source/components-overview/pop_syn/single_star.rst
+++ b/docs/_source/components-overview/pop_syn/single_star.rst
@@ -32,7 +32,7 @@ The star properties are defined as follows
   * - ``state``
     - The state of the star, see state options.
   * - ``metallicity``
-    - Fractional metal content (Z) of the star.
+    - Ratio to solar metallicity (Z/Z_sun, e.g., 1.0 for solar metallicity).
   * - ``mass``
     - Stellar mass in M_sun.
   * - ``log_R``

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -40,7 +40,7 @@ from posydon.utils.posydonwarning import Pwarn
 STARPROPERTIES = [
     'state',            # the evolutionary state of the star. For more info see
                         # `posydon.utils.common_functions.check_state_of_star`
-    'metallicity',      # initial mass fraction of metals
+    'metallicity',      # Z/Z_sun, ratio to solar metallicity (1.0 for solar)
     'mass',             # mass (solar units)
     'log_R',            # log10 of radius (solar units)
     'log_L',            # log10 luminosity (solar units)

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -60,7 +60,7 @@ OBJECT_FIXED_SUB_DTYPES = {
 STARPROPERTIES_DTYPES = {
     'state': 'string',            # the evolutionary state of the star. For more info see
                                 # `posydon.utils.common_functions.check_state_of_star`
-    'metallicity': 'float64',      # initial mass fraction of metals
+    'metallicity': 'float64',      # Z/Z_sun, ratio to solar metallicity (1.0 for solar)
     'mass': 'float64',             # mass (solar units)
     'log_R': 'float64',            # log10 of radius (solar units)
     'log_L': 'float64',            # log10 luminosity (solar units)


### PR DESCRIPTION
Clarifies that `'metallicity'` in the single star properties is the solar metallicity ratio.
Solves issue #787.