### PR TITLE
force deeper checkout

### DIFF
--- a/.github/workflows/publish-to-anaconda.yml
+++ b/.github/workflows/publish-to-anaconda.yml
@@ -11,6 +11,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: publish-to-conda
       uses: POSYDON-code/publish_to_anaconda@v1.0.1


### PR DESCRIPTION
Somehow the GIT_DESCRIBE_TAG is not working, while it was working correctly on the last release.
Maybe this is because I re-released v2.3.0, and the git version checkout is confused by the version.

Or there's a github issue happening, since the publish of the website is also erroring...