### PR TITLE
Check for kwarg updates to `track_matcher` on reload

### DIFF
--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -503,9 +503,11 @@ class SimulationProperties:
 
         Returns
         -------
-        dict
-            The updated ``step_kwargs`` dictionary, containing a validated
-            ``metallicity`` entry and potentially a ``track_matcher`` object.
+        tuple
+            The step tuple containing the step function and the updated 
+            ``step_kwargs`` dictionary. This new step_kwargs contains a 
+            validated ``metallicity`` entry and potentially a 
+            ``track_matcher`` object.
 
         Notes
         -----
@@ -515,6 +517,9 @@ class SimulationProperties:
         for repeated `(metallicity, step_name)` combinations.
         """
         step_func, step_kwargs = step_tup
+        # copy these to track what was originally passed before adding defaults
+        # in case we need to update a TrackMatcher for a step, this method only
+        # cares about updating what it is told to, not everything.
         original_step_kwargs = step_kwargs.copy()
 
         # check/assign metallicity for the step
@@ -535,49 +540,125 @@ class SimulationProperties:
         if step_name in step_grid_map:
             step_kwargs['grid_path'] = step_grid_map[step_name]
 
-        # each metallicity/step combo could require
-        # a unique TrackMatcher, so check for that
-        matcher_key = (metallicity, step_name)
         if "track_matcher" in step_func.DEFAULT_KWARGS:
-            matcher_needed = matcher_key not in self.track_matchers
-            step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
-
-            if matcher_needed:
-                # Always just create a new TrackMatcher if it does not exist
-                self.create_track_matcher(metallicity, step_name, matcher_kwargs)
-
-            else:
-                track_matcher = self.track_matchers[matcher_key]
-                retrain = False
-                # subsequently check if any properties need to be updated,
-                # in case reloading for example
-                for k, v in matcher_kwargs.items():
-                    # only care to update kwargs actually passed via load_step
-                    if k in original_step_kwargs:
-                        do_update = track_matcher.kwargs[k] != original_step_kwargs[k]
-                        if do_update:
-                            setattr(track_matcher, k, matcher_kwargs[k])
-                            track_matcher.kwargs[k] = matcher_kwargs[k]
-                            if k in track_matcher.TRAINING_TRIGGERS:
-                                retrain = True
-                if retrain:
-                    updated_kwargs = track_matcher.kwargs
-                    self.create_track_matcher(metallicity, step_name, updated_kwargs)
-            # check for and delete any old TrackMatcher's this step has to save RAM
-            for mk in list(self.track_matchers):
-                this_met, this_stepn = mk
-                if this_met != metallicity and this_stepn == step_name:
-                    del self.track_matchers[mk]
-
-            if verbose:
-                kw_list = [f"\t{key}: {val}" for key, val in matcher_kwargs.items()]
-                print(f"matcher_kwargs: \n" + "\n".join(kw_list))
-            step_kwargs['track_matcher'] = self.track_matchers[matcher_key]
+            # each metallicity/step combo could require
+            # a unique TrackMatcher, so check for that
+            step_kwargs = self._check_track_matcher(metallicity,
+                                                    step_name, 
+                                                    step_kwargs,
+                                                    original_step_kwargs, 
+                                                    verbose)
 
         if "RNG" in step_func.DEFAULT_KWARGS:
             step_kwargs['RNG'] = RNG
 
-        return step_tup
+        return (step_func, step_kwargs)
+
+    def _check_track_matcher(self, metallicity, step_name, step_kwargs,
+                            original_step_kwargs, verbose=False):
+        """
+        Validate, create, update, and assign the TrackMatcher for an evolution step.
+
+        A unique TrackMatcher is maintained for each ``(metallicity, step_name)``
+        combination. If a TrackMatcher for the requested combination does not
+        already exist in this SimulationProperties, one is created using the 
+        supplied matcher-specific keyword arguments. If one already exists, 
+        its explicitly supplied properties are compared against the existing 
+        values and updated when necessary. If an updated property is one of the 
+        TrackMatcher's training triggers, the TrackMatcher is recreated so that 
+        it is retrained with the new settings.
+
+        TrackMatcher-specific keyword arguments are separated from the remaining
+        step keyword arguments using ``TrackMatcher.separate_kwargs``. The
+        resulting TrackMatcher instance is then added to ``step_kwargs`` under
+        the ``"track_matcher"`` key.
+
+        TrackMatchers for other metallicities associated with the same step are
+        removed after the requested matcher has been created or retrieved. This
+        limits the number of simultaneously stored TrackMatcher objects and
+        reduces memory usage.
+
+        Parameters
+        ----------
+        metallicity : float
+            Stellar metallicity associated with the evolutionary step. This value
+            is used together with ``step_name`` to identify the required
+            TrackMatcher.
+        step_name : str
+            Name of the evolutionary step for which the TrackMatcher is required.
+        step_kwargs : dict
+            Keyword arguments for the step. TrackMatcher-specific arguments are
+            separated from this dictionary and the resulting TrackMatcher instance
+            is added under the ``"track_matcher"`` key.
+        original_step_kwargs : dict
+            Copy of the keyword arguments originally supplied to the evolution step 
+            before defaults or other values were added. Only properties explicitly
+            present in this dictionary are considered when determining whether an
+            existing TrackMatcher needs to be updated.
+        verbose : bool, optional
+            If True, print the TrackMatcher keyword arguments used for the current
+            step.
+
+        Returns
+        -------
+        dict
+            The updated step keyword arguments containing the TrackMatcher-specific
+            arguments removed and the appropriate TrackMatcher instance assigned
+            to the ``"track_matcher"`` key.
+
+        Notes
+        -----
+        - TrackMatcher objects are stored in ``self.track_matchers`` using
+        ``(metallicity, step_name)`` as the key.
+        - GRIDInterpolator objects required by the TrackMatcher are created and
+        cached by ``create_track_matcher``.
+        - Existing TrackMatchers are reused when their explicitly supplied
+        configuration has not changed.
+        - If a training-triggering TrackMatcher property changes, the existing
+        matcher is recreated using the updated configuration.
+        - TrackMatchers for other metallicities but the same ``step_name`` are
+        deleted to conserve memory.
+        """
+
+        matcher_key = (metallicity, step_name)
+        matcher_needed = matcher_key not in self.track_matchers
+        step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
+
+        if matcher_needed:
+            # Always just create a new TrackMatcher if it does not exist
+            self.create_track_matcher(metallicity, step_name, matcher_kwargs)
+
+        else:
+            track_matcher = self.track_matchers[matcher_key]
+            retrain = False
+            # subsequently check if any properties need to be updated,
+            # in case reloading for example
+            for k, v in matcher_kwargs.items():
+                # only care to update kwargs actually passed via load_step
+                if k in original_step_kwargs:
+                    do_update = track_matcher.kwargs[k] != original_step_kwargs[k]
+                    if do_update:
+                        setattr(track_matcher, k, matcher_kwargs[k])
+                        track_matcher.kwargs[k] = matcher_kwargs[k]
+                        if k in track_matcher.TRAINING_TRIGGERS:
+                            retrain = True
+            if retrain:
+                updated_kwargs = track_matcher.kwargs
+                self.create_track_matcher(metallicity, step_name, updated_kwargs)
+        # check for and delete any old TrackMatcher's this step has to save RAM
+        for mk in list(self.track_matchers):
+            this_met, this_stepn = mk
+            if this_met != metallicity and this_stepn == step_name:
+                del self.track_matchers[mk]
+
+
+        if verbose:
+            kw_list = [f"\t{key}: {val}" for key, val in matcher_kwargs.items()]
+            print(f"matcher_kwargs: \n" + "\n".join(kw_list))
+        # reference ths TrackMatcher in this step's kwargs
+        step_kwargs['track_matcher'] = self.track_matchers[matcher_key]
+
+        return step_kwargs
 
     def create_track_matcher(self, metallicity, step_name, matcher_kwargs):
         """

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -541,11 +541,19 @@ class SimulationProperties:
             matcher_needed = matcher_key not in self.track_matchers
             original_step_kwargs = step_kwargs.copy()
             step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
