### PR TITLE
Fix is_in_ball linear branch comparing x to itself

### DIFF
--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -2055,7 +2055,7 @@ def is_in_ball(x, x0, ux, log):
         w = (np.log10(x) > np.log10(x0) - d) & (np.log10(x) < np.log10(x0) + d)
     else:
         d = np.diff(ux)[0] / 2
-        w = (x > x - d) & (x < x + d)
+        w = (x > x0 - d) & (x < x0 + d)
     return w
 
 


### PR DESCRIPTION
The non-log branch of is_in_ball computed (x > x - d) & (x < x + d), which is always True for finite x, so slice selection in plot_mc_classifier selected all points regardless of the third coordinate. Compare against x0, which is done in the log=True branch above.