### PR TITLE
[fix] Flatten time array in DTD plotting

### DIFF
--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -2244,7 +2244,7 @@ class TransientPopulation(Population):
         model_weights = self.model_weights(model_weights_identifier).to_numpy().flatten()
 
         if metallicity is None:
-            time = self.select(columns=["time"]).values
+            time = self.select(columns=["time"]).to_numpy().flatten()
             time = time * 1e6  # yr
 
             # Create histogram with model weights
@@ -2256,7 +2256,7 @@ class TransientPopulation(Population):
                 raise ValueError("The metallicity is not present in the population!")
 
             time_df = self.select(columns=['metallicity', 'time'])
-            time = time_df[time_df['metallicity'] == metallicity].drop(columns=['metallicity']).values
+            time = time_df[time_df['metallicity'] == metallicity].drop(columns=['metallicity']).to_numpy().flatten()
             time = time * 1e6  # yr
 
             # Get weights for the specific metallicity


### PR DESCRIPTION
Flattens the time array in the DTD plotting, as suggested in the issue #856, closing it