### PR TITLE
fix: flatten time array in TransientPopulation.plot_delay_time_distribution (closes #856)

### DIFF
--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -2244,7 +2244,7 @@ class TransientPopulation(Population):
         model_weights = self.model_weights(model_weights_identifier).to_numpy().flatten()
 
         if metallicity is None:
-            time = self.select(columns=["time"]).values
+            time = self.select(columns=["time"]).to_numpy().flatten()
             time = time * 1e6  # yr
 
             # Create histogram with model weights


### PR DESCRIPTION
## What
`TransientPopulation.plot_delay_time_distribution()` raised a ValueError when calling `np.histogram()` with model weights because the `time` array obtained via `.select().values` was 2D (shape (N,1)) while `model_weights` was 1D (shape (N,)).

## Fix
Changed the line:
```python
time = self.select(columns=["time"]).values
```
to:
```python
time = self.select(columns=["time"]).to_numpy().flatten()
```
This ensures the `time` array is 1D, matching the shape of the weights.

Closes #856