### PR TITLE
Set compression arguments in grid initialization

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1543,6 +1543,9 @@ class PSyGrid:
         else:
             raise KeyError("Some runs are missing from the HDF5 grid.")
 
+        # set the compression arguments
+        self._make_compression_args()
+        
         self._say("\tDone.")
 
     def close(self):

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1545,7 +1545,7 @@ class PSyGrid:
 
         # set the compression arguments
         self._make_compression_args()
-        
+
         self._say("\tDone.")
 
     def close(self):


### PR DESCRIPTION
Add compression arguments setup in the grid initialization. Otherwise they're never loaded