### PR TITLE
Fix Single He star inlist layering

### DIFF
--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -323,14 +323,15 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
             with open(special_single_star_user_inlist, 'wb') as f:
                 f.write(b'&controls\n\n')
                 f.write('\t{0} = {1}\n'.format("x_logical_ctrl(1)", ".true.").encode('utf-8'))
-
                 f.write(b'\n\n')
-
                 f.write(b"""
-        / ! end of star1_controls namelist
+                         / ! end of star1_controls namelist
+                         """)
+            if 'star1_controls_user' not in mesa_inlists or mesa_inlists['star1_controls_user'] is None:
+                mesa_inlists['star1_controls_user'] = []
 
-        """)
-            mesa_inlists['star1_controls_special'] = special_single_star_user_inlist
+            mesa_inlists['star1_controls_user'].append(special_single_star_user_inlist)
+
         elif system_type == "CO-He_star" and mesa_inlists['single_star_grid']:
             inlists_location = '{0}/{1}/{2}/'.format(inlists_dir, 'r11701', system_type)
             print("Based on system_type {0} "
@@ -358,18 +359,15 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
             with open(special_single_star_user_inlist, 'wb') as f:
                 f.write(b'&controls\n\n')
                 f.write('\t{0} = {1}\n'.format("x_logical_ctrl(1)", ".true.").encode('utf-8'))
-
                 f.write(b'\n\n')
                 f.write(b"""
-        / ! end of star1_controls namelist
-
-        """)
+                         / ! end of star1_controls namelist
+                         """)
                 f.write(b'&star_job\n\n')
                 f.write(b"""
-        / / ! end of star_job namelist
-
-        """)
-            mesa_inlists['star1_controls_special'].append(special_single_star_user_inlist)
+                         / / ! end of star_job namelist
+                         """)
+            mesa_inlists['star1_controls_user'].append(special_single_star_user_inlist)
 
     # change back to where I was
     os.chdir(where_am_i_now)

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -345,8 +345,12 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
             # Find the user single star controls
             single_star_scenario = sorted(glob.glob(os.path.join(inlists_location, "star1_formation", "*step*")))
             print("These are the user inlists used in the single star grid: {0}".format(single_star_scenario))
-            mesa_inlists['star1_controls_user'] = single_star_scenario
-            mesa_inlists['star1_job_user'] = single_star_scenario
+            if 'star1_controls_user' not in mesa_inlists or mesa_inlists['star1_controls_user'] is None:
+                mesa_inlists['star1_controls_user'] = []
+            if 'star1_job_user' not in mesa_inlists or mesa_inlists['star1_job_user'] is None:
+                mesa_inlists['star1_job_user'] = []
+            mesa_inlists['star1_controls_user'].append(single_star_scenario)
+            mesa_inlists['star1_job_user'].append(single_star_scenario)
             print("You want a single star He grid, "
                   "this means that we need to make the inlist that will be used to evolve the system "
                   "and make sure we layer on the line "

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -327,9 +327,12 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
                 f.write(b"""
                          / ! end of star1_controls namelist
                          """)
+
+            # check if star1_controls_user exists already from .ini, if not, create it
             if 'star1_controls_user' not in mesa_inlists or mesa_inlists['star1_controls_user'] is None:
                 mesa_inlists['star1_controls_user'] = []
 
+            # always include this special inlist for single stars
             mesa_inlists['star1_controls_user'].append(special_single_star_user_inlist)
 
         elif system_type == "CO-He_star" and mesa_inlists['single_star_grid']:
@@ -345,10 +348,13 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
             # Find the user single star controls
             single_star_scenario = sorted(glob.glob(os.path.join(inlists_location, "star1_formation", "*step*")))
             print("These are the user inlists used in the single star grid: {0}".format(single_star_scenario))
+
+            # check if star1_controls_user, star1_job_user exists already from .ini, if not create it
             if 'star1_controls_user' not in mesa_inlists or mesa_inlists['star1_controls_user'] is None:
                 mesa_inlists['star1_controls_user'] = []
             if 'star1_job_user' not in mesa_inlists or mesa_inlists['star1_job_user'] is None:
                 mesa_inlists['star1_job_user'] = []
+            # extend always with star formation settings for single He star
             mesa_inlists['star1_controls_user'].extend(single_star_scenario)
             mesa_inlists['star1_job_user'].extend(single_star_scenario)
             print("You want a single star He grid, "
@@ -371,7 +377,10 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
                 f.write(b"""
                          / / ! end of star_job namelist
                          """)
+
+            # always include this special inlist for single stars
             mesa_inlists['star1_controls_user'].append(special_single_star_user_inlist)
+            mesa_inlists['star1_job_user'].append(special_single_star_user_inlist)
 
     # change back to where I was
     os.chdir(where_am_i_now)

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -349,8 +349,8 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
                 mesa_inlists['star1_controls_user'] = []
             if 'star1_job_user' not in mesa_inlists or mesa_inlists['star1_job_user'] is None:
                 mesa_inlists['star1_job_user'] = []
-            mesa_inlists['star1_controls_user'].append(single_star_scenario)
-            mesa_inlists['star1_job_user'].append(single_star_scenario)
+            mesa_inlists['star1_controls_user'].extend(single_star_scenario)
+            mesa_inlists['star1_job_user'].extend(single_star_scenario)
             print("You want a single star He grid, "
                   "this means that we need to make the inlist that will be used to evolve the system "
                   "and make sure we layer on the line "


### PR DESCRIPTION
The inlist layering in single star grids was modified in the past to avoid overwriting any provided `star1_controls_user`. However, that patch took an approach that was incompatible with subsequent star formation scenario inlist layering. In `construct_static_inlist`, 

```python
        for step in range(number_of_star1_formation_steps):
            star1_formation['step{0}'.format(step)] = {}
            star1_formation['step{0}'.format(step)]['inlist_file'] = os.path.join(working_directory, 'star1', 'inlist_step{0}'.format(step))
            for k, v in star1_formation_dictionary.items():
                star1_formation['step{0}'.format(step)][k] = v[step] if type(v) == list else v
```

will look for star formation settings in `mesa_inlist['star1_job_*']` and `mesa_inlist['star1_controls_*']`. The previous fix added star1_controls_special as a separate, single-item entry rather than adding the special inlist to the existing star1_controls_user sequence. As a result, the special inlist was not layered consistently with the star-formation scenario inlists, and the resulting sequence could be incomplete.

This PR instead keeps the existing star1_job_user and star1_controls_user dictionary items and removes the separate star1_controls_special entry. It prevents the original overwrite by modifying the line that caused the issue:

```python
    if system_type == "HMS-HMS" and mesa_inlists['single_star_grid']:
        ...
        mesa_inlists['star1_controls_user'] = special_single_star_user_inlist
```

changing this to

```python
        if system_type == "HMS-HMS" and mesa_inlists['single_star_grid']:
            ...
            if 'star1_controls_user' not in mesa_inlists or mesa_inlists['star1_controls_user'] is None:
                mesa_inlists['star1_controls_user'] = []

            mesa_inlists['star1_controls_user'].append(special_single_star_user_inlist)
```

This preserves any existing star-formation inlists while adding the special single-star control inlist, following the same layering approach already used for the CO-He_star scenario.