### PR TITLE
[fix] Strip 'v' from version in meta.yaml

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: "{{ name|lower }}"
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ GIT_DESCRIBE_TAG.lstrip('v') }}
 
 source:
   path: ..


### PR DESCRIPTION
Due to the presence of the "v" in the conda version v2.3.0 isn't picked up as the latest version. This removes the "v" from the version, such that the next conda version doesn't have the v in there.

The other option according to AI is to use: GIT_DESCRIBE_TAG_PEP440.
But I cannot find clear documentation on it (https://github.com/conda/conda-build/issues/5991)