### PR TITLE
[fix/enhancement] move SN_models out of `final_values`

### DIFF
--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -282,7 +282,7 @@ def calculate_extra_values(i, path_to_csv_file, verbose=False):
         star_2_CO = False
 
     # load grid with ORIGINAL compression and get extra colums
-    grid_ORIGINAL = PSyGrid(grid_ORIGINAL_path)
+    grid_ORIGINAL = PSyGrid(grid_ORIGINAL_path, lazy=False)
     MESA_dirs_EXTRA_COLUMNS, EXTRA_COLUMNS = post_process_grid(grid_ORIGINAL,
                                               index=None, star_2_CO=star_2_CO,
                                               verbose=verbose)
@@ -296,7 +296,7 @@ def calculate_extra_values(i, path_to_csv_file, verbose=False):
     shutil.copyfile(grid_path, processed_grid_path)
 
     # load processed grid and append values
-    grid = PSyGrid(processed_grid_path)
+    grid = PSyGrid(processed_grid_path, lazy=False)
     add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS, EXTRA_COLUMNS)
     if verbose:
         print(f'Added processed quantities to grid: {processed_grid_path}')
@@ -357,7 +357,7 @@ def train_interpolators(i, path_to_csv_file, verbose=False):
 
     # load grid
     grid = PSyGrid(verbose=verbose)
-    grid.load(grid_path)
+    grid.load(grid_path, lazy=False)
 
     interp_method = [method, method]
     interp_classes = ["stable_MT", "unstable_MT"]
@@ -999,7 +999,7 @@ def rerun(i, path_to_csv_file, verbose=False):
 
     # load grid
     grid = PSyGrid(verbose=verbose)
-    grid.load(grid_path)
+    grid.load(grid_path, lazy=False)
 
     # export point to rerun
     if verbose:
@@ -1127,7 +1127,7 @@ def plot_grid(i, path_to_csv_file, verbose=False):
 
     # load grid
     grid = PSyGrid(verbose=verbose)
-    grid.load(grid_path)
+    grid.load(grid_path, lazy=False)
 
     for quantity_to_plot in quantities_to_plot:
         if verbose:
@@ -1387,7 +1387,7 @@ def do_check(i, path_to_csv_file, verbose=False):
 
     # load grid
     grid = PSyGrid(verbose=verbose)
-    grid.load(grid_path)
+    grid.load(grid_path, lazy=False)
 
     # do the checks
     for check_to_do in checks_to_do:

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -1409,15 +1409,19 @@ def do_check(i, path_to_csv_file, verbose=False):
                 failure_rate_in_percent = 0.
             print(f'Failure rate: {failure_rate_in_percent}% in {grid_path}')
         elif check_to_do=='CO_type':
-            for quantity in grid.final_values.dtype.names:
-                if (('S1_SN_MODEL' in quantity) and ('CO_type' in quantity)):
-                    count = Counter(grid.final_values[quantity])
-                    print(f'{quantity}: {count} in {grid_path}')
+            for model_name, sn_ds in grid.SN_MODELS.items():
+                for short_key in sn_ds.dtype.names:
+                    if 'CO_type' in short_key:
+                        full_key = short_key[:3] + model_name + '_' + short_key[3:]
+                        count = Counter(sn_ds[short_key])
+                        print(f'{full_key}: {count} in {grid_path}')
         elif check_to_do=='SN_type':
-            for quantity in grid.final_values.dtype.names:
-                if (('S1_SN_MODEL' in quantity) and ('SN_type' in quantity)):
-                    count = Counter(grid.final_values[quantity])
-                    print(f'{quantity}: {count} in {grid_path}')
+            for model_name, sn_ds in grid.SN_MODELS.items():
+                for short_key in sn_ds.dtype.names:
+                    if 'SN_type' in short_key:
+                        full_key = short_key[:3] + model_name + '_' + short_key[3:]
+                        count = Counter(sn_ds[short_key])
+                        print(f'{full_key}: {count} in {grid_path}')
             #TODO: add more checks
         else:
             Pwarn(f'Do not know how to do {check_to_do} for'+\

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -409,24 +409,31 @@ def train_interpolators(i, path_to_csv_file, verbose=False):
     # to catch reverse mass transfer cases where the secondary undergoes
     # core collapse first
     for SN_MODEL_NAME in SN_MODELS.keys():
+        if SN_MODEL_NAME not in grid.SN_MODELS:
+            continue
+        sn_ds = grid.SN_MODELS[SN_MODEL_NAME]
         for i in range(1,2): #TODO: range(1,3):
-            out_keys = [key for key in grid.final_values.dtype.names if (
-                                   key != "model_number" and
-                                   (type(grid.final_values[key][0]) != np.str_)
-                                   and any(~np.isnan(grid.final_values[key]))
-                                   and f"S{i}_{SN_MODEL_NAME}" in key)]
-
-            out_nan_keys = [key for key in grid.final_values.dtype.names if (
-                                key != "model_number"
-                                and (type(grid.final_values[key][0]) != np.str_)
-                                and all(np.isnan(grid.final_values[key]))
-                                and f"S{i}_{SN_MODEL_NAME}" in key)]
+            prefix = f'S{i}_'
+            out_keys = []
+            out_nan_keys = []
+            for short_key in sn_ds.dtype.names:
+                if not short_key.startswith(prefix):
+                    continue
+                col_data = sn_ds[short_key]
+                if col_data.dtype.kind in ('S', 'U', 'O'):
+                    continue
+                full_key = f'S{i}_{SN_MODEL_NAME}_{short_key[3:]}'
+                if any(~np.isnan(col_data)):
+                    out_keys.append(full_key)
+                else:
+                    out_nan_keys.append(full_key)
 
             # get interpolations classes dynamically
             interp_method = []
             interp_classes = []
+            co_interp_col = sn_ds[f'S{i}_CO_interpolation_class']
             for CO_interpolation_class in ["BH", "NS", "WD", "BH_reverse_MT"]:
-                if CO_interpolation_class in grid.final_values[f'S{i}_{SN_MODEL_NAME}_CO_interpolation_class']:
+                if CO_interpolation_class in co_interp_col:
                     interp_method.append(method)
                     interp_classes.append(CO_interpolation_class)
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -123,6 +123,41 @@ POSYDON_TO_MESA = {
 }
 
 
+def _collect_sn_model_values(sn_row, star_idx):
+    """Build the star.SN_MODEL_* dict from a SN dataset row (short names).
+
+    Parameters
+    ----------
+    sn_row : dict or None
+        Output of PSyRunView.get_SN_data() — keys like 'S1_CO_type'.
+    star_idx : int
+        1 or 2.
+
+    Returns
+    -------
+    dict or None
+    """
+    if sn_row is None:
+        return None
+    prefix = f'S{star_idx}_'
+    co_type = sn_row.get(f'{prefix}CO_type', 'None')
+    if str(co_type) == 'None':
+        return None
+    return {
+        'state':           co_type,
+        'SN_type':         sn_row[f'{prefix}SN_type'],
+        'f_fb':            sn_row[f'{prefix}f_fb'],
+        'mass':            sn_row[f'{prefix}mass'],
+        'spin':            sn_row[f'{prefix}spin'],
+        'm_disk_accreted': sn_row[f'{prefix}m_disk_accreted'],
+        'm_disk_radiated': sn_row[f'{prefix}m_disk_radiated'],
+        'M4':              sn_row[f'{prefix}M4'],
+        'mu4':             sn_row[f'{prefix}mu4'],
+        'h1_mass_ej':      sn_row[f'{prefix}h1_mass_ej'],
+        'he4_mass_ej':     sn_row[f'{prefix}he4_mass_ej'],
+    }
+
+
 class MesaGridStep:
     """Superclass for steps using the POSYDON grids."""
 
@@ -830,26 +865,13 @@ class MesaGridStep:
         # update nearest neighbor core collapse quantites
         if interpolation_class != 'unstable_MT':
             for SN_MODEL_NAME in SN_MODELS.keys():
+                sn_row = cb.get_SN_data(SN_MODEL_NAME)
                 for i, star in enumerate(stars):
-                    col_name = f'S{i+1}_{SN_MODEL_NAME}_CO_type'
-                    if ((not stars_CO[i])
-                        and (cb.final_values[col_name] != 'None')):
-                        values = {}
-                        for key in ['state', 'SN_type', 'f_fb', 'mass', 'spin',
-                                    'm_disk_accreted', 'm_disk_radiated', 'M4',
-                                    'mu4', 'h1_mass_ej', 'he4_mass_ej']:
-                            if key == "state":
-                                state = cb.final_values[col_name]
-                                values[key] = state
-                            elif key == "SN_type":
-                                col_name = f'S{i+1}_{SN_MODEL_NAME}_{key}'
-                                values[key] = cb.final_values[col_name]
-                            else:
-                                col_name = f'S{i+1}_{SN_MODEL_NAME}_{key}'
-                                values[key] = cb.final_values[col_name]
-                        setattr(star, SN_MODEL_NAME, values)
+                    if not stars_CO[i]:
+                        values = _collect_sn_model_values(sn_row, i + 1)
                     else:
-                        setattr(star, SN_MODEL_NAME, None)
+                        values = None
+                    setattr(star, SN_MODEL_NAME, values)
 
     def initial_final_interpolation(self, star_1_CO=False, star_2_CO=False):
         """Update the binary through initial-final interpolation."""

--- a/posydon/grids/lazy_hdf.py
+++ b/posydon/grids/lazy_hdf.py
@@ -73,7 +73,7 @@ class LazyHDF5:
         return data
 
     def astype(self, dtype): # pragma: no cover
-        return LazyHDF5(np.asarray(self).astype(dtype))
+        return np.asarray(self).astype(dtype)
 
     @property
     def dtype(self):

--- a/posydon/grids/lazy_hdf.py
+++ b/posydon/grids/lazy_hdf.py
@@ -73,7 +73,7 @@ class LazyHDF5:
         return data
 
     def astype(self, dtype): # pragma: no cover
-        return np.asarray(self).astype(dtype)
+        return LazyHDF5(np.asarray(self).astype(dtype), self._dtype_set)
 
     @property
     def dtype(self):

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -168,7 +168,6 @@ def post_process_grid(grid, index=None, star_2_CO=True, SN_MODELS=SN_MODELS,
 
     """
     print('Post processing grid...')
-    print(grid.compression_args)
     EXTRA_COLUMNS = {}
     if single_star: # only star 1 columns in case of single star grid
         stars = [1]
@@ -576,6 +575,9 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     if 'final_values' in hdf5_file['grid']:
         del hdf5_file['grid/final_values']
 
+    # TODO: we should optimize the compression for reads, since we ar mostly
+    # reading the data. This should also be for the SN_MODELS and initial_values.
+    # This also includes optimizing the chunk size for the new datasets.
     hdf5_file.create_dataset('grid/final_values', data=out, **grid.compression_args)
 
     if 'SN_MODELS' in hdf5_file['grid']:

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -2,13 +2,16 @@
 
 import copy
 
+import h5py
 import numpy as np
+from numpy.lib import recfunctions
 from tqdm import tqdm
 
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.flow_chart import STAR_STATES_CC
 from posydon.binary_evol.singlestar import SingleStar
 from posydon.binary_evol.SN.step_SN import StepSN
+from posydon.grids.psygrid import H5_REC_STR_DTYPE
 from posydon.grids.SN_MODELS import SN_MODELS, get_SN_MODEL
 from posydon.utils.common_functions import (
     CEE_parameters_from_core_abundance_thresholds,
@@ -143,7 +146,7 @@ def post_process_grid(grid, index=None, star_2_CO=True, SN_MODELS=SN_MODELS,
     grid : PSyGrid
         MESA grid in PSyGrid format.
     index : None, int, or list with two int (default: None)
-        If None, loop over all indicies otherwise provide a range, e.g. [10,20]
+        If None, loop over all indices otherwise provide a range, e.g. [10,20]
         or a single index, e.g. 42.
     star_2_CO : bool (default: True)
         If 'False' star 2 is not a compact object.
@@ -164,6 +167,8 @@ def post_process_grid(grid, index=None, star_2_CO=True, SN_MODELS=SN_MODELS,
         Dictionary containing all post processed quantities.
 
     """
+    print('Post processing grid...')
+    print(grid.compression_args)
     EXTRA_COLUMNS = {}
     if single_star: # only star 1 columns in case of single star grid
         stars = [1]
@@ -187,21 +192,21 @@ def post_process_grid(grid, index=None, star_2_CO=True, SN_MODELS=SN_MODELS,
 
     # loop over all gird, index or range
     if index is None:
-        indicies = range(len(grid.MESA_dirs))
+        indices = range(len(grid.MESA_dirs))
         MESA_dirs = grid.MESA_dirs
     elif isinstance(index, int):
-        indicies = range(index, index+1)
+        indices = range(index, index+1)
         MESA_dirs = grid.MESA_dirs[index:index+1]
     elif isinstance(index, list):
         if len(index) != 2:
             raise ValueError('Index range should have dim=2!')
-        indicies = range(index[0], index[1])
+        indices = range(index[0], index[1])
         MESA_dirs = grid.MESA_dirs[index[0]:index[1]]
     else:
         raise TypeError('The argument `index` should be None, an integer, or '
                         'a list of two integers.')
 
-    for i in tqdm(indicies):
+    for i in tqdm(indices):
 
         if not single_star:
             # initilise binary
@@ -515,10 +520,86 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
         raise ValueError(
             'EXTRA_COLUMNS do not follow the correct order of grid!')
 
+    SN_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if 'SN_MODEL' in col]
+    OTHER_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if col not in SN_COLUMNS]
+
+    # Open the grid to write to
+    grid._reload_hdf5_file(writeable=True)
+    hdf5_file = grid.hdf5
+
+    # Convert the dictionary of lists to dictionary of numpy arrays and set the correct dtype for each column.
     for column in EXTRA_COLUMNS.keys():
         if (("state" in column) or ("type" in column) or ("class" in column)
             or (column == 'mt_history')):
-            values = np.asarray(EXTRA_COLUMNS[column], str)
+            EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column], dtype=str)
+            # replace U with S in the dtype to ensure compatibility with HDF5 string dtype
+            dtype = np.dtype(H5_REC_STR_DTYPE.replace('U', 'S'))
+            EXTRA_COLUMNS[column] = EXTRA_COLUMNS[column].astype(dtype)
         else:
-            values = np.asarray(EXTRA_COLUMNS[column], float)
-        grid.add_column(column, values, overwrite=True)
+            EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column], dtype=np.float64)
+
+    # get the final_values dataset
+    final_values = grid.final_values
+
+    new_dtype = []
+    for name in final_values.dtype.names:
+        old_dtype = final_values.dtype[name]
+        if old_dtype.kind == 'U':
+            new_dtype.append((name, H5_REC_STR_DTYPE.replace('U', 'S')))
+        else:
+            new_dtype.append((name, old_dtype))
+
+    if any(dt[1] != final_values.dtype[dt[0]] for dt in new_dtype):
+        final_values = final_values.astype(new_dtype)
+
+    # replace dtype of U to S in final_values to ensure compatibility with HDF5 string dtype
+    # check for overlap between final_values and OTHER_COLUMNS
+    # check that the new columns are not already in the dataset
+    # append_fields cannot handle already existing fields in structured arrays.
+    # Remove the existing values, because they will be overwritten by the new values.
+    overlap = set(final_values.dtype.names).intersection(set(OTHER_COLUMNS))
+    # remove overlapping fields from final_values
+    # The new values are written to file
+    if overlap:
+        final_values = recfunctions.drop_fields(final_values, list(overlap))
+        print('final_values dtype after dropping overlapping fields:', final_values.dtype)
+
+    # Add the final_values to the dataset
+    out = recfunctions.append_fields(base=final_values,
+                                     names=OTHER_COLUMNS,
+                                     data=[np.asarray(EXTRA_COLUMNS[column], dtype=EXTRA_COLUMNS[column].dtype) for column in OTHER_COLUMNS],
+                                     dtypes=[EXTRA_COLUMNS[column].dtype for column in OTHER_COLUMNS],
+                                    )
+
+    # write the new final_values to the dataset
+    # This will overwrite the existing final_values dataset with the new one containing the extra columns.
+    if 'final_values' in hdf5_file['grid']:
+        del hdf5_file['grid/final_values']
+
+    hdf5_file.create_dataset('grid/final_values', data=out, **grid.compression_args)
+
+    if 'SN_MODELS' in hdf5_file['grid']:
+        del hdf5_file['grid/SN_MODELS']
+
+    SN_MODELS_group = hdf5_file['grid'].create_group('SN_MODELS')
+
+    # Store each SN_MODEL in a separate dataset.
+    # Generally only a single dataset is needed per population synthesis run.
+    for SN_MODEL_NAME in SN_MODELS.keys():
+        # filter the columns for the specific SN_MODEL
+        SN_MODEL_columns = [col for col in SN_COLUMNS if f'{SN_MODEL_NAME}_' in col]
+        SN_MODEL_data = np.rec.fromarrays([EXTRA_COLUMNS[col] for col in SN_MODEL_columns],
+                                         names=[col.replace(f'{SN_MODEL_NAME}_', '') for col in SN_MODEL_columns])
+
+        # write the SN_MODEL data to the SN_MODELS group in the HDF5 file
+        SN_MODELS_group.create_dataset(SN_MODEL_NAME, data=SN_MODEL_data, **grid.compression_args)
+
+        # write metadata about the SN_MODEL as attributes to the dataset
+        SN_MODEL = get_SN_MODEL(SN_MODEL_NAME)
+        for key, value in SN_MODEL.items():
+            SN_MODELS_group[SN_MODEL_NAME].attrs[key] = value
+
+
+    # close the file
+    grid._reload_hdf5_file(writeable=False)
+    grid.close()

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -519,6 +519,9 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
         raise ValueError(
             'EXTRA_COLUMNS do not follow the correct order of grid!')
 
+    if not EXTRA_COLUMNS:
+        return
+
     SN_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if 'SN_MODEL' in col]
     OTHER_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if col not in SN_COLUMNS]
 
@@ -529,16 +532,17 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     grid._reload_hdf5_file(writeable=True)
     hdf5_file = grid.hdf5
 
-    # Convert the dictionary of lists to dictionary of numpy arrays and set the correct dtype for each column.
+    str_dtype = np.dtype(H5_REC_STR_DTYPE.replace('U', 'S'))
+
+    # Convert the dictionary of lists to numpy arrays with correct dtypes.
     for column in EXTRA_COLUMNS.keys():
         if (("state" in column) or ("type" in column) or ("class" in column)
             or (column == 'mt_history')):
-            EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column], dtype=str)
-            # replace U with S in the dtype to ensure compatibility with HDF5 string dtype
-            dtype = np.dtype(H5_REC_STR_DTYPE.replace('U', 'S'))
-            EXTRA_COLUMNS[column] = EXTRA_COLUMNS[column].astype(dtype)
+            EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column],
+                                             dtype=str).astype(str_dtype)
         else:
-            EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column], dtype=np.float64)
+            EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column],
+                                             dtype=np.float64)
 
     new_dtype = []
     for name in final_values.dtype.names:
@@ -551,55 +555,49 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     if any(dt[1] != final_values.dtype[dt[0]] for dt in new_dtype):
         final_values = final_values.astype(new_dtype)
 
-    # replace dtype of U to S in final_values to ensure compatibility with HDF5 string dtype
-    # check for overlap between final_values and OTHER_COLUMNS
-    # check that the new columns are not already in the dataset
-    # append_fields cannot handle already existing fields in structured arrays.
-    # Remove the existing values, because they will be overwritten by the new values.
+    # Only append non-SN columns to final_values.
+    # SN columns are written to a separate /grid/SN_MODELS group below.
     overlap = set(final_values.dtype.names).intersection(set(OTHER_COLUMNS))
-    # remove overlapping fields from final_values
-    # The new values are written to file
     if overlap:
         final_values = recfunctions.drop_fields(final_values, list(overlap))
 
-    # Add the final_values to the dataset
-    out = recfunctions.append_fields(base=final_values,
-                                     names=EXTRA_COLUMNS,
-                                     data=[np.asarray(EXTRA_COLUMNS[column], dtype=EXTRA_COLUMNS[column].dtype) for column in EXTRA_COLUMNS],
-                                     dtypes=[EXTRA_COLUMNS[column].dtype for column in EXTRA_COLUMNS],
-                                    )
+    if OTHER_COLUMNS:
+        out = recfunctions.append_fields(
+            base=final_values,
+            names=list(OTHER_COLUMNS),
+            data=[np.asarray(EXTRA_COLUMNS[col], dtype=EXTRA_COLUMNS[col].dtype)
+                  for col in OTHER_COLUMNS],
+            dtypes=[EXTRA_COLUMNS[col].dtype for col in OTHER_COLUMNS],
+        )
+    else:
+        out = final_values
 
-    # write the new final_values to the dataset
-    # This will overwrite the existing final_values dataset with the new one containing the extra columns.
     if 'final_values' in hdf5_file['grid']:
         del hdf5_file['grid/final_values']
 
-    # TODO: we should optimize the compression for reads, since we ar mostly
-    # reading the data. This should also be for the SN_MODELS and initial_values.
-    # This also includes optimizing the chunk size for the new datasets.
-    hdf5_file.create_dataset('grid/final_values', data=out, **grid.compression_args)
+    hdf5_file.create_dataset('grid/final_values', data=out,
+                             **grid.compression_args)
 
-    # if 'SN_MODELS' in hdf5_file['grid']:
-    #     del hdf5_file['grid/SN_MODELS']
+    # Write each SN model into /grid/SN_MODELS/{SN_MODEL_NAME}.
+    # Rerunning post-processing recreates the group cleanly.
+    if 'SN_MODELS' in hdf5_file['grid']:
+        del hdf5_file['grid/SN_MODELS']
 
-    # SN_MODELS_group = hdf5_file['grid'].create_group('SN_MODELS')
+    SN_MODELS_group = hdf5_file['grid'].create_group('SN_MODELS')
 
-    # # Store each SN_MODEL in a separate dataset.
-    # # Generally only a single dataset is needed per population synthesis run.
-    # for SN_MODEL_NAME in SN_MODELS.keys():
-    #     # filter the columns for the specific SN_MODEL
-    #     SN_MODEL_columns = [col for col in SN_COLUMNS if f'{SN_MODEL_NAME}_' in col]
-    #     SN_MODEL_data = np.rec.fromarrays([EXTRA_COLUMNS[col] for col in SN_MODEL_columns],
-    #                                      names=[col.replace(f'{SN_MODEL_NAME}_', '') for col in SN_MODEL_columns])
-
-    #     # write the SN_MODEL data to the SN_MODELS group in the HDF5 file
-    #     SN_MODELS_group.create_dataset(SN_MODEL_NAME, data=SN_MODEL_data, **grid.compression_args)
-
-    #     # write metadata about the SN_MODEL as attributes to the dataset
-    #     SN_MODEL = get_SN_MODEL(SN_MODEL_NAME)
-    #     for key, value in SN_MODEL.items():
-    #         SN_MODELS_group[SN_MODEL_NAME].attrs[key] = value
-
+    for SN_MODEL_NAME in SN_MODELS.keys():
+        sn_cols = [col for col in SN_COLUMNS if f'{SN_MODEL_NAME}_' in col]
+        if not sn_cols:
+            continue
+        short_names = [col.replace(f'{SN_MODEL_NAME}_', '') for col in sn_cols]
+        sn_data = np.rec.fromarrays(
+            [EXTRA_COLUMNS[col] for col in sn_cols],
+            names=short_names,
+        )
+        SN_MODELS_group.create_dataset(SN_MODEL_NAME, data=sn_data,
+                                       **grid.compression_args)
+        for key, value in get_SN_MODEL(SN_MODEL_NAME).items():
+            SN_MODELS_group[SN_MODEL_NAME].attrs[key] = value
 
     # close the file
     grid._reload_hdf5_file(writeable=False)

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -522,6 +522,9 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     SN_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if 'SN_MODEL' in col]
     OTHER_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if col not in SN_COLUMNS]
 
