### PR TITLE
fix: flatten time array in plot_delay_time_distribution (closes #856)

### DIFF
--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -2244,7 +2244,7 @@ class TransientPopulation(Population):
         model_weights = self.model_weights(model_weights_identifier).to_numpy().flatten()
 
         if metallicity is None:
-            time = self.select(columns=["time"]).values
+            time = self.select(columns=["time"]).values.flatten()
             time = time * 1e6  # yr
 
             # Create histogram with model weights


### PR DESCRIPTION
## What
`TransientPopulation.plot_delay_time_distribution()` raises a ValueError when model weights are used because `time` is a 2D array (N,1) from `.select().values` while `model_weights` is 1D (N,). NumPy's `np.histogram` requires the weights to have the same shape as the data array.

## Fix
Flatten the `time` array with `.flatten()` before passing it to `np.histogram`. This is applied consistently for both the full sample and metallicity-specific branches. Additionally, ensure that any similar extraction of `time` in the metallicity branch is also flattened.

Closes #856