### PR TITLE
fix: prevent internal save in plot_popsyn_over_grid_slice when save_fig=False

### DIFF
--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -250,7 +250,10 @@ def plot_popsyn_over_grid_slice(pop, grid_type, met_Zsun,
             PLOT_PROPERTIES['title'] += f'\n {channel}'
 
         # change the file name for the plot
-        PLOT_PROPERTIES['fname'] = tmp_fname % bin_center
+        if save_fig:
+            PLOT_PROPERTIES['fname'] = tmp_fname % bin_center
+        else:
+            PLOT_PROPERTIES['fname'] = None
 
         # change size of the figure for properties
         if prop is not None:


### PR DESCRIPTION
## PR Title
fix: prevent internal save in plot_popsyn_over_grid_slice when save_fig=False

## PR Body
`plot_popsyn_over_grid_slice` sets `PLOT_PROPERTIES["fname"]` unconditionally on line 253, even when the caller passes `save_fig=False`. The outer function correctly skips its own `plt.savefig` but the filename survives into `plot_grid_slice` and then into `plot2D.__call__`, which saves whenever `self.fname is not None`. So `save_fig=False` only suppresses the outermost save, not the one happening inside `plot2D`.

This is a problem if the internal save triggers a matplotlib render path the user's environment can't handle (e.g. LaTeX text rendering without the right packages installed, which is what hit the reporter of #852).

The fix wraps the `PLOT_PROPERTIES["fname"]` assignment in an `if save_fig` check and sets it to `None` in the `else` branch. This means `plot2D` sees no filename and skips its internal `fig.savefig`. The `save_fig=True` path is unchanged — `fname` gets set exactly as before.

Verified by tracing the code path: with `save_fig=False`, `PLOT_PROPERTIES["fname"]` is now `None` when it reaches `grid.plot2D(..., **PLOT_PROPERTIES)`, so `plot2D.__call__` skips the save. With `save_fig=True`, the existing filename logic runs identically.

Closes #852

## Before submitting
[09:59:02] Checked for CLA and CONTRIBUTING docs — none found. No PR template. No competing PRs on this issue. Repo has no CLAassistant bot.
[09:59:15] Checked CONTRIBUTING.md, CLA, recent community PRs — repo is academic (BSD-3-Clause), maintainers labelled this good-first-issue + bug within a day. No CLA barrier.
[10:00:26] Real bug, well-reported with full traceback and root cause identified by the issue author.
[10:14:20] Diff stays exactly inside SCOPE. One file, one function, four lines. No refactors, no drive-by edits. save_fig=True path untouched. Board (Priya + Dave) APPROVE.
[10:14:31] Strategically: POSYDON is a real academic codebase (UNIGE + Northwestern), actively maintained, 29 releases. Two maintainers labelled good-first-issue + bug within a day — clear signal. Diversifying into scientific Python complements the dev-tooling portfolio.

## Diff
diff --git a/posydon/visualization/plot_pop.py b/posydon/visualization/plot_pop.py
index 4905861..cfd596e 100644
--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -250,7 +250,10 @@ def plot_popsyn_over_grid_slice(pop, grid_type, met_Zsun,
             PLOT_PROPERTIES['title'] += f'\n {channel}'
 
         # change the file name for the plot
-        PLOT_PROPERTIES['fname'] = tmp_fname % bin_center
+        if save_fig:
+            PLOT_PROPERTIES['fname'] = tmp_fname % bin_center
+        else:
+            PLOT_PROPERTIES['fname'] = None
 
         # change size of the figure for properties
         if prop is not None:
PR_PLAN_READY: outbox/pr-POSYDON-code-POSYDON-20260618-094652.md  BRANCH: fix/852-save-fig-internal-save  BASE: main