+
+            # these matcher kwargs will trigger retraining the TrackMatcher
+            retrain_triggers = ["grid_Hrich", "grid_strippedHe", "path", "metallicity",
+                                "matching_method", "matching_tolerance", "matching_tolerance_hard",
+                                "list_for_matching_HMS", "list_for_matching_HeStar", 
+                                "list_for_matching_postMS", "list_for_matching_postHeMS"]
+
             if matcher_needed:
-                # create TrackMatcher if needed
+                # Always just create a new TrackMatcher if it does not exist
                 self.create_track_matcher(metallicity, step_name, matcher_kwargs)
 
             else:
+                retrain = False
                 # subsequently check if any properties need to be updated,
                 # in case reloading for example
                 for k, v in matcher_kwargs.items():
@@ -553,6 +561,11 @@ class SimulationProperties:
                     if k in original_step_kwargs:
                         setattr(self.track_matchers[matcher_key], k, matcher_kwargs[k])
                         self.track_matchers[matcher_key].kwargs[k] = matcher_kwargs[k]
+                        if k in retrain_triggers:
+                            retrain = True
+                if retrain:
+                    updated_kwargs = self.track_matchers[matcher_key].kwargs
+                    self.create_track_matcher(metallicity, step_name, updated_kwargs)
 
             if verbose:
                 kw_list = [f"\t{key}: {val}" for key, val in matcher_kwargs.items()]

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -546,7 +546,7 @@ class SimulationProperties:
                 self.create_track_matcher(metallicity, step_name, matcher_kwargs)
 
             else:
