### PR TITLE
[enhancement] save the reweighting population parameters to file

### DIFF
--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -1974,16 +1974,19 @@ class TransientPopulation(Population):
             if '/' + base_path in store.keys():
                 Pwarn("Model weights already exist! Overwriting them!", "OverwriteWarning")
                 del store[base_path]
-                if '/' + base_path + '_simulation_parameters' in store.keys():
-                    del store[base_path + '_simulation_parameters']
+                if '/' + base_path + '_population_parameters' in store.keys():
+                    del store[base_path + '_population_parameters']
 
             store.put(base_path, model_weights)
-            store.put(base_path + '_simulation_parameters', pd.DataFrame([simulation_parameters]))
+            tmp_df = pd.DataFrame()
+            for k, v in population_parameters.items():
+                tmp_df[k] = [v]
+            store.put(base_path + '_population_parameters', tmp_df)
 
         return model_weights
 
-    def simulation_parameters(self, model_weights_identifier):
-        """Retrieve the simulation parameters used to calculate model weights.
+    def model_weight_parameters(self, model_weights_identifier):
+        """Retrieve the population parameters used to calculate model weights.
 
         Parameters
         ----------
@@ -1995,9 +1998,10 @@ class TransientPopulation(Population):
         dict
             The simulation parameters used when calculating the model weights.
         """
-        key = 'transients/' + self.transient_name + '/weights/' + model_weights_identifier + '_simulation_parameters'
+        key = 'transients/' + self.transient_name + '/weights/' + model_weights_identifier + '_population_parameters'
         with pd.HDFStore(self.filename, mode="r") as store:
-            return store[key].iloc[0].to_dict()
+            tmp_df = store[key]
+            return {c: tmp_df[c].iloc[0] for c in tmp_df.columns}
 
     def model_weights(self, model_weights_identifier=None):
         """Retrieve the model weights of the transient population.
@@ -2020,7 +2024,7 @@ class TransientPopulation(Population):
             with pd.HDFStore(self.filename, mode="r") as store:
                 keys = [k.split('/')[-1] for k in store.keys()
                         if k.startswith('/transients/' + self.transient_name + '/weights/')
-                        and not k.endswith('_simulation_parameters')]
+                        and not k.endswith('_population_parameters')]
                 model_weights = pd.concat([store['transients/' + self.transient_name + '/weights/' + key] for key in keys], axis=1)
         else:
             with pd.HDFStore(self.filename, mode="r") as store:

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -1902,6 +1902,7 @@ class TransientPopulation(Population):
             The model weights of the transient population and have units of Msun^-1.
         """
         if population_parameters is None:
+            # TODO: have a centralised location for the default population parameters?
             population_parameters = {'number_of_binaries': 1000000,
                                     'binary_fraction_scheme':'const',
                                     'binary_fraction_const':0.7,
@@ -1996,7 +1997,7 @@ class TransientPopulation(Population):
         Returns
         -------
         dict
-            The simulation parameters used when calculating the model weights.
+            The population parameters used when calculating the model weights.
         """
         key = 'transients/' + self.transient_name + '/weights/' + model_weights_identifier + '_population_parameters'
         with pd.HDFStore(self.filename, mode="r") as store:

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -1969,13 +1969,35 @@ class TransientPopulation(Population):
             model_weights[model_weights_identifier] = (
                 model_weights.index.to_series().map(weight_mapping).fillna(model_weights[model_weights_identifier]))
 
+        base_path = 'transients/' + self.transient_name + '/weights/' + model_weights_identifier
         with pd.HDFStore(self.filename, mode="a") as store:
-            if '/transients/' + self.transient_name + '/weights/' + model_weights_identifier in store.keys():
+            if '/' + base_path in store.keys():
                 Pwarn("Model weights already exist! Overwriting them!", "OverwriteWarning")
-                del store['transients/' + self.transient_name + '/weights/' + model_weights_identifier]
+                del store[base_path]
+                if '/' + base_path + '_simulation_parameters' in store.keys():
+                    del store[base_path + '_simulation_parameters']
 
-            store.put('transients/' + self.transient_name + '/weights/' + model_weights_identifier, model_weights)
+            store.put(base_path, model_weights)
+            store.put(base_path + '_simulation_parameters', pd.DataFrame([simulation_parameters]))
+
         return model_weights
+
+    def simulation_parameters(self, model_weights_identifier):
+        """Retrieve the simulation parameters used to calculate model weights.
+
+        Parameters
+        ----------
+        model_weights_identifier : str
+            Identifier for the model weights.
+
+        Returns
+        -------
+        dict
+            The simulation parameters used when calculating the model weights.
+        """
+        key = 'transients/' + self.transient_name + '/weights/' + model_weights_identifier + '_simulation_parameters'
+        with pd.HDFStore(self.filename, mode="r") as store:
+            return store[key].iloc[0].to_dict()
 
     def model_weights(self, model_weights_identifier=None):
         """Retrieve the model weights of the transient population.
@@ -1996,7 +2018,9 @@ class TransientPopulation(Population):
 
         if model_weights_identifier is None:
             with pd.HDFStore(self.filename, mode="r") as store:
-                keys = [k.split('/')[-1] for k in store.keys() if k.startswith('/transients/' + self.transient_name + '/weights/')]
+                keys = [k.split('/')[-1] for k in store.keys()
+                        if k.startswith('/transients/' + self.transient_name + '/weights/')
+                        and not k.endswith('_simulation_parameters')]
                 model_weights = pd.concat([store['transients/' + self.transient_name + '/weights/' + key] for key in keys], axis=1)
         else:
             with pd.HDFStore(self.filename, mode="r") as store:


### PR DESCRIPTION
This PR saves the population parameters used for reweighting to the hdf5 file.

Additionally this adds a function to load these parameters based on the `model_weight_identifier` stored in the file. 