### PR TITLE
Added a missing comma in population_params_default.ini preventing two columns from being saved

### DIFF
--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -663,7 +663,7 @@
                   'natal_kick_velocity',
                   'natal_kick_azimuthal_angle',
                   'natal_kick_polar_angle',
-                  'natal_kick_mean_anomaly'
+                  'natal_kick_mean_anomaly',
                   'spin_orbit_tilt_first_SN',
                   'spin_orbit_tilt_second_SN',
                   'f_fb',


### PR DESCRIPTION
`population_params_default.ini` is missing a comma, which prevents `natal_kick_mean_anomaly` and `spin_orbit_tilt_first_SN` from being returned by default for S1. 

```
[SingleStar_1_output]

...

'natal_kick_polar_angle',
'natal_kick_mean_anomaly' <--- missing comma
'spin_orbit_tilt_first_SN',

```

This might be the largest PR of all time :P 