-                # subsequently check if any properties need to be updated, 
+                # subsequently check if any properties need to be updated,
                 # in case reloading for example
                 for k, v in matcher_kwargs.items():
                     # only care to update kwargs actually passed via load_step

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -563,6 +563,11 @@ class SimulationProperties:
                 if retrain:
                     updated_kwargs = track_matcher.kwargs
                     self.create_track_matcher(metallicity, step_name, updated_kwargs)
+            # check for and delete any old TrackMatcher's this step has to save RAM
+            for mk in list(self.track_matchers):
+                this_met, this_stepn = mk
+                if this_met != metallicity and this_stepn == step_name:
+                    del self.track_matchers[mk]
 
             if verbose:
                 kw_list = [f"\t{key}: {val}" for key, val in matcher_kwargs.items()]

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -655,7 +655,7 @@ class SimulationProperties:
             if this_met != metallicity and this_stepn == step_name:
                 del self.track_matchers[mk]
                 # delete associated cached grids to save RAM too,
-                # but only if no other TrackMatcher is using this 
+                # but only if no other TrackMatcher is using this
                 # metallicity. Otherwise, grid still needed.
                 other_steps_at_this_met = any(other_met == this_met
                                           for other_met, _ in self.track_matchers)

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -539,10 +539,18 @@ class SimulationProperties:
         matcher_key = (metallicity, step_name)
         if "track_matcher" in step_func.DEFAULT_KWARGS:
             matcher_needed = matcher_key not in self.track_matchers
+            step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
             if matcher_needed:
                 # create TrackMatcher if needed
-                step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
                 self.create_track_matcher(metallicity, step_name, matcher_kwargs)
+
+            else:
+                # subsequently check if any properties need to be updated, 
+                # in case reloading for example
+                for k, v in matcher_kwargs.items():
+                    # only care to update any new kwargs set differently from defaults
+                    if matcher_kwargs[k] != self.track_matchers[matcher_key].DEFAULT_KWARGS[k]:
+                        setattr(self.track_matchers[matcher_key], k, matcher_kwargs[k])
 
             if verbose:
                 kw_list = [f"\t{key}: {val}" for key, val in matcher_kwargs.items()]

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -545,7 +545,7 @@ class SimulationProperties:
             # these matcher kwargs will trigger retraining the TrackMatcher
             retrain_triggers = ["grid_Hrich", "grid_strippedHe", "path", "metallicity",
                                 "matching_method", "matching_tolerance", "matching_tolerance_hard",
-                                "list_for_matching_HMS", "list_for_matching_HeStar", 
+                                "list_for_matching_HMS", "list_for_matching_HeStar",
                                 "list_for_matching_postMS", "list_for_matching_postHeMS"]
 
             if matcher_needed:

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -654,6 +654,15 @@ class SimulationProperties:
             this_met, this_stepn = mk
             if this_met != metallicity and this_stepn == step_name:
                 del self.track_matchers[mk]
+                # delete associated cached grids to save RAM too,
+                # but only if no other TrackMatcher is using this 
+                # metallicity. Otherwise, grid still needed.
+                other_steps_at_this_met = any(other_met == this_met
+                                          for other_met, _ in self.track_matchers)
+
+                if not other_steps_at_this_met:
+                    del self.grids_Hrich[this_met]
+                    del self.grids_strippedHe[this_met]
 
 
         if verbose:

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -578,6 +578,10 @@ class SimulationProperties:
         limits the number of simultaneously stored TrackMatcher objects and
         reduces memory usage.
 
+        Note that in multi-metallicity runs, each metallicity is assigned to a 
+        unique BinaryPopulation, each of which has its own unique 
+        SimulationProperties at that given metallicity..
+
         Parameters
         ----------
         metallicity : float

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -552,6 +552,7 @@ class SimulationProperties:
                     # only care to update kwargs actually passed via load_step
                     if k in original_step_kwargs:
                         setattr(self.track_matchers[matcher_key], k, matcher_kwargs[k])