+    # get the final_values dataset
+    final_values = np.array(grid.final_values)
+
     # Open the grid to write to
     grid._reload_hdf5_file(writeable=True)
     hdf5_file = grid.hdf5
@@ -536,9 +539,6 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
             EXTRA_COLUMNS[column] = EXTRA_COLUMNS[column].astype(dtype)
         else:
             EXTRA_COLUMNS[column] = np.array(EXTRA_COLUMNS[column], dtype=np.float64)
-
-    # get the final_values dataset
-    final_values = grid.final_values
 
     new_dtype = []
     for name in final_values.dtype.names:
@@ -561,13 +561,12 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     # The new values are written to file
     if overlap:
         final_values = recfunctions.drop_fields(final_values, list(overlap))
-        print('final_values dtype after dropping overlapping fields:', final_values.dtype)
 
     # Add the final_values to the dataset
     out = recfunctions.append_fields(base=final_values,
-                                     names=OTHER_COLUMNS,
-                                     data=[np.asarray(EXTRA_COLUMNS[column], dtype=EXTRA_COLUMNS[column].dtype) for column in OTHER_COLUMNS],
-                                     dtypes=[EXTRA_COLUMNS[column].dtype for column in OTHER_COLUMNS],
+                                     names=EXTRA_COLUMNS,
+                                     data=[np.asarray(EXTRA_COLUMNS[column], dtype=EXTRA_COLUMNS[column].dtype) for column in EXTRA_COLUMNS],
+                                     dtypes=[EXTRA_COLUMNS[column].dtype for column in EXTRA_COLUMNS],
                                     )
 
     # write the new final_values to the dataset
@@ -580,26 +579,26 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     # This also includes optimizing the chunk size for the new datasets.
     hdf5_file.create_dataset('grid/final_values', data=out, **grid.compression_args)
 
-    if 'SN_MODELS' in hdf5_file['grid']:
-        del hdf5_file['grid/SN_MODELS']
+    # if 'SN_MODELS' in hdf5_file['grid']:
+    #     del hdf5_file['grid/SN_MODELS']
 
-    SN_MODELS_group = hdf5_file['grid'].create_group('SN_MODELS')
+    # SN_MODELS_group = hdf5_file['grid'].create_group('SN_MODELS')
 
-    # Store each SN_MODEL in a separate dataset.
-    # Generally only a single dataset is needed per population synthesis run.
-    for SN_MODEL_NAME in SN_MODELS.keys():
-        # filter the columns for the specific SN_MODEL
-        SN_MODEL_columns = [col for col in SN_COLUMNS if f'{SN_MODEL_NAME}_' in col]
-        SN_MODEL_data = np.rec.fromarrays([EXTRA_COLUMNS[col] for col in SN_MODEL_columns],
-                                         names=[col.replace(f'{SN_MODEL_NAME}_', '') for col in SN_MODEL_columns])
+    # # Store each SN_MODEL in a separate dataset.
+    # # Generally only a single dataset is needed per population synthesis run.
+    # for SN_MODEL_NAME in SN_MODELS.keys():
+    #     # filter the columns for the specific SN_MODEL
+    #     SN_MODEL_columns = [col for col in SN_COLUMNS if f'{SN_MODEL_NAME}_' in col]
+    #     SN_MODEL_data = np.rec.fromarrays([EXTRA_COLUMNS[col] for col in SN_MODEL_columns],
+    #                                      names=[col.replace(f'{SN_MODEL_NAME}_', '') for col in SN_MODEL_columns])
 
-        # write the SN_MODEL data to the SN_MODELS group in the HDF5 file
-        SN_MODELS_group.create_dataset(SN_MODEL_NAME, data=SN_MODEL_data, **grid.compression_args)
+    #     # write the SN_MODEL data to the SN_MODELS group in the HDF5 file
+    #     SN_MODELS_group.create_dataset(SN_MODEL_NAME, data=SN_MODEL_data, **grid.compression_args)
 
-        # write metadata about the SN_MODEL as attributes to the dataset
-        SN_MODEL = get_SN_MODEL(SN_MODEL_NAME)
-        for key, value in SN_MODEL.items():
-            SN_MODELS_group[SN_MODEL_NAME].attrs[key] = value
+    #     # write metadata about the SN_MODEL as attributes to the dataset
+    #     SN_MODEL = get_SN_MODEL(SN_MODEL_NAME)
+    #     for key, value in SN_MODEL.items():
+    #         SN_MODELS_group[SN_MODEL_NAME].attrs[key] = value
 
 
     # close the file

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -551,12 +551,15 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     new_dtype = []
     for name in final_values.dtype.names:
         old_dtype = final_values.dtype[name]
+        # if unicode, convert to bytes for HDF5 compatibility
         if old_dtype.kind == 'U':
             new_dtype.append((name, H5_REC_STR_DTYPE.replace('U', 'S')))
         else:
             new_dtype.append((name, old_dtype))
 
+    # Loop over new_dtypes (HDF5 compatible) and check if any differ from final_values dtypes
     if any(dt[1] != final_values.dtype[dt[0]] for dt in new_dtype):
+        # update w/ matching dtypes
         final_values = final_values.astype(new_dtype)
 
     # Only append non-SN columns to final_values.

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -522,8 +522,12 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS,
     if not EXTRA_COLUMNS:
         return
 
