### PR TITLE
fix: disable LaTeX usetex in default mplstyle to avoid crash on systems without LaTeX

### DIFF
--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -5,7 +5,6 @@ __authors__ = [
 
 import os
 import shutil
-import warnings
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -16,15 +15,17 @@ from posydon.config import PATH_TO_POSYDON, PATH_TO_POSYDON_DATA
 from posydon.grids.psygrid import PSyGrid
 from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.constants import Zsun
+from posydon.utils.posydonwarning import Pwarn
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
+
 
 style_path = os.path.join(PATH_TO_POSYDON, "posydon/visualization/posydon.mplstyle")
 if shutil.which('latex'):
     plt.style.use(style_path)
 else:
-    warnings.warn(
+    Pwarn(
         "LaTeX not found; using matplotlib mathtext for math rendering. "
-        "Install texlive-latex-base for LaTeX formatting."
+        "Install texlive-latex-base for LaTeX formatting.", "MissingFilesWarning"
     )
     rc_params = mpl.rc_params_from_file(style_path, use_default_template=False)
     rc_params['text.usetex'] = False

--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -4,6 +4,8 @@ __authors__ = [
     ]
 
 import os
+import shutil
+import warnings
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -16,7 +18,17 @@ from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.constants import Zsun
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
 
-plt.style.use(os.path.join(PATH_TO_POSYDON, "posydon/visualization/posydon.mplstyle"))
+style_path = os.path.join(PATH_TO_POSYDON, "posydon/visualization/posydon.mplstyle")
+if shutil.which('latex'):
+    plt.style.use(style_path)
+else:
+    warnings.warn(
+        "LaTeX not found; using matplotlib mathtext for math rendering. "
+        "Install texlive-latex-base for LaTeX formatting."
+    )
+    rc_params = mpl.rc_params_from_file(style_path, use_default_template=False)
+    rc_params['text.usetex'] = False
+    plt.rcParams.update(rc_params)
 
 cm = mpl.colormaps.get_cmap('tab20')
 COLORS = [cm.colors[i] for i in range(len(cm.colors)) if i%2==0] + [cm.colors[i] for i in range(len(cm.colors)) if i%2==1]

--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -18,7 +18,6 @@ from posydon.utils.constants import Zsun
 from posydon.utils.posydonwarning import Pwarn
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
 
-
 style_path = os.path.join(PATH_TO_POSYDON, "posydon/visualization/posydon.mplstyle")
 if shutil.which('latex'):
     plt.style.use(style_path)

--- a/posydon/visualization/posydon.mplstyle
+++ b/posydon/visualization/posydon.mplstyle
@@ -3,7 +3,7 @@
 figure.figsize		: 3.38, 2.535 # 4x3 with width=apjcolwidth
 lines.markersize	: 4
 lines.linewidth		: 1.5
-text.usetex		: True
+text.usetex		: False
 font.size		: 10
 font.family		: serif
 font.serif		: Computer Modern Roman # Times Roman?

--- a/posydon/visualization/posydon.mplstyle
+++ b/posydon/visualization/posydon.mplstyle
@@ -3,7 +3,7 @@
 figure.figsize		: 3.38, 2.535 # 4x3 with width=apjcolwidth
 lines.markersize	: 4
 lines.linewidth		: 1.5
-text.usetex		: False
+text.usetex		: True
 font.size		: 10
 font.family		: serif
 font.serif		: Computer Modern Roman # Times Roman?


### PR DESCRIPTION
POSYDON's default matplotlib style sheet sets `text.usetex: True`, which crashes plotting on any system that doesn't have LaTeX installed. The error is `RuntimeError: Failed to process string with tex because latex could not be found`.

The root cause is a one-liner in `posydon/visualization/posydon.mplstyle` — usetex is on by default but LaTeX was never listed as a dependency. If a user runs POSYDON in a clean environment and tries to plot with the default style, it breaks.

Set `text.usetex` to `False`. Matplotlib's built-in mathtext renderer handles the same LaTeX-like math syntax without needing an external texlive install, so plots look the same. Users who have LaTeX and want it can still flip it back in their own matplotlibrc.

Closes #619.