+                        self.track_matchers[matcher_key].kwargs[k] = matcher_kwargs[k]
 
             if verbose:
                 kw_list = [f"\t{key}: {val}" for key, val in matcher_kwargs.items()]

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -578,8 +578,8 @@ class SimulationProperties:
         limits the number of simultaneously stored TrackMatcher objects and
         reduces memory usage.
 
-        Note that in multi-metallicity runs, each metallicity is assigned to a 
-        unique BinaryPopulation, each of which has its own unique 
+        Note that in multi-metallicity runs, each metallicity is assigned to a
+        unique BinaryPopulation, each of which has its own unique
         SimulationProperties at that given metallicity..
 
         Parameters

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -547,18 +547,19 @@ class SimulationProperties:
                 self.create_track_matcher(metallicity, step_name, matcher_kwargs)
 
             else:
+                track_matcher = self.track_matchers[matcher_key]
                 retrain = False
                 # subsequently check if any properties need to be updated,
                 # in case reloading for example
                 for k, v in matcher_kwargs.items():
                     # only care to update kwargs actually passed via load_step
                     if k in original_step_kwargs:
-                        setattr(self.track_matchers[matcher_key], k, matcher_kwargs[k])
-                        self.track_matchers[matcher_key].kwargs[k] = matcher_kwargs[k]
-                        if k in self.track_matchers[matcher_key].TRAINING_TRIGGERS:
+                        setattr(track_matcher, k, matcher_kwargs[k])
+                        track_matcher.kwargs[k] = matcher_kwargs[k]
+                        if k in track_matcher.TRAINING_TRIGGERS:
                             retrain = True
                 if retrain:
-                    updated_kwargs = self.track_matchers[matcher_key].kwargs
+                    updated_kwargs = track_matcher.kwargs
                     self.create_track_matcher(metallicity, step_name, updated_kwargs)
 
             if verbose:

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -554,10 +554,12 @@ class SimulationProperties:
                 for k, v in matcher_kwargs.items():
                     # only care to update kwargs actually passed via load_step
                     if k in original_step_kwargs:
-                        setattr(track_matcher, k, matcher_kwargs[k])
-                        track_matcher.kwargs[k] = matcher_kwargs[k]
-                        if k in track_matcher.TRAINING_TRIGGERS:
-                            retrain = True
+                        do_update = track_matcher.kwargs[k] != original_step_kwargs[k]
+                        if do_update:
+                            setattr(track_matcher, k, matcher_kwargs[k])
+                            track_matcher.kwargs[k] = matcher_kwargs[k]
+                            if k in track_matcher.TRAINING_TRIGGERS:
+                                retrain = True
                 if retrain:
                     updated_kwargs = track_matcher.kwargs
                     self.create_track_matcher(metallicity, step_name, updated_kwargs)

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -539,6 +539,7 @@ class SimulationProperties:
         matcher_key = (metallicity, step_name)
         if "track_matcher" in step_func.DEFAULT_KWARGS:
             matcher_needed = matcher_key not in self.track_matchers
+            original_step_kwargs = step_kwargs.copy()
             step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
             if matcher_needed:
                 # create TrackMatcher if needed
@@ -548,8 +549,8 @@ class SimulationProperties:
                 # subsequently check if any properties need to be updated, 
                 # in case reloading for example
                 for k, v in matcher_kwargs.items():
-                    # only care to update any new kwargs set differently from defaults
-                    if matcher_kwargs[k] != self.track_matchers[matcher_key].DEFAULT_KWARGS[k]:
+                    # only care to update kwargs actually passed via load_step
+                    if k in original_step_kwargs:
                         setattr(self.track_matchers[matcher_key], k, matcher_kwargs[k])
 
             if verbose:

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -504,9 +504,9 @@ class SimulationProperties:
         Returns
         -------
         tuple
-            The step tuple containing the step function and the updated 
-            ``step_kwargs`` dictionary. This new step_kwargs contains a 
-            validated ``metallicity`` entry and potentially a 
+            The step tuple containing the step function and the updated
+            ``step_kwargs`` dictionary. This new step_kwargs contains a
+            validated ``metallicity`` entry and potentially a
             ``track_matcher`` object.
 
         Notes
