### PR TITLE
Add missing argument for `.ini` file when running binary test suite

### DIFF
--- a/dev-tools/run_test_suite.sh
+++ b/dev-tools/run_test_suite.sh
@@ -143,6 +143,7 @@ for Z in $METALLICITIES; do
         --output "$OUTPUT_FILE" \
         --branch "$BRANCH" \
         --sha "$ACTUAL_SHA" \
+        --ini "$TEST_INI" \
         2>&1 | tee "$LOG_FILE"
     EXIT_CODE=${PIPESTATUS[0]}
 


### PR DESCRIPTION
When running the binary test suite, unique `.ini` files are created per comparison branch. However, the path to this unique file was not being passed. Now it is.