### PR TITLE
DCO step comparison tolerance

### DIFF
--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -69,16 +69,16 @@ class _SBrentqDenseOutput:
         result = np.empty((4, len(tau_target)))
         tau_lo = self.sol(self.s_lo)[1]
         tau_hi = self.sol(self.s_hi)[1]
-        
-        # An absolute tolerance for floating-point comparisons scaled 
+
+        # An absolute tolerance for floating-point comparisons scaled
         # with |tau_hi| when tau_hi >= 1, otherwise 1
         # (so the tolerance does not become unrealistically small).
         eps = 100 * np.finfo(float).eps * max(1.0, abs(tau_hi))
-        
+
         for i, tau in enumerate(tau_target):
             f_lo = tau_lo - tau
             f_hi = tau_hi - tau
-            
+
             if f_lo * f_hi > 0:
                 print(
                     f"FAILED at i={i}: "

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -79,16 +79,27 @@ class _SBrentqDenseOutput:
         # (At least 1.0 scale so the tolerance does not become
         #  unreasonably small.)
         tau_scale = max(1.0, abs(tau_lo), abs(tau_hi))
-        eps = 100 * np.finfo(float).eps * tau_scale
+        # Treat endpoint residuals smaller than eps as zero to guard
+        # against floating-point roundoff near the integration endpoints.
+        tol = 1e4
+        eps = tol * np.finfo(float).eps * tau_scale
 
         for i, tau in enumerate(tau_target):
 
-            # check f(a) lower bound
-            if abs(tau - tau_lo) <= eps:
+            # function values at integration boundaries
+            fa = tau_lo - tau
+            fb = tau_hi - tau
+
+            # check lower endpoint
+            if abs(fa) <= eps:
                 s_star = self.s_lo
-            # check f(b) upper bound
-            elif abs(tau - tau_hi) <= eps:
+            # check upper endpoint
+            elif abs(fb) <= eps:
                 s_star = self.s_hi
+            elif fa * fb > 0:
+                raise ValueError(f"Requested tau={tau:.17e} outside interval "
+                                 f"[{tau_lo:.17e}, {tau_hi:.17e}].")
+            # else root find for a solution
             else:
                 s_star = brentq(
                     lambda s: self.sol(s)[1] - tau,

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -68,21 +68,21 @@ class _SBrentqDenseOutput:
         # convert physical time to dimensionless time
         tau_target = (t_phys - self.t0_phys) / self.t_scale
         result = np.empty((4, len(tau_target)))
-        # tau range to be covered by root-finding, 
+        # tau range to be covered by root-finding,
         # tau(s_lo) and tau(s_hi)
         tau_lo = self.sol(self.s_lo)[1]
         tau_hi = self.sol(self.s_hi)[1]
-        
-        # An absolute tolerance for floating-point comparisons 
-        # based on machine floating-point precision, scaled 
+
+        # An absolute tolerance for floating-point comparisons
+        # based on machine floating-point precision, scaled
         # to |tau_hi|, |tau_lo|, or 1.0, whichever is largest.
-        # (At least 1.0 scale so the tolerance does not become 
+        # (At least 1.0 scale so the tolerance does not become
         #  unreasonably small.)
         tau_scale = max(1.0, abs(tau_lo), abs(tau_hi))
         eps = 100 * np.finfo(float).eps * tau_scale
-        
+
         for i, tau in enumerate(tau_target):
-            
+
             # check f(a) lower bound
             if abs(tau - tau_lo) <= eps:
                 s_star = self.s_lo

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -66,15 +66,38 @@ class _SBrentqDenseOutput:
     def __call__(self, t_phys):
         t_phys = np.atleast_1d(np.asarray(t_phys, dtype=float))
         tau_target = (t_phys - self.t0_phys) / self.t_scale
+        result = np.empty((4, len(tau_target)))
+        tau_lo = self.sol(self.s_lo)[1]
+        tau_hi = self.sol(self.s_hi)[1]
+        
+        # An absolute tolerance for floating-point comparisons scaled 
+        # with |tau_hi| when tau_hi >= 1, otherwise 1
+        # (so the tolerance does not become unrealistically small).
+        eps = 100 * np.finfo(float).eps * max(1.0, abs(tau_hi))
+        
+        for i, tau in enumerate(tau_target):
+            f_lo = tau_lo - tau
+            f_hi = tau_hi - tau
+            
+            if f_lo * f_hi > 0:
+                print(
+                    f"FAILED at i={i}: "
+                    f"tau_target={tau}, "
+                    f"f_lo={f_lo}, "
+                    f"f_hi={f_hi}"
+                )
 
-        n = len(tau_target)
-        result = np.empty((4, n))
-        for i in range(n):
-            s_star = brentq(
-                lambda s: self.sol(s)[1] - tau_target[i],
-                self.s_lo, self.s_hi,
-                xtol=1e-14, rtol=1e-14,
-            )
+            if abs(tau - tau_lo) <= eps:
+                s_star = self.s_lo
+            elif abs(tau - tau_hi) <= eps:
+                s_star = self.s_hi
+            else:
+                s_star = brentq(
+                    lambda s: self.sol(s)[1] - tau,
+                    self.s_lo,
+                    self.s_hi,
+                    xtol=1e-14,
+                    rtol=1e-14)
             raw = self.sol(s_star)          # [l, tau, omega_sec, omega_pri]
             alpha = np.exp(-s_star)
             result[0, i] = alpha * self.a0_Rsun   # separation (Rsun)
@@ -85,6 +108,7 @@ class _SBrentqDenseOutput:
         if result.shape[1] == 1:
             return result[:, 0]
         return result
+
 
 
 class DoubleCO(detached_step):

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -65,30 +65,28 @@ class _SBrentqDenseOutput:
 
     def __call__(self, t_phys):
         t_phys = np.atleast_1d(np.asarray(t_phys, dtype=float))
+        # convert physical time to dimensionless time
         tau_target = (t_phys - self.t0_phys) / self.t_scale
         result = np.empty((4, len(tau_target)))
+        # tau range to be covered by root-finding, 
+        # tau(s_lo) and tau(s_hi)
         tau_lo = self.sol(self.s_lo)[1]
         tau_hi = self.sol(self.s_hi)[1]
         
-        # An absolute tolerance for floating-point comparisons scaled 
-        # with |tau_hi| when tau_hi >= 1, otherwise 1
-        # (so the tolerance does not become unrealistically small).
-        eps = 100 * np.finfo(float).eps * max(1.0, abs(tau_hi))
+        # An absolute tolerance for floating-point comparisons 
+        # based on machine floating-point precision, scaled 
+        # to |tau_hi|, |tau_lo|, or 1.0, whichever is largest.
+        # (At least 1.0 scale so the tolerance does not become 
+        #  unreasonably small.)
+        tau_scale = max(1.0, abs(tau_lo), abs(tau_hi))
+        eps = 100 * np.finfo(float).eps * tau_scale
         
         for i, tau in enumerate(tau_target):
-            f_lo = tau_lo - tau
-            f_hi = tau_hi - tau
             
-            if f_lo * f_hi > 0:
-                print(
-                    f"FAILED at i={i}: "
-                    f"tau_target={tau}, "
-                    f"f_lo={f_lo}, "
-                    f"f_hi={f_hi}"
-                )
-
+            # check f(a) lower bound
             if abs(tau - tau_lo) <= eps:
                 s_star = self.s_lo
+            # check f(b) upper bound
             elif abs(tau - tau_hi) <= eps:
                 s_star = self.s_hi
             else:


### PR DESCRIPTION
In step DCO, when translating $\tau(s)$ back to physical time, we use the `brentq` root-finding method to solve the equation $f(s) = \tau(s)−\tau_{target} = 0$ within a bounded interval $s\in\left[s_{lo},s_{hi}\right]$. The `brentq` method requires that the function values at the interval endpoints (i.e., $f(s_{lo})$ and $f(s_{hi})$ ) have opposite signs, to guarantee that a root exists in that interval.

If $f(s_{lo})$ and $f(s_{hi})$ have the same sign, then this error occurs:

```python
ValueError: f(a) and f(b) must have different signs
```

In DCO evolution, this error can occur when $\tau_{target}$ is numerically very close to an endpoint value, such as $\tau(s_{lo})$. In this case, the desired root is at (or extremely close to) the integration boundary. Due to floating point rounding, $\tau_{target}$ may lie slightly outside the range of $\tau(s_{lo})$ and $\tau(s_{hi})$, causing $f(s_{lo})$ and $f(s_{hi})$ to have the same sign even though $\tau_{target}$ is effectively at the boundary.

For example, if $\tau_{target} = -10.000000000000001$, $\tau(s_{lo}) = -10$, and $\tau(s_{hi}) = -5$. The method `brentq` will see 

$$f(s_{lo}) = \tau(s_{lo}) - \tau_{target} = 10^{-15}$$

and

$$f(s_{hi}) = \tau(s_{hi}) - \tau_{target} \approx 5$$

The method then sees $f(s_{lo})$ and $f(s_{hi})$ as having the same sign, `brentq` can not bracket a root, and fails.

To handle this case, the endpoint values are checked explicitly before calling `brentq`. We define a tolerance $\epsilon$ that is based on floating point precision and if

$$|\tau_{target}-\tau(s_{lo}) | < \epsilon$$

or

$$|\tau_{target}-\tau(s_{hi}) | < \epsilon$$

the corresponding boundary value $s_{lo}$ or $s_{hi}$ is used directly instead of calling `brentq`.

>[!NOTE]
> A real example triggering this error has these values:
> `f_lo = -1.4447446103803316e-05, f_hi = -1.6940658945086007e-21`
> `tau_target[i] = 1.4447446103803316e-05, tau_lo = 0.0, tau_hi = 1.4447446103803314e-05`