@@ -544,9 +544,9 @@ class SimulationProperties:
             # each metallicity/step combo could require
             # a unique TrackMatcher, so check for that
             step_kwargs = self._check_track_matcher(metallicity,
-                                                    step_name, 
+                                                    step_name,
                                                     step_kwargs,
-                                                    original_step_kwargs, 
+                                                    original_step_kwargs,
                                                     verbose)
 
         if "RNG" in step_func.DEFAULT_KWARGS:
@@ -561,11 +561,11 @@ class SimulationProperties:
 
         A unique TrackMatcher is maintained for each ``(metallicity, step_name)``
         combination. If a TrackMatcher for the requested combination does not
-        already exist in this SimulationProperties, one is created using the 
-        supplied matcher-specific keyword arguments. If one already exists, 
-        its explicitly supplied properties are compared against the existing 
-        values and updated when necessary. If an updated property is one of the 
-        TrackMatcher's training triggers, the TrackMatcher is recreated so that 
+        already exist in this SimulationProperties, one is created using the
+        supplied matcher-specific keyword arguments. If one already exists,
+        its explicitly supplied properties are compared against the existing
+        values and updated when necessary. If an updated property is one of the
+        TrackMatcher's training triggers, the TrackMatcher is recreated so that
         it is retrained with the new settings.
 
         TrackMatcher-specific keyword arguments are separated from the remaining
@@ -591,7 +591,7 @@ class SimulationProperties:
             separated from this dictionary and the resulting TrackMatcher instance
             is added under the ``"track_matcher"`` key.
         original_step_kwargs : dict
-            Copy of the keyword arguments originally supplied to the evolution step 
+            Copy of the keyword arguments originally supplied to the evolution step
             before defaults or other values were added. Only properties explicitly
             present in this dictionary are considered when determining whether an
             existing TrackMatcher needs to be updated.

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -542,12 +542,6 @@ class SimulationProperties:
             original_step_kwargs = step_kwargs.copy()
             step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
 
-            # these matcher kwargs will trigger retraining the TrackMatcher
-            retrain_triggers = ["grid_Hrich", "grid_strippedHe", "path", "metallicity",
-                                "matching_method", "matching_tolerance", "matching_tolerance_hard",
-                                "list_for_matching_HMS", "list_for_matching_HeStar", 
-                                "list_for_matching_postMS", "list_for_matching_postHeMS"]
-
             if matcher_needed:
                 # Always just create a new TrackMatcher if it does not exist
                 self.create_track_matcher(metallicity, step_name, matcher_kwargs)
@@ -561,7 +555,7 @@ class SimulationProperties:
                     if k in original_step_kwargs:
                         setattr(self.track_matchers[matcher_key], k, matcher_kwargs[k])
                         self.track_matchers[matcher_key].kwargs[k] = matcher_kwargs[k]
