### PR TITLE
Warn before downloading data

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -300,7 +300,7 @@ class MesaGridStep:
         if not (os.path.exists(self.grid_name.replace('%d','0')) or
                 os.path.exists(self.grid_name.replace('_%d',''))):
             Pwarn(f"While loading interpolators, unable to find {self.grid_name}."
-                   "Attempting to download the data from Zenodo.", 
+                   "Attempting to download the data from Zenodo.",
                    "MissingFilesWarning")
             data_download()
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -299,6 +299,9 @@ class MesaGridStep:
         # Check if interpolation files exist
         if not (os.path.exists(self.grid_name.replace('%d','0')) or
                 os.path.exists(self.grid_name.replace('_%d',''))):
+            Pwarn(f"While loading interpolators, unable to find {self.grid_name}."
+                   "Attempting to download the data from Zenodo.", 
+                   "MissingFilesWarning")
             data_download()
 
         if self.verbose:


### PR DESCRIPTION
If `$PATH_TO_POSYDON` data is malformed or an expected file is missing there, our code will try to download data from Zenodo to remedy the issue.

This adds a warning that says which file triggered this response and the fact that this is happening before doing so.