### PR TITLE
Remove VariableKey class

### DIFF
--- a/posydon/unit_tests/utils/test_configfile.py
+++ b/posydon/unit_tests/utils/test_configfile.py
@@ -24,7 +24,7 @@ from pytest import fixture, raises
 class TestElements:
     # check for objects, which should be an element of the tested module
     def test_dir(self):
-        elements = {'ConfigFile', 'VariableKey', '__authors__',\
+        elements = {'ConfigFile', '__authors__',\
                     '__builtins__', '__cached__', '__doc__', '__file__',\
                     '__loader__', '__name__', '__package__', '__spec__',\
                     'ast', 'configparser', 'copy', 'json', 'np', 'operator',\
@@ -49,9 +49,6 @@ class TestElements:
 
     def test_instance_parse_inifile(self):
         assert isroutine(totest.parse_inifile)
-
-    def test_instance_VariableKey(self):
-        assert isclass(totest.VariableKey)
 
 
 class TestFunctions:
@@ -310,7 +307,3 @@ class TestConfigFile:
     def test_len(self, ConfigFile_filled, test_entries):
         assert isroutine(ConfigFile_filled.__len__)
         assert len(ConfigFile_filled) == len(test_entries)
-
-
-#class TestVariableKey:
-#    # test the VariableKey class: looks to be not used as long as using python3

--- a/posydon/utils/configfile.py
+++ b/posydon/utils/configfile.py
@@ -258,12 +258,8 @@ def parse_inifile(inifile):
                                              _eval(node.right))
             elif isinstance(node, ast.List):
                 return [_eval(x) for x in node.elts]
-            elif isinstance(node, ast.Name): # pragma: no cover
-                # return regular string, since True/False/None are handled
-                # as ast.NameConstant in python3, not ast.Name
-                return node.id
             elif isinstance(node, ast.NameConstant):
-                # None, True, False are nameconstants in python3 but names in 2
+                # return True, False, or None
                 return node.value
             else:
                 raise Exception('Unsupported type {}'.format(node))

--- a/posydon/utils/configfile.py
+++ b/posydon/utils/configfile.py
@@ -259,19 +259,9 @@ def parse_inifile(inifile):
             elif isinstance(node, ast.List):
                 return [_eval(x) for x in node.elts]
             elif isinstance(node, ast.Name): # pragma: no cover
-                result = VariableKey(item=node)
-                constants_lookup = {
-                    'True': True,
-                    'False': False,
-                    'None': None,
-                }
-                value = constants_lookup.get(result.name, result,)
-                if type(value) == VariableKey:
-                    # return regular string
-                    return value.name
-                else:
-                    # return special string like True or False
-                    return value
+                # return regular string, since True/False/None are handled
+                # as ast.NameConstant in python3, not ast.Name
+                return node.id
             elif isinstance(node, ast.NameConstant):
                 # None, True, False are nameconstants in python3 but names in 2
                 return node.value
@@ -311,25 +301,3 @@ def parse_inifile(inifile):
     slurm = dictionary['slurm']
 
     return run_parameters, slurm, mesa_inlists, mesa_extras
-
-
-class VariableKey(object): # pragma: no cover
-    """A dictionary key which is a variable.
-
-    @ivar item: The variable AST object.
-    """
-
-    def __init__(self, item):
-        """Construct the object by giving a `name` to it."""
-        self.name = item.id
-
-    def __eq__(self, compare):
-        """Equality if the names are the same."""
-        return (
-            compare.__class__ == self.__class__
-            and compare.name == self.name
-        )
-
-    def __hash__(self):
-        """Allow hashing using the name of the variable."""
-        return hash(self.name)


### PR DESCRIPTION
The `utils/configfile.py` file contains the VariableKey class that does not work with python3 (See issue #464). 
Given that it's been in the codebase means that it never gets hit. See the issue for a more detailed description on why this can be removed.

This PR removes the class and the unit_tests for it.
This closes issue #464 .