-    SN_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if 'SN_MODEL' in col]
-    OTHER_COLUMNS = [col for col in EXTRA_COLUMNS.keys() if col not in SN_COLUMNS]
+    SN_COLUMNS, OTHER_COLUMNS = [], []
+    for col in EXTRA_COLUMNS.keys():
+        if 'SN_MODEL' in col:
+            SN_COLUMNS.append(col)
+        else:
+            OTHER_COLUMNS.append(col)
 
     # get the final_values dataset
     final_values = np.array(grid.final_values)

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -220,7 +220,6 @@ from posydon.utils.common_functions import (
 )
 from posydon.utils.configfile import ConfigFile
 from posydon.utils.gridutils import (
-    LazyHDF5,
     add_field,
     fix_He_core,
     join_lists,

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -221,6 +221,7 @@ from posydon.utils.common_functions import (
 )
 from posydon.utils.configfile import ConfigFile
 from posydon.utils.gridutils import (
+    _get_grid_column,
     add_field,
     fix_He_core,
     join_lists,

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -405,6 +405,8 @@ class PSyGrid:
         if self.filepath is not None:
             self.load(self.filepath)
 
+        # the com
+
     def _reset(self):
         """(Re)set attributes to defaults, except `filename` and `verbose`."""
         self.close()
@@ -1493,14 +1495,10 @@ class PSyGrid:
                 dtype = (dtype[0], H5_REC_STR_DTYPE.replace("S", "U"))
             new_dtype[dtype[0]] = dtype[1]
 
-        if lazy:
-            initial_values = LazyHDF5(initial_values)
-            final_values = LazyHDF5(final_values, new_dtype)
-        else: # pragma: no cover
-            initial_values = initial_values[()]
-            final_values = final_values[()]
-            new_dtype = list(new_dtype.items())
-            final_values = final_values.astype(new_dtype)
+        initial_values = initial_values[()]
+        final_values = final_values[()]
+        new_dtype = list(new_dtype.items())
+        final_values = final_values.astype(new_dtype)
 
         self.initial_values = initial_values
         self.final_values = final_values
@@ -1541,6 +1539,9 @@ class PSyGrid:
             self.n_runs = n_expected
         else:
             raise KeyError("Some runs are missing from the HDF5 grid.")
+
+        # load the compression args for later use
+        self._make_compression_args()
 
         self._say("\tDone.")
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -389,7 +389,7 @@ GRIDPROPERTIES = {
 class PSyGrid:
     """Class handling a grid of MESA runs encoded in HDF5 format."""
 
-    def __init__(self, filepath=None, verbose=False):
+    def __init__(self, filepath=None, verbose=False, lazy=False):
         """Initialize the PSyGrid, and if `filename` is provided, open it.
 
         Parameters
@@ -404,7 +404,7 @@ class PSyGrid:
         self.filepath = filepath
         self.verbose = verbose
         if self.filepath is not None:
-            self.load(self.filepath)
+            self.load(self.filepath, lazy=lazy)
 
 
     def _reset(self):
@@ -420,39 +420,6 @@ class PSyGrid:
         self.n_runs = 0
         self.eeps = None
 
-    @property
-    def SN_values_old(self):
-        """Returns all SN_MODELS values as a structured array in the old format.
-
-        old format: S1/2_{SN_MODEL_NAME}_{VARIABLE_NAME}
-
-        Returns
-        -------
-        np.ndarray
-            Structured array with the SN_MODELS values. The columns are the
-            same as the datasets in the SN_MODELS group of the HDF5 file.
-            The name is
-        """
-
-        group = self.hdf5['grid/SN_MODELS']
-        SN_models = list(group.keys())
-        out = []
-        for SN_model in SN_models:
-            out.append(rfn.rename_fields(group[SN_model][:],
-                                    {name: f'{name[:3]}{SN_model}_{name[3:]}' for name in group[SN_model].dtype.names}))
-
-        self._SN_values = rfn.merge_arrays(out, flatten=True, usemask=False)
-
-    @property
-    def SN_values(self):
-        """Returns the hdf5 group of the SN_MODELS, which can be accessed as a dictionary of datasets.
-
-        Returns
-        -------
-        h5py.Group
-            The SN_MODELS group of the HDF5 file, which contains datasets for each SN model.
-        """
-        return self.hdf5['/grid/SN_MODELS']
 
     def _make_compression_args(self):
         """Convert compression information from the config."""

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -221,6 +221,7 @@ from posydon.utils.common_functions import (
 )
 from posydon.utils.configfile import ConfigFile
 from posydon.utils.gridutils import (
+    LazyHDF5,
     _get_grid_column,
     add_field,
     fix_He_core,

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1525,8 +1525,11 @@ class PSyGrid:
                     self._SN_values[model_name] = LazyHDF5(ds, dtype_set=sn_dtype)
                 else:
                     arr = ds[()]
-                    if sn_dtype:
+                    if sn_dtype: 
                         arr = arr.astype(list(sn_dtype.items()))
+                    # this is typically unreachable, maybe occurs w/ corrupted data
+                    else: # pragma: no cover
+                        pass
                     self._SN_values[model_name] = arr
 
         # load MESA dirs

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -189,6 +189,7 @@ import h5py
 import numpy as np
 import pandas as pd
 import tqdm
+from numpy.lib import recfunctions as rfn
 
 from posydon.grids.downsampling import TrackDownsampler
 from posydon.grids.io import (
@@ -405,7 +406,6 @@ class PSyGrid:
         if self.filepath is not None:
             self.load(self.filepath)
 
-        # the com
 
     def _reset(self):
         """(Re)set attributes to defaults, except `filename` and `verbose`."""
@@ -414,10 +414,45 @@ class PSyGrid:
         self.MESA_dirs = []
         self.initial_values = None
         self.final_values = None
+        self._SN_values = None
         self.config = ConfigFile()
         self._make_compression_args()
         self.n_runs = 0
         self.eeps = None
+
+    @property
+    def SN_values_old(self):
+        """Returns all SN_MODELS values as a structured array in the old format.
+
+        old format: S1/2_{SN_MODEL_NAME}_{VARIABLE_NAME}
+
+        Returns
+        -------
+        np.ndarray
+            Structured array with the SN_MODELS values. The columns are the
+            same as the datasets in the SN_MODELS group of the HDF5 file.
+            The name is
+        """
+
+        group = self.hdf5['grid/SN_MODELS']
+        SN_models = list(group.keys())
+        out = []
+        for SN_model in SN_models:
+            out.append(rfn.rename_fields(group[SN_model][:],
+                                    {name: f'{name[:3]}{SN_model}_{name[3:]}' for name in group[SN_model].dtype.names}))
+
+        self._SN_values = rfn.merge_arrays(out, flatten=True, usemask=False)
+
+    @property
+    def SN_values(self):
+        """Returns the hdf5 group of the SN_MODELS, which can be accessed as a dictionary of datasets.
+
+        Returns
+        -------
+        h5py.Group
+            The SN_MODELS group of the HDF5 file, which contains datasets for each SN model.
+        """
+        return self.hdf5['/grid/SN_MODELS']
 
     def _make_compression_args(self):
         """Convert compression information from the config."""
@@ -1495,10 +1530,14 @@ class PSyGrid:
                 dtype = (dtype[0], H5_REC_STR_DTYPE.replace("S", "U"))
             new_dtype[dtype[0]] = dtype[1]
 
-        initial_values = initial_values[()]
-        final_values = final_values[()]
-        new_dtype = list(new_dtype.items())
-        final_values = final_values.astype(new_dtype)
+        if lazy:
+                initial_values = LazyHDF5(initial_values)
+                final_values = LazyHDF5(final_values, dtype_set=new_dtype)
+        else:
+            initial_values = initial_values[()]
+            final_values = final_values[()]
+            new_dtype = list(new_dtype.items())
+            final_values = final_values.astype(new_dtype)
 
         self.initial_values = initial_values
         self.final_values = final_values

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -222,7 +222,6 @@ from posydon.utils.common_functions import (
 from posydon.utils.configfile import ConfigFile
 from posydon.utils.gridutils import (
     LazyHDF5,
-    _get_grid_column,
     add_field,
     fix_He_core,
     join_lists,

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -414,7 +414,7 @@ class PSyGrid:
         self.MESA_dirs = []
         self.initial_values = None
         self.final_values = None
-        self._SN_values = None
+        self._SN_values = {}
         self.config = ConfigFile()
         self._make_compression_args()
         self.n_runs = 0
@@ -1509,6 +1509,25 @@ class PSyGrid:
         self.initial_values = initial_values
         self.final_values = final_values
 
+        # load SN_MODELS datasets if present
+        self._SN_values = {}
+        if 'SN_MODELS' in hdf5['/grid']:
+            self._say("\tLoading SN_MODELS datasets...")
+            for model_name, ds in hdf5['/grid/SN_MODELS'].items():
+                sn_dtype = {}
+                for dname, dtp in ds.dtype.descr:
+                    if '_type' in dname or '_state' in dname or '_class' in dname:
+                        sn_dtype[dname] = H5_REC_STR_DTYPE.replace('S', 'U')
+                    else:
+                        sn_dtype[dname] = dtp
+                if lazy:
+                    self._SN_values[model_name] = LazyHDF5(ds, dtype_set=sn_dtype)
+                else:
+                    arr = ds[()]
+                    if sn_dtype:
+                        arr = arr.astype(list(sn_dtype.items()))
+                    self._SN_values[model_name] = arr
+
         # load MESA dirs
         self._say("\tAcquiring paths to MESA directories...")
         self.MESA_dirs = list(hdf5["/relative_file_paths"])
@@ -1680,6 +1699,30 @@ class PSyGrid:
         if index not in self:
             raise IndexError("Index {} out of bounds.".format(index))
         return PSyRunView(self, index)
+
+    @property
+    def SN_MODELS(self):
+        """Dict mapping SN_MODEL_NAME to its LazyHDF5 or ndarray dataset."""
+        return self._SN_values
+
+    def get_SN_run_data(self, run_index, model_name):
+        """Return a dict of SN quantities (short names) for one run.
+
+        Parameters
+        ----------
+        run_index : int
+        model_name : str
+            Key from SN_MODELS (e.g. 'SN_MODEL_v2_01').
+
+        Returns
+        -------
+        dict or None
+            Keys like 'S1_CO_type', 'S1_mass', etc.; None if model absent.
+        """
+        if model_name not in self._SN_values:
+            return None
+        row = self._SN_values[model_name][run_index]
+        return {name: row[name] for name in row.dtype.names}
 
     def get_pandas_initial_final(self):
         """Convert the initial/final values into a single Pandas dataframe.
@@ -2281,6 +2324,20 @@ class PSyRunView:
 
         """
         return self[key]
+
+    def get_SN_data(self, model_name):
+        """Return SN dataset row dict for this run and the given model.
+
+        Parameters
+        ----------
+        model_name : str
+            Key from SN_MODELS (e.g. 'SN_MODEL_v2_01').
+
+        Returns
+        -------
+        dict or None
+        """
+        return self.psygrid.get_SN_run_data(self.index, model_name)
 
     def __str__(self):
         """Return a summary of the PSyRunView in a string.

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1500,8 +1500,8 @@ class PSyGrid:
             new_dtype[dtype[0]] = dtype[1]
 
         if lazy:
-                initial_values = LazyHDF5(initial_values)
-                final_values = LazyHDF5(final_values, dtype_set=new_dtype)
+            initial_values = LazyHDF5(initial_values)
+            final_values = LazyHDF5(final_values, dtype_set=new_dtype)
         else:
             initial_values = initial_values[()]
             final_values = final_values[()]

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1525,7 +1525,7 @@ class PSyGrid:
                     self._SN_values[model_name] = LazyHDF5(ds, dtype_set=sn_dtype)
                 else:
                     arr = ds[()]
-                    if sn_dtype: 
+                    if sn_dtype:
                         arr = arr.astype(list(sn_dtype.items()))
                     # this is typically unreachable, maybe occurs w/ corrupted data
                     else: # pragma: no cover

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1747,11 +1747,9 @@ class PSyGrid:
         # Include SN model columns (moved out of final_values after migration)
         for model_name, sn_ds in self.SN_MODELS.items():
             for short_key in sn_ds.dtype.names:
-                prefix = short_key[:3]           # 'S1_' or 'S2_'
-                rest = short_key[3:]             # e.g. 'CO_type'
-                full_key = f'{prefix}{model_name}_{rest}'
-                new_col_name = "final_" + full_key
-                df[new_col_name] = np.array(sn_ds[short_key])
+                prefix, field_name = short_key.split('_', 1)
+                full_key = f"final_{prefix}_{model_name}_{field_name}"
+                df[full_key] = np.array(sn_ds[short_key])
         return df
 
     def __len__(self):

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1741,6 +1741,15 @@ class PSyGrid:
         for key in self.final_values.dtype.names:
             new_col_name = "final_" + key
             df[new_col_name] = self.final_values[key]
+
+        # Include SN model columns (moved out of final_values after migration)
+        for model_name, sn_ds in self.SN_MODELS.items():
+            for short_key in sn_ds.dtype.names:
+                prefix = short_key[:3]           # 'S1_' or 'S2_'
+                rest = short_key[3:]             # e.g. 'CO_type'
+                full_key = f'{prefix}{model_name}_{rest}'
+                new_col_name = "final_" + full_key
+                df[new_col_name] = np.array(sn_ds[short_key])
         return df
 
     def __len__(self):

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -201,6 +201,34 @@ from posydon.utils.posydonwarning import Pwarn
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
 
 
+def _get_grid_column(grid, key):
+    """Return a column array sourced from final_values or SN_MODELS datasets.
+
+    SN model columns (e.g. 'S1_SN_MODEL_v2_01_CO_type') are stored with
+    stripped short names ('S1_CO_type') inside per-model SN datasets.
+    This helper transparently routes to the correct source.
+
+    Parameters
+    ----------
+    grid : PSyGrid
+    key : str
+        Full column name (e.g. 'S1_SN_MODEL_v2_01_CO_type').
+
+    Returns
+    -------
+    np.ndarray
+    """
+    if key in grid.final_values.dtype.names:
+        return np.array(grid.final_values[key])
+    for model_name, ds in grid.SN_MODELS.items():
+        infix = f'{model_name}_'
+        prefix_len = 3  # len('S1_') == len('S2_')
+        if key[prefix_len:prefix_len + len(infix)] == infix:
+            short = key[:prefix_len] + key[prefix_len + len(infix):]
+            return np.array(ds[short])
+    raise KeyError(f"Column {key!r} not found in final_values or SN_MODELS")
+
+
 # INITIAL-FINAL INTERPOLATOR
 class IFInterpolator:
     """Class handling initial-final interpolation.
@@ -465,18 +493,46 @@ class BaseIFInterpolator:
                     and (type(grid.final_values[key][0]) != np.str_)
                     and any(pd.notna(grid.final_values[key]))
                 ]
+                # Add SN numeric columns from SN datasets.
+                for model_name, ds in grid.SN_MODELS.items():
+                    for fname in ds.dtype.names:
+                        if ('_type' not in fname and '_state' not in fname
+                                and '_class' not in fname):
+                            prefix = fname[:3]
+                            rest = fname[3:]
+                            full = f'{prefix}{model_name}_{rest}'
+                            col = np.array(ds[fname])
+                            if any(pd.notna(col)):
+                                self.out_keys.append(full)
             if self.out_nan_keys is None:
                 self.out_nan_keys = [
                     key for key in grid.final_values.dtype.names
                     if type(grid.final_values[key][0]) != np.str_
                     and all(pd.isna(grid.final_values[key]))
                 ]
+                for model_name, ds in grid.SN_MODELS.items():
+                    for fname in ds.dtype.names:
+                        if ('_type' not in fname and '_state' not in fname
+                                and '_class' not in fname):
+                            prefix = fname[:3]
+                            rest = fname[3:]
+                            full = f'{prefix}{model_name}_{rest}'
+                            col = np.array(ds[fname])
+                            if all(pd.isna(col)):
+                                self.out_nan_keys.append(full)
 
             self.constraints = find_constraints_to_apply(self.out_keys)
 
             if c_keys is None:
                 c_keys = [key for key in grid.final_values.dtype.names
                           if type(grid.final_values[key][0]) == np.str_]
+                # Add SN string columns from SN datasets.
+                for model_name, ds in grid.SN_MODELS.items():
+                    for fname in ds.dtype.names:
+                        if '_type' in fname or '_state' in fname or '_class' in fname:
+                            prefix = fname[:3]
+                            rest = fname[3:]
+                            c_keys.append(f'{prefix}{model_name}_{rest}')
 
             self.classifiers = {key: None for key in c_keys}
             self.n_in, self.n_out = len(self.in_keys), len(self.out_keys)
@@ -571,7 +627,7 @@ class BaseIFInterpolator:
         for i in range(self.n_in):
             X[:, i] = grid.initial_values[self.in_keys[i]]
         for i in range(self.n_out):
-            Y[:, i] = grid.final_values[self.out_keys[i]]
+            Y[:, i] = _get_grid_column(grid, self.out_keys[i])
 
         if self.interp_in_q:
             i_m1 = self.in_keys.index('star_1_mass')
@@ -724,7 +780,7 @@ class BaseIFInterpolator:
 
         """
         v = self.valid >= 0
-        wnn = grid.final_values[key] != 'None'
+        wnn = _get_grid_column(grid, key) != 'None'
         if any(wnn[v]):
             if (method == 'kNN') or (method == '1NN'):
                 self.classifiers[key] = KNNClassifier()
@@ -732,9 +788,9 @@ class BaseIFInterpolator:
                 raise ValueError("Wrong method name.")
             # If we want to exclude Nones as a class:
             # XTn = self.X_scaler.normalize(self.XT[v & wnn, :])
-            # y = grid.final_values[key][v & wnn]
+            # y = _get_grid_column(grid, key)[v & wnn]
             XTn = self.X_scaler.normalize(self.XT[v, :])
-            y = grid.final_values[key][v]
+            y = _get_grid_column(grid, key)[v]
             uy = np.unique(y)
             print(f"\nTraining {method} classifier for {key} "
                   f"[nclasses = {len(uy)}]...")
@@ -1825,7 +1881,7 @@ def analize_nones(classifiers, valid, grid):
     print("\nNones in categorical variables:")
     for key in classifiers:
         n = []
-        y = grid.final_values[key]
+        y = _get_grid_column(grid, key)
         for v in range(4):
             n.append(np.sum(y[valid == v] == 'None'))
         if np.sum(np.array(n)) > 0:

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -197,36 +197,9 @@ from posydon.interpolation.constraints import (
     sanitize_interpolated_quantities,
 )
 from posydon.interpolation.data_scaling import DataScaler
+from posydon.utils.gridutils import _get_grid_column
 from posydon.utils.posydonwarning import Pwarn
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
-
-
-def _get_grid_column(grid, key):
-    """Return a column array sourced from final_values or SN_MODELS datasets.
-
-    SN model columns (e.g. 'S1_SN_MODEL_v2_01_CO_type') are stored with
-    stripped short names ('S1_CO_type') inside per-model SN datasets.
-    This helper transparently routes to the correct source.
-
-    Parameters
-    ----------
-    grid : PSyGrid
-    key : str
-        Full column name (e.g. 'S1_SN_MODEL_v2_01_CO_type').
-
-    Returns
-    -------
-    np.ndarray
-    """
-    if key in grid.final_values.dtype.names:
-        return np.array(grid.final_values[key])
-    for model_name, ds in grid.SN_MODELS.items():
-        infix = f'{model_name}_'
-        prefix_len = 3  # len('S1_') == len('S2_')
-        if key[prefix_len:prefix_len + len(infix)] == infix:
-            short = key[:prefix_len] + key[prefix_len + len(infix):]
-            return np.array(ds[short])
-    raise KeyError(f"Column {key!r} not found in final_values or SN_MODELS")
 
 
 # INITIAL-FINAL INTERPOLATOR

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -548,23 +548,23 @@ class BaseIFInterpolator:
             if (self.interp_method == 'linear'
                     or isinstance(self.interp_method, list)):
                 print("\nFilling missing values (nans) with 1NN")
-                self._fillNans(grid.final_values[self.c_key])
+                self._fillNans(_get_grid_column(grid, self.c_key))
             elif self.interp_method == '1NN':
                 self.YT[pd.isna(self.YT)] = -100
 
             if (self.in_scaling is None) or (self.out_scaling is None):
                 if self.interp_method == '1NN':
-                    self.in_scaling, self.out_scaling = (self._bestInScaling(grid.final_values[self.c_key]),
+                    self.in_scaling, self.out_scaling = (self._bestInScaling(_get_grid_column(grid, self.c_key)),
                                                          ['none']*self.n_out)
                 else:
-                    self.in_scaling, self.out_scaling = self._bestScaling(grid.final_values[self.c_key])
+                    self.in_scaling, self.out_scaling = self._bestScaling(_get_grid_column(grid, self.c_key))
 
             self.X_scaler = Scaler(self.in_scaling,
                                    self.XT[self.valid >= 0, :],
-                                   grid.final_values[self.c_key][self.valid > 0])
+                                   _get_grid_column(grid, self.c_key)[self.valid > 0])
             self.Y_scaler = Scaler(self.out_scaling,
                                    self.YT[self.valid > 0, :],
-                                   grid.final_values[self.c_key][self.valid > 0])
+                                   _get_grid_column(grid, self.c_key)[self.valid > 0])
 
             if self.class_method == "kNN":
                 options = {'nfolds': 3, 'p_test': 0.05, 'nmax': 10}
@@ -573,7 +573,7 @@ class BaseIFInterpolator:
             self.train_classifiers(grid, method=self.class_method, **options)
 
             self.train_interpolator(
-                ic=grid.final_values[self.c_key])
+                ic=_get_grid_column(grid, self.c_key))
 
     def save(self, filename):
         """Save complete interpolation model.

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -1760,11 +1760,11 @@ def assess_models(models, grid_T, grid_t, ux2, path='./'):
             for c in uic:
                 f = grid_T.final_values['interpolation_class'] == c
                 print(
-                    f"\t{c}: [{np.sum(grid_T.final_values[key][f] == 'None')}"
+                    f"\t{c}: [{np.sum(_get_grid_column(grid_T, key)[f] == 'None')}"
                     f"/{np.sum(f)}] NaNs")
 
             # Ground Truth
-            zt_gt = grid_t.final_values[key][validt >= 0]
+            zt_gt = _get_grid_column(grid_t, key)[validt >= 0]
             # Confusion Matrices
             for i, m in enumerate(models):
                 print(f"\n\t  {m.classifiers[key].method}")
@@ -1781,8 +1781,8 @@ def assess_models(models, grid_T, grid_t, ux2, path='./'):
                     key, m.classifiers[key].labels, savename=savename)
                 plt.close(fig)
 
-                ZT = grid_T.final_values[key][m.valid >= 0]
-                zt_gt = grid_t.final_values[key][validt >= 0]
+                ZT = _get_grid_column(grid_T, key)[m.valid >= 0]
+                zt_gt = _get_grid_column(grid_t, key)[validt >= 0]
                 fig, ax = plot_mc_classifier(
                     m, key, m.XT[m.valid >= 0, :], ZT, ux2, Xt=Xt[validt >= 0],
                     zt=zt_gt, zt_pred=Ztpred[i][key], path=path2prmaps)

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -468,15 +468,14 @@ class BaseIFInterpolator:
                 ]
                 # Add SN numeric columns from SN datasets.
                 for model_name, ds in grid.SN_MODELS.items():
-                    for fname in ds.dtype.names:
-                        if ('_type' not in fname and '_state' not in fname
-                                and '_class' not in fname):
-                            prefix = fname[:3]
-                            rest = fname[3:]
-                            full = f'{prefix}{model_name}_{rest}'
-                            col = np.array(ds[fname])
+                    for short_key in ds.dtype.names:
+                        if ('_type' not in short_key and '_state' not in short_key
+                                and '_class' not in short_key):
+                            prefix, field_name = short_key.split('_', 1)
+                            full_key = f"{prefix}_{model_name}_{field_name}"
+                            col = np.array(ds[short_key])
                             if any(pd.notna(col)):
-                                self.out_keys.append(full)
+                                self.out_keys.append(full_key)
             if self.out_nan_keys is None:
                 self.out_nan_keys = [
                     key for key in grid.final_values.dtype.names
@@ -484,15 +483,14 @@ class BaseIFInterpolator:
                     and all(pd.isna(grid.final_values[key]))
                 ]
                 for model_name, ds in grid.SN_MODELS.items():
-                    for fname in ds.dtype.names:
-                        if ('_type' not in fname and '_state' not in fname
-                                and '_class' not in fname):
-                            prefix = fname[:3]
-                            rest = fname[3:]
-                            full = f'{prefix}{model_name}_{rest}'
-                            col = np.array(ds[fname])
+                    for short_key in ds.dtype.names:
+                        if ('_type' not in short_key and '_state' not in short_key
+                                and '_class' not in short_key):
+                            prefix, field_name = short_key.split('_', 1)
+                            full_key = f"{prefix}_{model_name}_{field_name}"
+                            col = np.array(ds[short_key])
                             if all(pd.isna(col)):
-                                self.out_nan_keys.append(full)
+                                self.out_nan_keys.append(full_key)
 
             self.constraints = find_constraints_to_apply(self.out_keys)
 
@@ -501,11 +499,11 @@ class BaseIFInterpolator:
                           if type(grid.final_values[key][0]) == np.str_]
                 # Add SN string columns from SN datasets.
                 for model_name, ds in grid.SN_MODELS.items():
-                    for fname in ds.dtype.names:
-                        if '_type' in fname or '_state' in fname or '_class' in fname:
-                            prefix = fname[:3]
-                            rest = fname[3:]
-                            c_keys.append(f'{prefix}{model_name}_{rest}')
+                    for short_key in ds.dtype.names:
+                        if '_type' in short_key or '_state' in short_key or '_class' in short_key:
+                            prefix, field_name = short_key.split('_', 1)
+                            full_key = f"{prefix}_{model_name}_{field_name}"
+                            c_keys.append(full_key)
 
             self.classifiers = {key: None for key in c_keys}
             self.n_in, self.n_out = len(self.in_keys), len(self.out_keys)

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -542,11 +542,10 @@ class GRIDInterpolator():
             for key in self.final_keys:
                 if 'SN_MODEL' in key:
                     model_name = _extract_model_name(key)
-                    prefix = key[:3]
-                    short = prefix + key[3 + len(model_name) + 1:]
+                    short_key = '_'.join(key.split(f'_{model_name}_'))
                     sn_row = grid[idx].get_SN_data(model_name)
                     self.grid_final_values[m][key] = (
-                        sn_row[short] if sn_row is not None else np.nan)
+                        sn_row[short_key] if sn_row is not None else np.nan)
                 else:
                     self.grid_final_values[m][key] = final_value[key]
             for key in self.profile_keys:

--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -19,6 +19,15 @@ from posydon.utils.interpolators import interp1d
 from .data_scaling import DataScaler
 
 
+def _extract_model_name(key):
+    """Extract SN_MODEL_NAME from a full column key.
+
+    E.g. 'S1_SN_MODEL_v2_01_CO_type' → 'SN_MODEL_v2_01'.
+    """
+    rest = key[3:]  # strip 'S1_' or 'S2_'
+    return next(name for name in SN_MODELS if rest.startswith(name + '_'))
+
+
 class psyTrackInterp:
     """Perform track interpolation for POSYDON."""
 
@@ -531,7 +540,15 @@ class GRIDInterpolator():
             for key in self.keys:
                 self.grid_data[m][key] = data[self.translate[key]]
             for key in self.final_keys:
-                self.grid_final_values[m][key] = final_value[key]
+                if 'SN_MODEL' in key:
+                    model_name = _extract_model_name(key)
+                    prefix = key[:3]
+                    short = prefix + key[3 + len(model_name) + 1:]
+                    sn_row = grid[idx].get_SN_data(model_name)
+                    self.grid_final_values[m][key] = (
+                        sn_row[short] if sn_row is not None else np.nan)
+                else:
+                    self.grid_final_values[m][key] = final_value[key]
             for key in self.profile_keys:
                 self.grid_profile[m][key] = profile[key]
 

--- a/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
+++ b/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
@@ -342,7 +342,7 @@ def get_PSyGrid(dir_path, idx, binary_history, star_history, profile,\
     return path
 
 
-def get_simple_PSyGrid(dir_path, idx, binary_history, star_history, profile, 
+def get_simple_PSyGrid(dir_path, idx, binary_history, star_history, profile,
                        add_SN_MODELS=False):
     """Create a PSyGrid file with two runs (+ the empty run0) and reduced
     columns in the initial and final values.

--- a/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
+++ b/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
@@ -342,7 +342,8 @@ def get_PSyGrid(dir_path, idx, binary_history, star_history, profile,\
     return path
 
 
-def get_simple_PSyGrid(dir_path, idx, binary_history, star_history, profile):
+def get_simple_PSyGrid(dir_path, idx, binary_history, star_history, profile, 
+                       add_SN_MODELS=False):
     """Create a PSyGrid file with two runs (+ the empty run0) and reduced
     columns in the initial and final values.
 
@@ -370,4 +371,5 @@ def get_simple_PSyGrid(dir_path, idx, binary_history, star_history, profile):
                                                          '<f8')],\
                        final_values_dtypes=[('period_days', '<f8'),\
                                             ('termination_flag_1',\
-                                             h5py.string_dtype())])
+                                             h5py.string_dtype())],
+                       add_SN_MODELS=add_SN_MODELS)

--- a/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
+++ b/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
@@ -16,12 +16,13 @@ import h5py
 import numpy as np
 
 from posydon.grids.psygrid import H5_UNICODE_DTYPE, PSyGrid
+from posydon.grids.SN_MODELS import SN_MODELS, get_SN_MODEL
 
 
 # helper functions
 def get_PSyGrid(dir_path, idx, binary_history, star_history, profile,\
                 n_runs=6, initial_values_dtypes=None,\
-                final_values_dtypes=None):
+                final_values_dtypes=None, add_SN_MODELS=False):
     """Create a PSyGrid file with some runs
 
     Parameters
@@ -295,9 +296,49 @@ def get_PSyGrid(dir_path, idx, binary_history, star_history, profile,\
             fin_vals += [tuple(fin_vals_run)]
         fin_val = np.array(fin_vals, dtype=fin_dtypes)
         hdf5_file.create_dataset("/grid/final_values", data=fin_val)
+
+        if add_SN_MODELS:
+            # Create SN data
+            SN_MODELS_group = hdf5_file["grid"].create_group("SN_MODELS")
+            # Just use the first SN model for testing
+            MODEL = next(iter(SN_MODELS))
+            n = n_runs + 1
+
+            # Build (post-processed) EXTRA_COLUMNS into hdf5 for tests
+            EXTRA_COLUMNS = {}
+            for star_i in (1, 2):
+                for qty in (
+                    "state", "SN_type", "f_fb", "mass", "spin",
+                    "m_disk_accreted", "m_disk_radiated",
+                    "CO_interpolation_class", "M4", "mu4",
+                    "h1_mass_ej", "he4_mass_ej"
+                ):
+                    EXTRA_COLUMNS[f"S{star_i}_{MODEL}_{qty}"] = np.array([np.nan] * n, 
+                                                                        dtype="<f8")
+
+                # Writer expects CO_type rather than state
+                EXTRA_COLUMNS[f"S{star_i}_{MODEL}_CO_type"] = \
+                    EXTRA_COLUMNS.pop(f"S{star_i}_{MODEL}_state")
+
+                for qty in ("CO_type", "SN_type", "CO_interpolation_class"):
+                    EXTRA_COLUMNS[f"S{star_i}_{MODEL}_{qty}"] = np.array(["None"] * n, 
+                                                                        dtype="S70")
+
+            sn_data = np.rec.fromarrays(
+                EXTRA_COLUMNS.values(),
+                names=[name.replace(f"{MODEL}_", "") for name in EXTRA_COLUMNS],
+            )
+
+            SN_MODELS_group.create_dataset(MODEL, data=sn_data)
+
+            for key, value in get_SN_MODEL(MODEL).items():
+                SN_MODELS_group[MODEL].attrs[key] = value
+
+        # other things
         hdf5_file.attrs["config"] = json.dumps(str(dict(Grid.config)))
         rel_paths = np.array(MESA_paths, dtype=H5_STRING)
         hdf5_file.create_dataset("relative_file_paths", data=rel_paths)
+
     return path
 
 

--- a/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
+++ b/posydon/unit_tests/_helper_functions_for_tests/psygrid.py
@@ -313,7 +313,7 @@ def get_PSyGrid(dir_path, idx, binary_history, star_history, profile,\
                     "CO_interpolation_class", "M4", "mu4",
                     "h1_mass_ej", "he4_mass_ej"
                 ):
-                    EXTRA_COLUMNS[f"S{star_i}_{MODEL}_{qty}"] = np.array([np.nan] * n, 
+                    EXTRA_COLUMNS[f"S{star_i}_{MODEL}_{qty}"] = np.array([np.nan] * n,
                                                                         dtype="<f8")
 
                 # Writer expects CO_type rather than state
@@ -321,7 +321,7 @@ def get_PSyGrid(dir_path, idx, binary_history, star_history, profile,\
                     EXTRA_COLUMNS.pop(f"S{star_i}_{MODEL}_state")
 
                 for qty in ("CO_type", "SN_type", "CO_interpolation_class"):
-                    EXTRA_COLUMNS[f"S{star_i}_{MODEL}_{qty}"] = np.array(["None"] * n, 
+                    EXTRA_COLUMNS[f"S{star_i}_{MODEL}_{qty}"] = np.array(["None"] * n,
                                                                         dtype="S70")
 
             sn_data = np.rec.fromarrays(

--- a/posydon/unit_tests/grids/test_post_processing.py
+++ b/posydon/unit_tests/grids/test_post_processing.py
@@ -637,7 +637,7 @@ class TestFunctions:
         with h5py.File(grid_path, 'r') as f:
             assert list(f['grid/SN_MODELS'].keys()).count(MODEL) == 1, (
                 "SN_MODEL dataset duplicated after second write")
-            
+
 
         # do some last tests, edge cases and things
         grid3 = PSyGrid()
@@ -666,5 +666,3 @@ class TestFunctions:
 
         totest.add_post_processed_quantities(grid3, list(grid3.MESA_dirs),
                                              EXTRA_COLUMNS)
-
-

--- a/posydon/unit_tests/grids/test_post_processing.py
+++ b/posydon/unit_tests/grids/test_post_processing.py
@@ -587,6 +587,11 @@ class TestFunctions:
             for qty in ['CO_type', 'SN_type', 'CO_interpolation_class']:
                 EXTRA_COLUMNS[f'S{star_i}_{MODEL}_{qty}'] = ['None'] * n
 
+        # add a column without SN_MODEL prefix for testing
+        #EXTRA_COLUMNS['test_other_column'] = np.arange(n, dtype=np.float64)
+        # add a unicode string column for testing
+        #grid.final_values['unicode_column'] = np.array(['a'] * n, dtype='U70')
+
         totest.add_post_processed_quantities(grid, list(grid.MESA_dirs),
                                              EXTRA_COLUMNS)
 
@@ -632,3 +637,34 @@ class TestFunctions:
         with h5py.File(grid_path, 'r') as f:
             assert list(f['grid/SN_MODELS'].keys()).count(MODEL) == 1, (
                 "SN_MODEL dataset duplicated after second write")
+            
+
+        # do some last tests, edge cases and things
+        grid3 = PSyGrid()
+        grid3.load(grid_path)
+        # test presence of a column other than SN data in EXTRA_COLUMNS
+        EXTRA_COLUMNS['other_column'] = np.arange(n, dtype=np.float64)
+        # case where extras has a column that also exists in final_values
+        EXTRA_COLUMNS['age'] = np.arange(n, dtype=np.float64)
+        # case where final_values needs no conversion from unicode to bytes
+        # (we convert it here, beforehand)
+        new_dtype = []
+        final_values = np.array(grid3.final_values)
+        for field in final_values.dtype.names:
+            dt = final_values.dtype[field]
+            if dt.kind == "U":
+                new_dtype.append((field, "S70"))
+            else:
+                new_dtype.append((field, dt))
+        grid3.final_values = final_values.astype(new_dtype)
+
+        # test case where grid is missing the final_values dataset
+        grid3._reload_hdf5_file(writeable=True)
+        if 'final_values' in grid3.hdf5['grid']:
+            del grid3.hdf5['grid']['final_values']
+        grid3._reload_hdf5_file(writeable=False)
+
+        totest.add_post_processed_quantities(grid3, list(grid3.MESA_dirs),
+                                             EXTRA_COLUMNS)
+
+

--- a/posydon/unit_tests/grids/test_post_processing.py
+++ b/posydon/unit_tests/grids/test_post_processing.py
@@ -48,7 +48,8 @@ class TestElements:
                     'calculate_Patton20_values_at_He_depl',\
                     'check_state_of_star', 'combine_TF12', 'copy', 'np',\
                     'post_process_grid', 'print_CC_quantities', 'tqdm',\
-                    'get_SN_MODEL'}
+                    'get_SN_MODEL', 'H5_REC_STR_DTYPE', 'h5py',\
+                    'recfunctions'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\
@@ -529,10 +530,7 @@ class TestFunctions:
                                             test_PSyGrid, single_star=True,\
                                             verbose=True)
 
-    def test_add_post_processed_quantities(self, grid, monkeypatch):
-        def mock_add_column(colname, array, where="final_values",\
-                            overwrite=True):
-            self.newcolumns[colname] = array
+    def test_add_post_processed_quantities(self, grid):
         # missing argument
         with raises(TypeError, match="missing 3 required positional "\
                                      +"arguments: 'grid', "\
@@ -547,17 +545,90 @@ class TestFunctions:
         with raises(ValueError, match="EXTRA_COLUMNS do not follow the "\
                                       +"correct order of grid!"):
             totest.add_post_processed_quantities(grid, ["Unit"], None)
-        # examples: nothing to add
+        # examples: nothing to add — should be a no-op
         totest.add_post_processed_quantities(grid, ["Test"], {})
         assert grid.final_values is None
-        # examples: add columns
-        with monkeypatch.context() as mp:
-            mp.setattr(grid, "add_column", mock_add_column)
-            EXTRA_COLUMNS = {'test_state': ["unit"], 'test_type': ["test"],\
-                             'test_class': ["unittest"], 'mt_history': [""],\
-                             'value': [1.0], 'values': [0.0, 1.0]}
-            self.newcolumns = {}
-            totest.add_post_processed_quantities(grid, ["Test"], EXTRA_COLUMNS)
-            for k,v in EXTRA_COLUMNS.items():
-                for i in range(len(v)):
-                    assert self.newcolumns[k][i] == v[i]
+
+    def test_add_post_processed_quantities_sn_schema(self, grid_path,
+                                                      binary_history,
+                                                      star_history, profile):
+        """SN columns land in /grid/SN_MODELS, not in final_values."""
+        import h5py
+
+        from posydon.grids.psygrid import PSyGrid
+        from posydon.grids.SN_MODELS import SN_MODELS, get_SN_MODEL
+
+        # Use just the first SN model to keep the test fast.
+        MODEL = list(SN_MODELS.keys())[0]
+
+        grid = PSyGrid()
+        grid.load(grid_path)
+        n = grid.n_runs + 1  # total entries including run0
+
+        # Build minimal SN EXTRA_COLUMNS for one model.
+        sn_val = np.nan
+        sn_str = b'None'
+        str_dtype = np.dtype('S70')
+        EXTRA_COLUMNS = {}
+        for star_i in (1, 2):
+            for qty in ['state', 'SN_type', 'f_fb', 'mass', 'spin',
+                        'm_disk_accreted', 'm_disk_radiated',
+                        'CO_interpolation_class', 'M4', 'mu4',
+                        'h1_mass_ej', 'he4_mass_ej']:
+                col = f'S{star_i}_{MODEL}_{qty}'
+                EXTRA_COLUMNS[col] = [sn_val] * n
+        # Rename state → CO_type as the writer expects.
+        for star_i in (1, 2):
+            old = f'S{star_i}_{MODEL}_state'
+            new = f'S{star_i}_{MODEL}_CO_type'
+            EXTRA_COLUMNS[new] = EXTRA_COLUMNS.pop(old)
+        # Make string columns actual strings so dtype detection works.
+        for star_i in (1, 2):
+            for qty in ['CO_type', 'SN_type', 'CO_interpolation_class']:
+                EXTRA_COLUMNS[f'S{star_i}_{MODEL}_{qty}'] = ['None'] * n
+
+        totest.add_post_processed_quantities(grid, list(grid.MESA_dirs),
+                                             EXTRA_COLUMNS)
+
+        # Re-open the HDF5 to inspect the schema.
+        with h5py.File(grid_path, 'r') as f:
+            # SN columns must be absent from final_values.
+            fv_names = f['grid/final_values'].dtype.names
+            assert not any('SN_MODEL' in nm for nm in fv_names), (
+                "SN_MODEL columns found in final_values")
+
+            # SN_MODELS group must exist with a dataset for the model.
+            assert 'SN_MODELS' in f['grid'], "SN_MODELS group missing"
+            assert MODEL in f['grid/SN_MODELS'], f"{MODEL} dataset missing"
+
+            ds = f[f'grid/SN_MODELS/{MODEL}']
+            short_names = ds.dtype.names
+
+            # Short names must not contain the model name.
+            for nm in short_names:
+                assert MODEL not in nm, (
+                    f"Model name found in short field name: {nm}")
+
+            # Short names for string fields should be there.
+            assert 'S1_CO_type' in short_names
+            assert 'S1_SN_type' in short_names
+            # Full names must NOT be present.
+            assert f'S1_{MODEL}_CO_type' not in short_names
+
+            # Attrs must contain the model's mechanism.
+            model_params = get_SN_MODEL(MODEL)
+            for key in model_params:
+                assert key in ds.attrs, f"Attr {key!r} missing from dataset"
+
+            # dtype of string field should be bytes (S-dtype) in HDF5.
+            assert ds.dtype['S1_CO_type'].kind == 'S', (
+                "S1_CO_type not stored as bytes in HDF5")
+
+        # Overwrite semantics: calling again should not error or duplicate.
+        grid2 = PSyGrid()
+        grid2.load(grid_path)
+        totest.add_post_processed_quantities(grid2, list(grid2.MESA_dirs),
+                                             EXTRA_COLUMNS)
+        with h5py.File(grid_path, 'r') as f:
+            assert list(f['grid/SN_MODELS'].keys()).count(MODEL) == 1, (
+                "SN_MODEL dataset duplicated after second write")

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -1037,6 +1037,14 @@ class TestPSyGrid:
                 if "run" in key:
                     del hdf5_file[f"/grid/{key}/"]
         return path
+    
+    @fixture
+    def grid_path_sne_data(self, tmp_path, binary_history, star_history,\
+                           profile):
+        path = get_simple_PSyGrid(tmp_path, 6, binary_history, star_history,\
+                                  profile, add_SN_MODELS=True)
+        
+        return path
 
     # test the PSyGrid class
     def test_init(self, PSyGrid, monkeypatch):
@@ -2002,7 +2010,7 @@ class TestPSyGrid:
             assert test_run.psygrid == PSyGrid
             assert test_run.index == i
 
-    def test_get_pandas_initial_final(self, PSyGrid, grid_path):
+    def test_get_pandas_initial_final(self, PSyGrid, grid_path, grid_path_sne_data):
         assert isroutine(PSyGrid.get_pandas_initial_final)
         with raises(AttributeError, match="'NoneType' object has no "\
                                           +"attribute 'dtype'"):
@@ -2030,6 +2038,11 @@ class TestPSyGrid:
             assert np.array_equal(PSyGrid.final_values[key],\
                                   np.array(test_df["final_"+key]),\
                                   equal_nan=allow_nan)
+            
+            # test case where grid has SNe model data
+            sne_grid = totest.PSyGrid()
+            sne_grid.load(grid_path_sne_data)
+            test_df = sne_grid.get_pandas_initial_final()
 
     def test_len(self, PSyGrid):
         assert isroutine(PSyGrid.__len__)
@@ -2653,6 +2666,14 @@ class TestPSyRunView:
     def PSyRunView(self, PSyGrid):
         # initialize an instance of the class with defaults
         return totest.PSyRunView(PSyGrid, 0)
+    
+    @fixture
+    def grid_path_sne_data(self, tmp_path, binary_history, star_history,\
+                           profile):
+        path = get_simple_PSyGrid(tmp_path, 1, binary_history, star_history,\
+                                  profile, add_SN_MODELS=True)
+        
+        return path
 
     # test the PSyRunView class
     def test_init(self, PSyRunView, PSyGrid):
@@ -2725,36 +2746,17 @@ class TestPSyRunView:
                    +f"'{PSyRunView.psygrid.filepath}' at key "\
                    +f"'{PSyRunView._hdf5_key()}'" == PSyRunView.__str__()
 
-    def test_get_SN_data(self, PSyGrid, tmp_path, binary_history,
-                         star_history, profile):
+    def test_get_SN_data(self, grid_path_sne_data):
         """PSyRunView.get_SN_data returns per-model SN dict or None."""
         import h5py as _h5py
 
         from posydon.grids.psygrid import H5_REC_STR_DTYPE
 
         MODEL = 'SN_MODEL_v2_01'
-        path = get_simple_PSyGrid(tmp_path, 99, binary_history, star_history,
-                                  profile)
-
-        # Inject a minimal SN_MODELS group into the HDF5 file.
-        n_rows = 3  # get_simple_PSyGrid creates 2 runs + run0 = 3 entries
-        str_dtype = np.dtype(H5_REC_STR_DTYPE.replace('U', 'S'))
-        sn_data = np.rec.fromarrays(
-            [np.array(['BH', 'None', 'NS'], dtype=str).astype(str_dtype),
-             np.array(['CCSN', 'None', 'CCSN'], dtype=str).astype(str_dtype),
-             np.array([0.1, np.nan, 0.2]),
-             np.array([10.0, np.nan, 8.0])],
-            names=['S1_CO_type', 'S1_SN_type', 'S1_f_fb', 'S1_mass'],
-        )
-        with _h5py.File(path, 'a') as f:
-            grp = f['grid'].require_group('SN_MODELS')
-            if MODEL in grp:
-                del grp[MODEL]
-            grp.create_dataset(MODEL, data=sn_data)
 
         # Load grid and verify SN_MODELS dict is populated.
         test_grid = totest.PSyGrid()
-        test_grid.load(path)
+        test_grid.load(grid_path_sne_data)
         assert isinstance(test_grid.SN_MODELS, dict)
         assert MODEL in test_grid.SN_MODELS
 

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -1037,13 +1037,13 @@ class TestPSyGrid:
                 if "run" in key:
                     del hdf5_file[f"/grid/{key}/"]
         return path
-    
+
     @fixture
     def grid_path_sne_data(self, tmp_path, binary_history, star_history,\
                            profile):
         path = get_simple_PSyGrid(tmp_path, 6, binary_history, star_history,\
                                   profile, add_SN_MODELS=True)
-        
+
         return path
 
     # test the PSyGrid class
@@ -2038,7 +2038,7 @@ class TestPSyGrid:
             assert np.array_equal(PSyGrid.final_values[key],\
                                   np.array(test_df["final_"+key]),\
                                   equal_nan=allow_nan)
-            
+
             # test case where grid has SNe model data
             sne_grid = totest.PSyGrid()
             sne_grid.load(grid_path_sne_data)
@@ -2666,13 +2666,13 @@ class TestPSyRunView:
     def PSyRunView(self, PSyGrid):
         # initialize an instance of the class with defaults
         return totest.PSyRunView(PSyGrid, 0)
-    
+
     @fixture
     def grid_path_sne_data(self, tmp_path, binary_history, star_history,\
                            profile):
         path = get_simple_PSyGrid(tmp_path, 1, binary_history, star_history,\
                                   profile, add_SN_MODELS=True)
-        
+
         return path
 
     # test the PSyRunView class

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -87,7 +87,7 @@ class TestElements:
                     'keep_till_central_abundance_He_C', 'np',\
                     'orbital_separation_from_period', 'os', 'pd', 'plot1D',\
                     'plot2D', 'read_EEP_data_file', 'read_MESA_data_file',\
-                    'read_initial_values', 'scrub', 'tqdm'}
+                    'read_initial_values', 'scrub', 'rfn', 'tqdm'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\
@@ -1040,7 +1040,7 @@ class TestPSyGrid:
 
     # test the PSyGrid class
     def test_init(self, PSyGrid, monkeypatch):
-        def mock_load(self, filepath=None):
+        def mock_load(self, filepath=None, lazy=True):
             return filepath
         assert isroutine(PSyGrid.__init__)
         # check that the instance is of correct type and all code in the
@@ -2724,3 +2724,56 @@ class TestPSyRunView:
             assert f"View of the run {i} in the file "\
                    +f"'{PSyRunView.psygrid.filepath}' at key "\
                    +f"'{PSyRunView._hdf5_key()}'" == PSyRunView.__str__()
+
+    def test_get_SN_data(self, PSyGrid, tmp_path, binary_history,
+                         star_history, profile):
+        """PSyRunView.get_SN_data returns per-model SN dict or None."""
+        import h5py as _h5py
+
+        from posydon.grids.psygrid import H5_REC_STR_DTYPE
+
+        MODEL = 'SN_MODEL_v2_01'
+        path = get_simple_PSyGrid(tmp_path, 99, binary_history, star_history,
+                                  profile)
+
+        # Inject a minimal SN_MODELS group into the HDF5 file.
+        n_rows = 3  # get_simple_PSyGrid creates 2 runs + run0 = 3 entries
+        str_dtype = np.dtype(H5_REC_STR_DTYPE.replace('U', 'S'))
+        sn_data = np.rec.fromarrays(
+            [np.array(['BH', 'None', 'NS'], dtype=str).astype(str_dtype),
+             np.array(['CCSN', 'None', 'CCSN'], dtype=str).astype(str_dtype),
+             np.array([0.1, np.nan, 0.2]),
+             np.array([10.0, np.nan, 8.0])],
+            names=['S1_CO_type', 'S1_SN_type', 'S1_f_fb', 'S1_mass'],
+        )
+        with _h5py.File(path, 'a') as f:
+            grp = f['grid'].require_group('SN_MODELS')
+            if MODEL in grp:
+                del grp[MODEL]
+            grp.create_dataset(MODEL, data=sn_data)
+
+        # Load grid and verify SN_MODELS dict is populated.
+        test_grid = totest.PSyGrid()
+        test_grid.load(path)
+        assert isinstance(test_grid.SN_MODELS, dict)
+        assert MODEL in test_grid.SN_MODELS
+
+        # Check that get_SN_run_data returns the correct dict.
+        row = test_grid.get_SN_run_data(0, MODEL)
+        assert isinstance(row, dict)
+        assert 'S1_CO_type' in row
+        # The value should be a Python str after dtype conversion.
+        assert isinstance(row['S1_CO_type'], str)
+
+        # Check unknown model returns None.
+        assert test_grid.get_SN_run_data(0, 'not_a_model') is None
+
+        # Check via PSyRunView.get_SN_data.
+        view = test_grid[0]
+        row_via_view = view.get_SN_data(MODEL)
+        assert row_via_view is not None
+        assert row_via_view['S1_CO_type'] == row['S1_CO_type']
+
+        # Unknown model via view also returns None.
+        assert view.get_SN_data('not_a_model') is None
+        test_grid.close()

--- a/posydon/unit_tests/utils/test_gridutils.py
+++ b/posydon/unit_tests/utils/test_gridutils.py
@@ -9,6 +9,8 @@ import posydon.utils.gridutils as totest
 
 # import the module which will be tested
 from posydon.grids.lazy_hdf import LazyHDF5
+from posydon.grids.psygrid import PSyGrid
+from posydon.unit_tests._helper_functions_for_tests.psygrid import get_PSyGrid
 
 # aliases
 np = totest.np
@@ -23,6 +25,23 @@ from pytest import approx, fixture, raises, warns
 
 from posydon.utils.posydonwarning import MissingFilesWarning
 
+@fixture
+def star_history():
+    # a temporary star history for testing
+    return np.array([(1.0, 0.2), (1.0e+2, 0.9), (1.0e+3, 0.2)],\
+                    dtype=[('star_age', '<f8'), ('center_he4', '<f8')])
+
+@fixture
+def binary_history():
+    # a temporary binary history for testing
+    return np.array([(1.0, 1.0), (1.1, 1.0e+2), (1.2, 1.0e+3)],\
+                    dtype=[('period_days', '<f8'), ('age', '<f8')])
+
+@fixture
+def profile():
+    # a temporary profile for testing
+    return np.array([(2.0, 1.0e+3), (1.1, 1.0e+2), (0.1, 1.0)],\
+                    dtype=[('mass', '<f8'), ('radius', '<f8')])
 
 # define test classes collecting several test functions
 class TestElements:
@@ -374,8 +393,37 @@ class TestFunctions:
             test_file.write("TEST INI SECTION 2&\n")
             test_file.write("test_empty = ''\n")
         return path
+    
+    @fixture
+    def psygrid(self, tmp_path, binary_history, star_history, profile):
+        # A PSyGrid object for testing
+        grid_path = get_PSyGrid(tmp_path, 1, binary_history, 
+                           star_history, profile, add_SN_MODELS=True)
+        return PSyGrid(grid_path)
 
     # test functions
+    def test_get_grid_column(self, psygrid):
+        # missing argument
+        with raises(TypeError, match="missing 2 required positional "\
+                                     +"arguments: 'grid' and 'key'"):
+            totest._get_grid_column()
+        # bad input
+        with raises(AttributeError, match = "'NoneType' object has no attribute 'final_values'"):
+            totest._get_grid_column(None, 'age')
+        with raises(TypeError, match = "'int' object is not subscriptable"):
+            totest._get_grid_column(psygrid, 0)
+        with raises(KeyError, match = "Column '' not found in final_values or SN_MODELS"):
+            totest._get_grid_column(psygrid, "")
+
+        # test getting a normal column
+        column_data = totest._get_grid_column(psygrid, 'age')
+        assert np.array_equal(column_data, psygrid.final_values['age'],
+                              equal_nan=True)
+        
+        # test getting a SN column
+        column_data = totest._get_grid_column(psygrid, 'S1_SN_MODEL_v2_01_CO_type')
+        assert np.array_equal(column_data, psygrid.SN_MODELS['SN_MODEL_v2_01']['S1_CO_type'])
+
     def test_join_lists(self):
         # missing argument
         with raises(TypeError, match="missing 2 required positional "\

--- a/posydon/unit_tests/utils/test_gridutils.py
+++ b/posydon/unit_tests/utils/test_gridutils.py
@@ -37,7 +37,7 @@ class TestElements:
                     '__authors__', '__builtins__',\
                     '__cached__', '__doc__', '__file__', '__loader__',\
                     '__name__', '__package__', '__spec__', 'add_field',\
-                    'clean_inlist_file', 'LazyHDF5',\
+                    'clean_inlist_file', '_get_grid_column', 'LazyHDF5',\
                     'convert_output_to_table', 'find_index_nearest_neighbour',\
                     'find_nearest', 'fix_He_core', 'get_cell_edges',\
                     'get_final_proposed_points', 'get_new_grid_name', 'gzip',\

--- a/posydon/unit_tests/utils/test_gridutils.py
+++ b/posydon/unit_tests/utils/test_gridutils.py
@@ -25,6 +25,7 @@ from pytest import approx, fixture, raises, warns
 
 from posydon.utils.posydonwarning import MissingFilesWarning
 
+
 @fixture
 def star_history():
     # a temporary star history for testing
@@ -393,11 +394,11 @@ class TestFunctions:
             test_file.write("TEST INI SECTION 2&\n")
             test_file.write("test_empty = ''\n")
         return path
-    
+
     @fixture
     def psygrid(self, tmp_path, binary_history, star_history, profile):
         # A PSyGrid object for testing
-        grid_path = get_PSyGrid(tmp_path, 1, binary_history, 
+        grid_path = get_PSyGrid(tmp_path, 1, binary_history,
                            star_history, profile, add_SN_MODELS=True)
         return PSyGrid(grid_path)
 
@@ -419,7 +420,7 @@ class TestFunctions:
         column_data = totest._get_grid_column(psygrid, 'age')
         assert np.array_equal(column_data, psygrid.final_values['age'],
                               equal_nan=True)
-        
+
         # test getting a SN column
         column_data = totest._get_grid_column(psygrid, 'S1_SN_MODEL_v2_01_CO_type')
         assert np.array_equal(column_data, psygrid.SN_MODELS['SN_MODEL_v2_01']['S1_CO_type'])

--- a/posydon/utils/gridutils.py
+++ b/posydon/utils/gridutils.py
@@ -23,6 +23,33 @@ __authors__ = [
 ]
 
 
+def _get_grid_column(grid, key):
+    """Return a column array sourced from final_values or SN_MODELS datasets.
+
+    SN model columns (e.g. 'S1_SN_MODEL_v2_01_CO_type') are stored with
+    stripped short names ('S1_CO_type') inside per-model SN datasets.
+    This helper transparently routes to the correct source.
+
+    Parameters
+    ----------
+    grid : PSyGrid
+    key : str
+        Full column name (e.g. 'S1_SN_MODEL_v2_01_CO_type').
+
+    Returns
+    -------
+    np.ndarray
+    """
+    if key in grid.final_values.dtype.names:
+        return np.array(grid.final_values[key])
+    for model_name, ds in grid.SN_MODELS.items():
+        infix = f'{model_name}_'
+        prefix_len = 3  # len('S1_') == len('S2_')
+        if key[prefix_len:prefix_len + len(infix)] == infix:
+            short = key[:prefix_len] + key[prefix_len + len(infix):]
+            return np.array(ds[short])
+    raise KeyError(f"Column {key!r} not found in final_values or SN_MODELS")
+
 def join_lists(A, B):
     """Make a joint list of A and B without elements already in A and keeping
     the order.

--- a/posydon/utils/gridutils.py
+++ b/posydon/utils/gridutils.py
@@ -107,6 +107,8 @@ def fix_He_core(history):
     return history
 
 
+# TODO: replace with numpy.lib.recfunctions?
+# allows adding multiple fields to a structured array as well. (more efficient probably?)
 def add_field(a, descr):
     """Return a new array that is like `a`, but has additional fields.
 

--- a/posydon/visualization/interpolation.py
+++ b/posydon/visualization/interpolation.py
@@ -9,6 +9,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from posydon.interpolation.IF_interpolation import _get_grid_column
+
 
 class EvaluateIFInterpolator:
     """ Class that is helpful for evaluating interpolation performance
@@ -43,8 +45,10 @@ class EvaluateIFInterpolator:
 
         iv = np.array(self.test_grid.initial_values[self.in_keys].tolist(),
                       dtype=float) # initial values
-        fv = np.array(self.test_grid.final_values[self.out_keys].tolist(),
-                      dtype=float) # final values
+        fv = np.column_stack([
+            np.asarray(_get_grid_column(self.test_grid, key), dtype=float)
+            for key in self.out_keys
+        ]) # final values
         ic = self.test_grid.final_values["interpolation_class"] # final values
 
         ivalid_inds = np.where(
@@ -76,7 +80,10 @@ class EvaluateIFInterpolator:
 
         for key, value in c.items():
 
-            labels = self.cfv[key]
+            if key in self.cfv.dtype.names:
+                labels = self.cfv[key]
+            else:
+                labels = _get_grid_column(self.test_grid, key)[cvalid_inds]
 
             classes = self.__find_labels(key)
 

--- a/posydon/visualization/plot2D.py
+++ b/posydon/visualization/plot2D.py
@@ -19,9 +19,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from posydon.interpolation.IF_interpolation import _get_grid_column
 from posydon.utils.constants import Zsun
-from posydon.utils.gridutils import add_field
+from posydon.utils.gridutils import _get_grid_column, add_field
 from posydon.utils.posydonwarning import Pwarn
 from posydon.visualization.combine_TF import combine_TF12
 from posydon.visualization.plot_defaults import (

--- a/posydon/visualization/plot2D.py
+++ b/posydon/visualization/plot2D.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from posydon.interpolation.IF_interpolation import _get_grid_column
 from posydon.utils.constants import Zsun
 from posydon.utils.gridutils import add_field
 from posydon.utils.posydonwarning import Pwarn
@@ -741,7 +742,7 @@ class plot2D(object):
         elif 'relative_change' in self.z_var_str:
             key = self.z_var_str.split('relative_change_')[1]
             relative_change_key = (
-                (old_final_values[key] - old_initial_values[key])
+                (_get_grid_column(self.psygrid, key) - old_initial_values[key])
                 / old_initial_values[key])
             new_final_values = add_field(old_final_values,
                                          [(self.z_var_str, "<f8")])
@@ -986,9 +987,11 @@ class plot2D(object):
             # read final values from final_values
             else:
                 if self.log10_z:
-                    self.z_var = np.log10(self.final_values[self.z_var_str])
+                    self.z_var = np.log10(
+                        _get_grid_column(self.psygrid, self.z_var_str))
                 else:
-                    self.z_var = self.final_values[self.z_var_str]
+                    self.z_var = _get_grid_column(
+                        self.psygrid, self.z_var_str)
 
         # take the z_var at oRLO
         else:

--- a/posydon/visualization/plot2D.py
+++ b/posydon/visualization/plot2D.py
@@ -967,7 +967,7 @@ class plot2D(object):
             elif self.binary_history:
                 final_values = []
                 for run in self.psygrid:
-                    # failed runs are stored as signle values or None
+                    # failed runs are stored as single values or None
                     # and not arrays
                     if run.binary_history is None:
                         final_values.append(np.nan)
@@ -1005,7 +1005,7 @@ class plot2D(object):
                     else:
                         raise ValueError(
                             "wrong selected_star_history_for_z_var")
-                    # failed runs are stored as signle values or None
+                    # failed runs are stored as single values or None
                     # and not arrays
                     if history is None:
                         values.append(np.nan)
@@ -1033,7 +1033,7 @@ class plot2D(object):
             elif self.binary_history:
                 values = []
                 for run in self.psygrid:
-                    # failed runs are stored as signle values or None
+                    # failed runs are stored as single values or None
                     # and not arrays
                     if run.binary_history is None:
                         values.append(np.nan)


### PR DESCRIPTION
We've likely hit the maximum number of columns in a single HDF5 dataset for the `final_values` with the increased number of SN models.
As such, we need to separate out the SN_models to make sure we will not hit the same issue in the future. 

I've rewritten the `add_post_processed_quantities` to:
1. Use the faster `recfuntions` from `numpy` to add all columns in one go to the structure array, `final_values`. Originally, we were writing one column at the time. deleting the existing `final_values` and then writing the new `final_values` with 1 extra column. Repeating this process for each new column we wanted to add (several hundred times given the number of SN_MODELS we have). This is a massive I/O overhead.
2. Store the `SN_MODELS` in their own group (`grid/SN_MODELS`) in the HDF5 file. Each SN_MODEL has its own dataset + in the attrs the parameters for the model are stored.
3. `grid.compression_args` are not actually populated correctly when loading a grid with `grid(path_to_file)` as such when writing the "new" datasets to file, they were uncompressed. 

> [!CAUTION]
> Bullet point 3 means that **the `final_values` dataset in the release dataset are uncompressed!**. I verified that this is the case!

<details>
<summary>Screenshots of uncompressed final_values</summary>

`final_values`
<img width="376" height="252" alt="image" src="https://github.com/user-attachments/assets/b3ac0652-d6d4-4180-bb4d-3647a76ae356" />

`initial_values`
<img width="339" height="395" alt="image" src="https://github.com/user-attachments/assets/5de6dc60-b750-4ab7-97e5-08d99dcf939c" />
</details>

This PR now also changes the `IF_interpolator` and `interpolator`. If required, the `IF_interpolator` now uses `_get_grid_column` to get the `final_values` or `SN_models`. It only does this if it looped over the SN_MODELS before. 

Changes to `step_MESA` is just how we access the `SN_MODEL` data. It should be checked if this stored everything exactly the same as before. `step_SN` is able to access this correctly at the moment.


> [!WARNING]
> There is a bug I noticed with the `LazyHDF5` accessing the HDF5 file when adding a column. When adding something to the HDF5f file, we reload the file, e.g. `grid._reload_hdf5_file()`. This invalidates the `LazyHDF5` linking. We should fix this, if possible, but not in this PR.