-                        if k in retrain_triggers:
+                        if k in self.track_matchers[matcher_key].TRAINING_TRIGGERS:
                             retrain = True
                 if retrain:
                     updated_kwargs = self.track_matchers[matcher_key].kwargs

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -515,6 +515,7 @@ class SimulationProperties:
         for repeated `(metallicity, step_name)` combinations.
         """
         step_func, step_kwargs = step_tup
+        original_step_kwargs = step_kwargs.copy()
 
         # check/assign metallicity for the step
         if "metallicity" in step_func.DEFAULT_KWARGS:
@@ -539,7 +540,6 @@ class SimulationProperties:
         matcher_key = (metallicity, step_name)
         if "track_matcher" in step_func.DEFAULT_KWARGS:
             matcher_needed = matcher_key not in self.track_matchers
-            original_step_kwargs = step_kwargs.copy()
             step_kwargs, matcher_kwargs = TrackMatcher.separate_kwargs(step_kwargs)
 
             if matcher_needed:

--- a/posydon/binary_evol/track_match.py
+++ b/posydon/binary_evol/track_match.py
@@ -264,7 +264,7 @@ class TrackMatcher:
                       "list_for_matching_postMS":None,
                       "list_for_matching_postHeMS":None,
                       "record_matching":False,
-                      "verbose":False}
+                      "verbose_matching":False}
 
     def __init__(self, **kwargs):
 
@@ -289,10 +289,14 @@ class TrackMatcher:
             for varname in self.DEFAULT_KWARGS:
                 default_value = self.DEFAULT_KWARGS[varname]
                 setattr(self, varname, kwargs.get(varname, default_value))
+
+            self.kwargs = kwargs
         else:
             for varname in self.DEFAULT_KWARGS:
                 default_value = self.DEFAULT_KWARGS[varname]
                 setattr(self, varname, default_value)
+                
+            self.kwargs = DEFAULT_KWARGS
 
         self.metallicity = convert_metallicity_to_string(self.metallicity)
 
@@ -429,7 +433,7 @@ class TrackMatcher:
             scaler_methods = list_for_matching[2]
             bnds = list_for_matching[3:]
 
-            if self.verbose:
+            if self.verbose_matching:
                 print("Matching parameters and their normalizations:\n",
                         match_attr_names, rescale_facs)
             for htrack in [True, False]:
@@ -734,7 +738,7 @@ class TrackMatcher:
 
         match_vals = [None, None]
 
-        if self.verbose:
+        if self.verbose_matching:
             print(f"\nMatching process started in detached step for "
                   f"{star.state} star with matching "
                   f"method = {self.matching_method}")
@@ -755,7 +759,7 @@ class TrackMatcher:
                                                                 get_root0,
                                                                 get_track_val)
 
-        if self.verbose:
+        if self.verbose_matching:
             # successful match
             if all(pd.notna(match_vals)):
 
@@ -1079,7 +1083,7 @@ class TrackMatcher:
             scaler_methods = list_for_matching[2]
             bnds = list_for_matching[3:]
 
-            if self.verbose:
+            if self.verbose_matching:
                 print("Matching parameters and their normalizations:\n",
                       match_attr_names, rescale_facs)
 
@@ -1154,7 +1158,7 @@ class TrackMatcher:
                     raise ValueError(f"{star.state} invalid for matching step")
 
             elif match_type == "alt":
-                if self.verbose:
+                if self.verbose_matching:
                     print("(Now trying to match with alternative parameters)")
 
                 # set alternative matching metrics based on star state
@@ -1174,7 +1178,7 @@ class TrackMatcher:
                       "post-MS star with a stripped-He grid","EvolutionWarning")
 
                 if star.state in STAR_STATES_FOR_HMS_MATCHING:
-                    if self.verbose:
+                    if self.verbose_matching:
                         print(f"We cannot use match_type={match_type} " \
                                 "since star is on the MS. Skipping...")
                     match_ok = False
@@ -1324,7 +1328,7 @@ class TrackMatcher:
 
             # Powell's method does not work with bound in SciPy version < 1.5.x
             if method == 'Powell' and SCIPY_VER < 1.5:
-                if self.verbose:
+                if self.verbose_matching:
                     print(f"Ignoring bounds because method = {method} "
                           f"does not accept them in SciPy v{SCIPY_VER}.x.")
                 bounds = None
@@ -1338,7 +1342,7 @@ class TrackMatcher:
                 # guard against NaN solutions, ensuring they will fail
                 sol.fun = 1e99 if np.isnan(sol.fun) else sol.fun
 
-                if self.verbose:
+                if self.verbose_matching:
                     print (f"Matching attempt completed:"
                             f"\nBest solution: {np.abs(sol.fun)} "
                             f"(tol = {self.matching_tolerance})"
@@ -1350,27 +1354,27 @@ class TrackMatcher:
 
             # check for failures:
             if (np.abs(sol.fun) > self.matching_tolerance):
-                if self.verbose:
+                if self.verbose_matching:
                     print (f"Matching result: FAILED"
                             "\nReason: Solution exceeds tolerance "
                             f"({np.abs(sol.fun)} > {self.matching_tolerance})")
                 match_ok = False
             if (not sol.success):
-                if self.verbose:
+                if self.verbose_matching:
                     print (f"Matching result: FAILED"
                             "\nReason: Optimizer failed (sol.success = "
                             f"{sol.success})"
                             f"\nOptimizer termination reason: {sol.message}")
                 match_ok = False
 
-            if match_ok and self.verbose:
+            if match_ok and self.verbose_matching:
                 print("Matching result: OK")
 
             return sol, new_htrack, match_ok
 
         # END SUBFUNCTION DEFIITIONS
 
-        if self.verbose:
+        if self.verbose_matching:
             print(DIVIDER_STR)
 
         # defined sequence of matching attempt types and methods
@@ -1397,7 +1401,7 @@ class TrackMatcher:
             match_type = match_sequence[attempt_num]["type"]
             method = match_sequence[attempt_num]["method"]
 
-            if self.verbose:
+            if self.verbose_matching:
                 print(f"\nMatching attempt {attempt_num} started...")
                 print(f"match_type = {match_type}")
                 print(f"method = {method}")
@@ -1419,7 +1423,7 @@ class TrackMatcher:
         # if matching is still not successful, set result to NaN:
         exceeds_tol = np.abs(best_sol.fun) > self.matching_tolerance_hard
         if (exceeds_tol or not best_sol.success):
-            if self.verbose:
+            if self.verbose_matching:
                 print("\nFinal matching result: FAILED")
                 if (np.abs(best_sol.fun) > self.matching_tolerance_hard):
                     print ("\nReason: Solution exceeds hard tolerance "+\
@@ -1435,7 +1439,7 @@ class TrackMatcher:
 
         # or else we found a solution
         else:
-            if self.verbose:
+            if self.verbose_matching:
                 print("\nFinal matching result: SUCCESS"
                         f"\nBest solution within hard tolerance: "
                         f"{np.abs(best_sol.fun):.8f}", "<",
@@ -1499,7 +1503,7 @@ class TrackMatcher:
                 match_m0, match_t0 = self.match_to_single_star(star)
                 t_after_matching = time.time()
 
-                if self.verbose:
+                if self.verbose_matching:
                     match_tspan = t_after_matching-t_before_matching
                     print(f"Matching duration: {match_tspan:.6g} sec\n")
 
@@ -1582,7 +1586,7 @@ class TrackMatcher:
         # validate age data
         i_bad = np.diff(age) <= 0
         if np.any(i_bad):
-            if self.verbose:
+            if self.verbose_matching:
                 print(f"Warning: found non-monotonic age data "
                       f"while matching star (m0={match_m0}). ")
             bad = [None]
@@ -1651,7 +1655,7 @@ class TrackMatcher:
 
         if (pd.notna(log_total_J) and pd.notna(total_MOI)):
 
-            if self.verbose:
+            if self.verbose_matching:
                 print("Calculating post-match omega using " \
                       "pre-match angular momentum and moment of inertia")
 
@@ -1665,7 +1669,7 @@ class TrackMatcher:
             # take into account radiation pressure)
             if pd.notna(omega):
 
-                if self.verbose:
+                if self.verbose_matching:
                     print("Calculating post-match omega using " \
                           "pre-match surf_avg_omega")
 
@@ -1673,7 +1677,7 @@ class TrackMatcher:
 
             elif pd.notna(omega_div_omega_c):
 
-                if self.verbose:
+                if self.verbose_matching:
                     print("Calculating post-match omega using " \
                           "pre-match surf_avg_omega_div_omega_crit")
 
@@ -1699,7 +1703,7 @@ class TrackMatcher:
 
             else:
                 omega_in_rad_per_yr = 0.0
-                if self.verbose:
+                if self.verbose_matching:
                     print("Could not calculate post-match omega, " \
                           "pre-match values are None or NaN.")
                     print("Pre-match rotation rates:")
@@ -1709,7 +1713,7 @@ class TrackMatcher:
                     Pwarn("Setting (post-match) rotation rate to zero.",
                           "InappropriateValueWarning")
 
-        if self.verbose and omega is not None and (omega_in_rad_per_yr != 0):
+        if self.verbose_matching and omega is not None and (omega_in_rad_per_yr != 0):
             print("pre-match omega [rad/yr] = ", omega * const.secyer)
             print("calculated omega [rad/yr] = ", omega_in_rad_per_yr)
             pcdiff = 100.0*(omega_in_rad_per_yr-omega * const.secyer) \
@@ -1916,7 +1920,7 @@ class TrackMatcher:
         # get the matched data of binary components
         # match secondary:
         if self.match_secondary:
-            if self.verbose:
+            if self.verbose_matching:
                 print(f"\nMatching secondary star (state = {secondary.state})...")
 
             if self.secondary_not_normal:
@@ -1944,7 +1948,7 @@ class TrackMatcher:
 
         if self.match_primary:
             # match primary
-            if self.verbose:
+            if self.verbose_matching:
                 print(f"\nMatching primary star (state = {primary.state})...")
 
             if self.primary_not_normal:

--- a/posydon/binary_evol/track_match.py
+++ b/posydon/binary_evol/track_match.py
@@ -295,7 +295,7 @@ class TrackMatcher:
             for varname in self.DEFAULT_KWARGS:
                 default_value = self.DEFAULT_KWARGS[varname]
                 setattr(self, varname, default_value)
-                
+
             self.kwargs = DEFAULT_KWARGS
 
         self.metallicity = convert_metallicity_to_string(self.metallicity)

--- a/posydon/binary_evol/track_match.py
+++ b/posydon/binary_evol/track_match.py
@@ -266,6 +266,15 @@ class TrackMatcher:
                       "record_matching":False,
                       "verbose_matching":False}
 
+    # If you ever create a TrackMatcher, the first time you do, it will be trained 
+    # using whatever settings exist for these kwargs. If you ever subsequently change
+    # these kwargs for that TrackMatcher, you'd need to retrain it. You can use this 
+    # list to flag the TrackMatcher for retraining.
+    TRAINING_TRIGGERS = ["grid_Hrich", "grid_strippedHe", "path", "metallicity",
+                         "matching_method", "matching_tolerance", "matching_tolerance_hard",
+                         "list_for_matching_HMS", "list_for_matching_HeStar", 
+                         "list_for_matching_postMS", "list_for_matching_postHeMS"]
+
     def __init__(self, **kwargs):
 
         # MESA history column names used as matching metrics

--- a/posydon/binary_evol/track_match.py
+++ b/posydon/binary_evol/track_match.py
@@ -266,13 +266,13 @@ class TrackMatcher:
                       "record_matching":False,
                       "verbose_matching":False}
 
-    # If you ever create a TrackMatcher, the first time you do, it will be trained 
+    # If you ever create a TrackMatcher, the first time you do, it will be trained
     # using whatever settings exist for these kwargs. If you ever subsequently change
-    # these kwargs for that TrackMatcher, you'd need to retrain it. You can use this 
+    # these kwargs for that TrackMatcher, you'd need to retrain it. You can use this
     # list to flag the TrackMatcher for retraining.
     TRAINING_TRIGGERS = ["grid_Hrich", "grid_strippedHe", "path", "metallicity",
                          "matching_method", "matching_tolerance", "matching_tolerance_hard",
-                         "list_for_matching_HMS", "list_for_matching_HeStar", 
+                         "list_for_matching_HMS", "list_for_matching_HeStar",
                          "list_for_matching_postMS", "list_for_matching_postHeMS"]
 
     def __init__(self, **kwargs):

--- a/posydon/binary_evol/track_match.py
+++ b/posydon/binary_evol/track_match.py
@@ -271,7 +271,6 @@ class TrackMatcher:
     # these kwargs for that TrackMatcher, you'd need to retrain it. You can use this
     # list to flag the TrackMatcher for retraining.
     TRAINING_TRIGGERS = ["grid_Hrich", "grid_strippedHe", "path", "metallicity",
-                         "matching_method", "matching_tolerance", "matching_tolerance_hard",
                          "list_for_matching_HMS", "list_for_matching_HeStar",
                          "list_for_matching_postMS", "list_for_matching_postHeMS"]
 

--- a/posydon/binary_evol/track_match.py
+++ b/posydon/binary_evol/track_match.py
@@ -296,7 +296,7 @@ class TrackMatcher:
                 default_value = self.DEFAULT_KWARGS[varname]
                 setattr(self, varname, default_value)
 
-            self.kwargs = DEFAULT_KWARGS
+            self.kwargs = self.DEFAULT_KWARGS.copy()
 
         self.metallicity = convert_metallicity_to_string(self.metallicity)
 

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -163,6 +163,8 @@
     # True, False
   verbose = False
     # True, False
+  verbose_matching = False
+    # True, False
 
 [step_disrupted]
   import = ['posydon.binary_evol.DT.step_disrupted','DisruptedStep']
@@ -191,6 +193,8 @@
   record_matching = False
     # True, False
   verbose = False
+    # True, False
+  verbose_matching = False
     # True, False
 
 [step_merged]
@@ -235,7 +239,8 @@
     # True, False
   verbose = False
     # True, False
-
+  verbose_matching = False
+    # True, False
 
 [step_initially_single]
   import = ['posydon.binary_evol.DT.step_initially_single','InitiallySingleStep']
@@ -265,6 +270,8 @@
     # True, False
   verbose = False
     # True, False
+  verbose_matching = False
+    # True, False
 
 [step_CE]
   import = ['posydon.binary_evol.CE.step_CEE', 'StepCEE']
@@ -287,6 +294,8 @@
     #        list_for_matching = [[matching attr. names], [rescale_factors],
     #                             [scaling method], [mass_bnds], [age_bnds]]
   record_matching = False
+    # True, False
+  verbose_matching = False
     # True, False
   prescription = 'alpha-lambda'
     # 'alpha-lambda'


### PR DESCRIPTION
Previously, if a matcher was created via a prior `SimulationProperties.load_step()` call, it would not be created again (intended) and could not have its kwargs updated (unintended).

This allows the kwargs to be updated upon reload. It also adds a separate verbosity flag for `TrackMatcher` that can be set to isolate track matching output, rather than all step output, the idea being to avoid unwanted screen clutter.