### PR TITLE
Fix binary.event not being reset in InitiallySingleStep

### DIFF
--- a/posydon/binary_evol/DT/step_initially_single.py
+++ b/posydon/binary_evol/DT/step_initially_single.py
@@ -35,5 +35,5 @@ class InitiallySingleStep(IsolatedStep):
         if binary.state != "initially_single_star":
             raise AttributeError("sent to InitiallySingleStep without the binary.state being initially_single_star")
 
-        binary.event == None
+        binary.event = None
         super().__call__(binary)


### PR DESCRIPTION
When entering the initial single step, the binary.event should be set to `None`. 
Currently, the code compares `binary.event` against `None`, which does not seem to be the intended here.