### PR TITLE
[enhancements] Additional documentation and explanation pages

### DIFF
--- a/docs/_source/components-overview/mesa-grids.rst
+++ b/docs/_source/components-overview/mesa-grids.rst
@@ -20,7 +20,8 @@ Learn how to run fix type grids using the POSYDON API.
 Running dynamic type grids
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Learn how to run dynamic type grids using the POSYDON API. TODO
+Learn how to run dynamic type grids using the POSYDON API. Dynamic grids are
+currently **experimental**; see :ref:`dynamic_grid`.
 
 .. toctree::
 

--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -1171,10 +1171,10 @@ This dictionary contains the parameters that will be saved in the output of the 
 
   * - ``scalar_names``
     - | Scalars to include in the output for SingleStar 1.
-      | Example: ``['natal_kick_array', 'SN_type', 'f_fb', 'spin_orbit_tilt_first_SN', 'spin_orbit_tilt_second_SN', 'm_disk_accreted', 'm_disk_radiated']``
+      | Example: ``['natal_kick_velocity', 'SN_type', 'f_fb', 'spin_orbit_tilt_first_SN', 'spin_orbit_tilt_second_SN', 'm_disk_accreted', 'm_disk_radiated']``
       | Options:
 
-      * ``'natal_kick_array'``: The array of natal kicks.
+      * ``'natal_kick_velocity'``: The velocity of the natal kick.
       * ``'SN_type'``: The type of supernova.
       * ``'f_fb'``: The fallback fraction.
       * ``'spin_orbit_tilt_first_SN'``: The spin-orbit tilt after the first supernova.
@@ -1183,7 +1183,7 @@ This dictionary contains the parameters that will be saved in the output of the 
       * ``'m_disk_radiated'``: The mass radiated from the disk.
     - .. code:: python
 
-        ['natal_kick_array',
+        ['natal_kick_velocity',
         'SN_type',
         'f_fb',
         'spin_orbit_tilt_first_SN',

--- a/docs/_source/components-overview/pop_syn/reweighting.rst
+++ b/docs/_source/components-overview/pop_syn/reweighting.rst
@@ -1,0 +1,79 @@
+.. _population_reweighting:
+
+Population Reweighting
+======================
+
+POSYDON allows you to reweight your populations after they have been evolved,
+based on the initial conditions of the binaries and single stars. This is a
+form of importance sampling: the weights are obtained from the ratio of the
+PDF of the target population to the PDF of the simulated population, evaluated
+at the initial conditions of each model.
+
+The reweighting step is performed on a ``TransientPopulation`` object with the
+``get_model_weights`` method. The implementation expects the following initial
+properties to be available in the population data:
+
+- ``S1_mass_i``: initial primary mass
+- ``S2_mass_i``: initial secondary mass
+- ``orbital_period_i``: initial orbital period
+- ``state_i``: initial state, which is used to distinguish binaries from
+  initially single stars
+
+Supported initial-condition distributions
+----------------------------------------
+
+The reweighting implementation in ``posydon.popsyn.norm_pop`` currently supports
+several distribution families. The table below summarizes the main options.
+
+.. list-table:: Supported reweighting distributions
+   :header-rows: 1
+   :widths: 20 25 25 30
+
+   * - Initial condition
+     - Supported schemes
+     - Required parameters
+     - Notes
+   * - Primary mass
+     - Any IMF class available in ``posydon.popsyn.IMFs``
+     - ``primary_mass_scheme``, ``primary_mass_min``, ``primary_mass_max``
+     - The scheme name is resolved dynamically from the IMF module. If it is not
+       recognized, a flat distribution is used and a warning is emitted.
+   * - Mass ratio
+     - ``flat_mass_ratio``, ``power_law_mass_ratio``
+     - For ``flat_mass_ratio``: ``secondary_mass_scheme`` plus
+       ``secondary_mass_min`` and ``secondary_mass_max`` (or explicit
+       ``q_min``/``q_max``). For ``power_law_mass_ratio``: ``mass_ratio_slope``
+       and optional ``q_min``/``q_max``.
+     - The flat mass-ratio distribution can be defined either from the allowed
+       secondary-mass range or from explicit mass-ratio bounds.
+   * - Orbital period
+     - ``period`` with ``Sana+12_period_extended`` or ``power_law``; or
+       ``separation`` with ``log_uniform``
+     - For ``period``: ``orbital_period_min`` and ``orbital_period_max``. For
+       ``Sana+12_period_extended`` no additional parameters are needed. For
+       ``power_law``: ``power_law_slope``. For ``separation``:
+       ``orbital_separation_min`` and ``orbital_separation_max``.
+     - Periods are interpreted in days. Separation-based inputs are converted
+       internally to periods using the orbital-separation relation.
+   * - Binary fraction
+     - ``const``
+     - ``binary_fraction_scheme``, ``binary_fraction_const``
+     - This is currently implemented as a constant binary fraction and is used
+       to distinguish single-star and binary PDFs.
+
+How the weights are computed
+---------------------------
+
+The method evaluates the target PDF and the simulation PDF at the initial
+conditions of each system and computes
+
+``weights = (PDF_target / PDF_sim) * (mean_mass_sim / mean_mass_pop) * (1 / M_sim)``
+
+where ``M_sim`` is the total simulated mass, ``mean_mass_sim`` is the mean mass
+of the simulated population, and ``mean_mass_pop`` is the mean mass of the
+requested target population.
+
+In practice, this means that the reweighted population is only meaningful when
+the target and simulation populations share the same support for the sampled
+initial-condition distributions. If the target distribution extends beyond the
+range covered by the simulation, you might miss systems!

--- a/docs/_source/components-overview/pop_syn/supernova_models.rst
+++ b/docs/_source/components-overview/pop_syn/supernova_models.rst
@@ -1,0 +1,346 @@
+.. _supernova_models:
+
+Supernova Models
+================
+
+POSYDON supports different supernova models for the formation of compact objects.
+The supernova model can be set in the configuration file of the population synthesis model.
+
+Overview
+--------
+
+The supernova treatment in POSYDON is determined by two key aspects:
+
+1. **Core-collapse mechanism**: The physical prescription for computing remnant properties
+2. **Computational approach**: How and when the collapse outcome is calculated
+
+Core-Collapse Mechanisms
+------------------------
+
+POSYDON supports the following core-collapse mechanisms:
+
+.. list-table:: Core-collapse mechanisms
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - Mechanism
+     - Engine
+     - Description
+   * - **Fryer+12-delayed**
+     - ``None``
+     - Classical rapid and delayed supernova engines from Fryer et al. (2012)
+   * - **Fryer+12-rapid**
+     - ``None``
+     - Classical rapid and delayed supernova engines from Fryer et al. (2012)
+   * - **Sukhbold+16-engine**
+     - ``N20``, ``W20``, ``S19.8``, ``W15``, ``W18``
+     - Uses pre-computed results from Sukhbold et al. (2016) based on neutrino-powered explosions
+   * - **Patton&Sukhbold20-engine**
+     -  ``N20``, ``W20``, ``S19.8``, ``W15``, ``W18``
+     - Advanced engine combining Patton & Sukhbold (2020) results for realistic explosion landscapes
+   * - **Maltsev+25-engine**
+     - ``M16``
+     - Maltsev et al. (2025) with updated explodability criteria and neutrino-driven physics. **Only valid M_CO < 10 Msun!**
+   * - **Couch+20-engine**
+     - ``"1.0", "1.2", "1.23", "1.25", "1.27", "1.3", "1.4"``
+     - Simulations of turbulence-aided neutrino-driven core-collapse supernovae from Couch et al. (2020)
+   * - **direct**
+     - ``None``
+     - Simplified prescriptions that directly collapse the pre-supernova to the baryonic mass
+   * - **direct_he_core**
+     - ``None``
+     - Simplified prescriptions that directly collapse the pre-supernova to the baryonic mass of the helium core
+
+
+
+Pulsational pair-instability supernova prescriptions
+----------------------------------------------------
+
+POSYDON also supports pulsational pair-instability supernova (PPISN) prescriptions, which can be set in the configuration file:
+
+.. list-table:: (P)PISN prescriptions
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - Prescription
+     - Parameters
+     - Description
+   * - **Marchant+19**
+     - ``None``
+     - Marchant et al. (2019) prescription for PPISN and PISN mass loss from
+     | Breivik et al. (2020).
+   * - **Hendriks+23**
+     - ``PISN_CO_shift`` and ``PPI_extra_mass_loss``
+     - Hendriks et al. (2023) prescription for PPISN and PISN mass loss.
+     | ``PISN_CO_shift`` shifts the CO core mass threshold for PPI onset
+     | and ``PPI_extra_mass_loss`` adds extra mass loss during PPISN events.
+     | PISN occurs if the remnant mass after PPI mass loss is less than 10 Msun.
+
+
+
+Computational Approaches
+------------------------
+
+The outcome of core collapse can be computed using three different approaches, controlled by configuration flags:
+
+Pre-Trained Interpolators
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+   use_interp_values = True
+   use_profiles = True
+   use_core_masses = True
+
+This is the **default and recommended approach** for population synthesis.
+The pre-trained interpolators use outcomes that were computed offline from the detailed MESA stellar profiles.
+Because the on-the-fly calculations use the down-sampled profiles, the interpolators are generally more accurate and faster.
+
+
+On-the-Fly Calculations with Downsampled Profiles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+   use_interp_values = False
+   use_profiles = True
+   use_core_masses = False
+
+This approach recalculates the core-collapse outcome during the simulation using stellar profiles. However, unlike the detailed profiles used to train the interpolators, these profiles are **downsampled** (reduced resolution) for computational efficiency.
+
+**Advantages**: More flexible, can handle evolutionary scenarios not covered by pre-computed grids, allows for model exploration
+
+**Disadvantages**: Slower than interpolators, potential accuracy loss due to profile downsampling
+
+**When to use**: For detailed model comparisons, sensitivity studies, or cases requiring custom physics
+
+Core-Masses Approach (Classical Population Synthesis)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+   use_interp_values = False
+   use_profiles = False
+   use_core_masses = True
+
+This classical approach uses only the core masses at carbon depletion, without requiring detailed stellar profiles.
+
+Pre-Defined Supernova Models
+----------------------------
+
+POSYDON provides a set of pre-defined supernova models (``SN_MODEL_v2_XX``) for which
+the initial-final interpolator has been trained.
+This requires the user to correctly set the supernova mechanism and engine in the configuration file of the population synthesis model.
+
+Model Overview
+^^^^^^^^^^^^^^
+
+The following table lists all pre-defined supernova models and their key characteristics:
+
+.. list-table:: Pre-defined SN Models
+   :header-rows: 1
+   :widths: 12 25 8 18 18
+
+   * - Model
+     - Mechanism
+     - Engine
+     - Conserve H-env
+     - PPI Mass Loss
+
+   * - SN_MODEL_v2_01
+     - Fryer+12-delayed
+     - \-
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_02
+     - Fryer+12-delayed
+     - \-
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_03
+     - Fryer+12-delayed
+     - \-
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_04
+     - Fryer+12-delayed
+     - \-
+     - Yes
+     - 0.0
+
+   * - SN_MODEL_v2_05
+     - Fryer+12-rapid
+     - \-
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_06
+     - Fryer+12-rapid
+     - \-
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_07
+     - Fryer+12-rapid
+     - \-
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_08
+     - Fryer+12-rapid
+     - \-
+     - Yes
+     - 0.0
+
+   * - SN_MODEL_v2_09
+     - Sukhbold+16-engine
+     - N20
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_10
+     - Sukhbold+16-engine
+     - N20
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_11
+     - Sukhbold+16-engine
+     - N20
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_12
+     - Sukhbold+16-engine
+     - N20
+     - Yes
+     - 0.0
+
+   * - SN_MODEL_v2_13
+     - Patton&Sukhbold20-engine
+     - N20
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_14
+     - Patton&Sukhbold20-engine
+     - N20
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_15
+     - Patton&Sukhbold20-engine
+     - N20
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_16
+     - Patton&Sukhbold20-engine
+     - N20
+     - Yes
+     - 0.0
+
+   * - SN_MODEL_v2_17
+     - Sukhbold+16-engine
+     - W20
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_18
+     - Sukhbold+16-engine
+     - W20
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_19
+     - Sukhbold+16-engine
+     - W20
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_20
+     - Sukhbold+16-engine
+     - W20
+     - Yes
+     - 0.0
+
+   * - SN_MODEL_v2_21
+     - Patton&Sukhbold20-engine
+     - W20
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_22
+     - Patton&Sukhbold20-engine
+     - W20
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_23
+     - Patton&Sukhbold20-engine
+     - W20
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_24
+     - Patton&Sukhbold20-engine
+     - W20
+     - Yes
+     - 0.0
+
+   * - SN_MODEL_v2_25
+     - Maltsev+25-engine
+     - M16
+     - No
+     - -20.0
+
+   * - SN_MODEL_v2_26
+     - Maltsev+25-engine
+     - M16
+     - Yes
+     - -20.0
+
+   * - SN_MODEL_v2_27
+     - Maltsev+25-engine
+     - M16
+     - No
+     - 0.0
+
+   * - SN_MODEL_v2_28
+     - Maltsev+25-engine
+     - M16
+     - Yes
+     - 0.0
+
+All pre-defined models use:
+
+- ``use_interp_values = False`` (on-the-fly calculations, not pre-trained interpolators)
+- ``use_profiles = True`` (detailed MESA profiles, downsampled during calculation)
+- ``use_core_masses = False``
+
+Configuration
+^^^^^^^^^^^^^
+
+To use a pre-defined model, specify it in your population synthesis configuration file:
+
+.. code-block:: ini
+
+   [supernova]
+   model = SN_MODEL_v2_13
+
+This will automatically load all parameters for that model. Alternatively, you can customize individual parameters:
+
+.. code-block:: ini
+
+   [supernova]
+   mechanism = Patton&Sukhbold20-engine
+   engine = N20
+   ECSN = Tauris+15
+   conserve_hydrogen_envelope = False
+   PPI_extra_mass_loss = -20.0
+   use_interp_values = True
+   use_profiles = False
+   use_core_masses = False

--- a/docs/_source/components-overview/population-synthesis.rst
+++ b/docs/_source/components-overview/population-synthesis.rst
@@ -1,0 +1,56 @@
+.. _population_synthesis:
+
+Population Synthesis
+====================
+The population synthesis framework is built on top of the `_stellar-binary-simulation`_ framework, and
+evolves a population of binaries using the `BinaryPopulation`_ class.
+
+It uses the same configuration file as the `_stellar-binary-simulation`_ framework, but it also allows to specify the initial conditions of the population, such as the initial mass function, the initial mass ratio distribution, and the initial orbital period distribution. See `SimulationProperties`_ for more information on the configuration parameters.
+
+
+
+The Binary Population Object
+----------------------------
+
+The `BinaryPopulation` object contains a list of `BinaryStar` objects and the `SimulationProperties` object which contains the information about the population synthesis model.
+
+.. toctree::
+    :maxdepth: 1
+
+    pop_syn/binary_population
+
+
+----
+
+The Synthetic Population Object
+-------------------------------
+
+The `SyntheticPopulation` object contains a collection of `BinaryPopulation` objects run, e.g. at different metallicities or with different model assumptions. It also provide the POSYDON API interface to analyse, process, and visualize the results of a POSYDON population synthesis model.
+
+.. toctree::
+    :maxdepth: 1
+
+    pop_syn/synthetic_population
+
+
+Reweighting Populations
+-----------------------
+POSYDON provides a reweighting framework that allows users to reweight the results of a population synthesis model to match a different set of initial conditions. This is useful for exploring the effects of different initial conditions on the results of a population synthesis model without having to run a new simulation.
+
+.. toctree::
+    :maxdepth: 1
+
+    pop_syn/reweighting
+
+
+
+The Star Formation History
+---------------------------
+
+The star formation history is a key component in population synthesis, since it
+determined the amount of stars that are formed at each moment in time.
+
+.. toctree::
+    :maxdepth: 1
+
+    pop_syn/star_formation_history

--- a/docs/_source/components-overview/post_processing/psygrid.rst
+++ b/docs/_source/components-overview/post_processing/psygrid.rst
@@ -385,10 +385,21 @@ arguments :samp:`compression`, :samp:`description`, and :samp:`verbose`.
 We recommend that you use the :ref:`post-processing pipeline <pipeline>` to
 create and join grids.
 
-..
-    Extract the initial and final values as a pandas data frame
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    TODO: get_pandas_initial_final()
+
+Get initial and final values as a pandas DataFrame
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you would rather work with the grid's bound values in a Pandas DataFrame
+(for example to combine them with your own analysis), the ``PSyGrid`` object
+provides the method
+:py:meth:`get_pandas_initial_final <posydon.grids.psygrid.PSyGrid.get_pandas_initial_final>`.
+It returns a DataFrame containing the initial and final values of every system
+in the grid, which you can then filter and inspect with the usual tools.
+
+.. code-block:: python
+
+    df = mygrid.get_pandas_initial_final()
+    print(df.head())
 
 
 Get reruns from a `PSyGrid` object

--- a/docs/_source/components-overview/stellar-binary-simulation.rst
+++ b/docs/_source/components-overview/stellar-binary-simulation.rst
@@ -5,8 +5,6 @@ Stellar & Binary-star Simulation
 ################################
 
 
-
-
 POSYDON: Building Populations with Object-Oriented Design
 =========================================================
 
@@ -34,19 +32,6 @@ The `BinaryStar` object contains the binary properties and its evolutionary hist
     :titlesonly:
 
     pop_syn/binary_star
-
-
-----
-
-The Binary Population Object
-----------------------------
-
-The `BinaryPopulation` object contains a list of `BinaryStar` objects and the `SimulationProperties` object which contains the information about the population synthesis model.
-
-.. toctree::
-    :maxdepth: 1
-
-    pop_syn/binary_population
 
 
 ----
@@ -103,24 +88,13 @@ To allow users to easier add functions for their own needs without changing the 
 ----
 
 
-The Synthetic Population Object
--------------------------------
-
-The `SyntheticPopulation` object contains a collection of `BinaryPopulation` objects run, e.g. at different metallicities or with different model assumptions. It also provide the POSYDON API interface to analyse, process, and visualize the results of a POSYDON population synthesis model.
-
-.. toctree::
-    :maxdepth: 1
-
-    pop_syn/synthetic_population
-
-
-The Star Formation History
----------------------------
-
-The star formation history is a key component in population synthesis, since it
-determined the amount of stars that are formed at each moment in time.
+Supernova models
+----------------
+In POSYDON, we provide a variety of supernova models that can be used to simulate the evolution of binary systems.
+We have both pre-trained interpolators that can be used to predict the outcome of a supernova event
+and on-the-fly calculations that can be used to compute the outcome of a supernova event during the simulation.
 
 .. toctree::
     :maxdepth: 1
 
-    pop_syn/star_formation_history
+    pop_syn/supernova_models

--- a/docs/_source/explanations/data-releases.rst
+++ b/docs/_source/explanations/data-releases.rst
@@ -1,0 +1,85 @@
+.. _data-releases:
+
+################
+Data Releases
+################
+
+POSYDON shares the precomputed (down-sampled) MESA simulation grids, together with their
+post-processed products (interpolators and classifiers), so that you can run
+population synthesis without having to run MESA yourself. These shared datasets
+are called data releases.
+
+Data Release 1 (DR1)
+--------------------
+
+DR1 was the first published dataset accompanying POSYDON v1. It contains a
+fixed grid of binary-system MESA simulations. Precise storage and content
+details of DR1 are described in the original POSYDON paper, `Fragos et
+al. (2023) <https://ui.adsabs.harvard.edu/abs/2023ApJS..264...45F/abstract>`_.
+
+Because the code evolved substantially between v1 and v2, DR1 is not the default
+data used by current POSYDON versions. The default download is DR2.
+
+Data Release 2 (DR2, default)
+------------------------------------
+
+DR2 accompanies POSYDON v2 and is the default dataset used by the code. It
+contains fixed grids of single- and binary-star MESA simulations processed
+through the POSYDON :ref:`processing pipeline <processing-pipeline>`, together
+with the trained interpolators and classifiers used for population synthesis.
+
+Metallicities
+~~~~~~~~~~~~~~
+
+Unlike DR1, DR2 contains simulations over **eight different metallicities**:
+::
+
+    1e-04_Zsun  1e-03_Zsun  ...  (solar Zsun and above)
+
+so that populations can be constructed over a wide range of star formation
+environments. Each metallicity is a separate download, which is convenient if
+you only need a subset (e.g. only the solar-metallicity grid to follow the
+*Getting Started* examples).
+
+Storage requirements
+~~~~~~~~~~~~~~~~~~~~~~
+
+The amount of disk space you need depends on the subset you download. The table
+below gives the canonical figures used throughout these documentation, with a
+single consistent set of numbers:
+
+===================== =================
+What you download      Approximate size
+===================== =================
+Full DR2 dataset       ~ 110 GB
+Each DR2 metallicity   ~ 14 GB
+DR1 dataset            ~ 40 GB
+===================== =================
+
+The exact footprint also depends on how many run types (``HMS-HMS``, ``He-He``,
+and so on; see :ref:`grid-types`) and metallicities you include.
+
+How to download
+-----------------
+
+The simplest way to obtain the data is with the ``get-posydon-data``
+command-line tool. For example, to download just the solar-metallicity DR2
+data used by the quick-start guides:
+
+.. code-block:: bash
+
+   get-posydon-data DR2_1Zsun
+
+And to download the full DR2 dataset:
+
+.. code-block:: bash
+
+   get-posydon-data DR2
+See the ``get-posydon-data`` reference page (``api_reference/get_posydon_data.rst``)
+for the full list of options.
+
+.. seealso::
+
+   * :ref:`grid-types` for what a grid contains and how DR2 is organized.
+   * :ref:`installation-guide` for how data is located on disk (the
+     ``PATH_TO_POSYDON_DATA`` variable).

--- a/docs/_source/explanations/data-releases.rst
+++ b/docs/_source/explanations/data-releases.rst
@@ -52,7 +52,7 @@ single consistent set of numbers:
 What you download      Approximate size
 ===================== =================
 Full DR2 dataset       ~ 110 GB
-Each DR2 metallicity   ~ 14 GB
+Each DR2 metallicity   ~ 12 GB
 DR1 dataset            ~ 40 GB
 ===================== =================
 

--- a/docs/_source/explanations/grid-types.rst
+++ b/docs/_source/explanations/grid-types.rst
@@ -1,0 +1,72 @@
+.. _grid-types:
+
+################
+Grid Types
+################
+
+A POSYDON *grid* is a collection of MESA simulations of stellar or binary
+systems that share a common set of physical assumptions and differ in
+their initial conditions. Understanding how grids are organized is key to
+knowing which data you are using and how you can extend it with your own runs.
+
+What grids are there?
+----------------------
+
+POSYDON ships with different grid types:
+
+- ``HMS-HMS`` grids: hydrogen-rich main-sequence primaries with hydrogen-rich main-sequence secondaries
+- ``HMS-HMS_RLO`` grids: hydrogen-rich main-sequence primaries with hydrogen-rich main-sequence secondaries, starting from Roche-lobe overflow (RLO)
+- ``HMS-CO_RLO`` grids: hydrogen-rich main-sequence primaries with a compact object companion (CO), starting from Roche-lobe overflow (RLO)
+- ``HeMS-CO`` grids: helium-rich main-sequence primaries with a compact object companion (CO)
+- ``HeMS-CO_RLO`` grids: helium-rich main-sequence primaries with a compact object companion (CO), starting from Roche-lobe overflow (RLO)
+
+- ``single_HMS`` grids: single hydrogen-rich main-sequence stars
+- ``single_HeMS`` grids: single helium-rich main-sequence stars
+
+What a grid contains
+--------------------
+
+Each grid contains a set of MESA simulations that are down-sampled to save disk space.
+For each run, the grid contains the ``initial_values``, ``final_values``, and ``history``
+of the simulation. The ``history`` is split between the ``binary_history`` and
+the histories of the individual stars (``history1`` and ``history2``).
+
+The grid therefore spans a defined region of this parameter space, sampled on a
+rectangular (grid) of points. Each run type has its own file, so within a given
+metallicity you will find one dataset per type.
+
+
+Fixed grids
+~~~~~~~~~~~
+
+A **fixed** (or rectilinearly sampled) grid is one in which the initial
+conditions are chosen on a fixed rectangular lattice of values ahead of time.
+Every point in the lattice is simulated, giving a uniform and predictable
+coverage of the parameter space. The published data releases (DR1, DR2) are
+fixed grids. You can run your own fixed grids with the POSYDON MESA grid API &mdash;
+see :ref:`fixed_grid` and :ref:`MESA-grids <MESA-grids>`.
+
+
+Example organization of downloaded data
+-----------------------------------------
+
+A typical data directory is organized by run type and metallicity, e.g.::
+
+    POSYDON_data/
+        HMS-HMS/
+            1e+00_Zsun.h5
+            ...
+        HMS-HMS_RLO/
+            ...
+        single_HMS/
+            ...
+
+where each ``.h5`` file contains one ``PSyGrid`` for a given run type and
+metallicity.
+
+Summary
+-------
+
+.. seealso::
+   * :ref:`data-releases` for the published datasets and their storage costs.
+   * :ref:`MESA-grids <MESA-grids>` for the tutorials on running your own grids.

--- a/docs/_source/getting-started/installation-guide.rst
+++ b/docs/_source/getting-started/installation-guide.rst
@@ -30,6 +30,19 @@ Anaconda (Recommended)
 
     If you haven't already, download and install Anaconda from `Anaconda's official website <https://www.anaconda.com/products/distribution>`_.
 
+.. important::
+
+    After you've installed Anaconda, you can use our installation script to set up
+    POSYDON on your machine or continue with the manual installation.
+    For the automatic installation, run the following command in your terminal
+    (this will install POSYDON in a new conda environment named ``posydon_env``):
+
+    .. code-block:: bash
+
+        bash <(curl -sSL https://raw.githubusercontent.com/POSYDON-code/POSYDON/main/install.sh)
+
+
+
 2. **Create a New Conda Environment**
 
     Open your terminal or Anaconda prompt and create a new environment called ``posydon_env`` using Python 3.11 (the ``-y`` automatically answers all confirmations with yes):

--- a/docs/_source/getting-started/prerequisites.rst
+++ b/docs/_source/getting-started/prerequisites.rst
@@ -11,26 +11,31 @@ POSYDON has been tested on the following operating systems:
 - Linux (Ubuntu 20.04 and newer, CentOS 7, etc.)
 - macOS (10.14 and newer)
 
-(Note: Adapt and expand the list based on the actual compatibility of POSYDON)
+POSYDON is developed and tested on Linux (and in particular on HPC clusters),
+which is the platform POSYDON is officially tested against. We aim to keep
+macOS working, but if you hit an issue on macOS please see the
+:ref:`troubleshooting guide <installation-issues>`.
 
 Software Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
 1. Python 3.11
-2. More dependencies are defined in our setup file and should be automatically applied during the installation. To allow you having different versions of the packages we require we strongly encourage to use a dedicated conda environment for POSYDON.
-
-(Note: Expand on any specific versions or configurations, if necessary.)
+2. More dependencies are defined in our setup file (``pyproject.toml``) and are
+   installed automatically during the installation. To keep different package
+   versions from interfering with each other, we strongly encourage you to use a
+   dedicated conda environment for POSYDON.
 
 Hardware Requirements
 ~~~~~~~~~~~~~~~~~~~~~
 
-**Storage**:
+**Storage**: The exact footprint depends on which data release and how many
+metallicities you download. See :ref:`data-releases` for the canonical numbers.
 
 In order to run a population synthesis model with POSYDON, you must ensure that you have enough free storage space. It depends on the dataset how much free space you need:
 
-- DR1: approximately **40GB**
 - DR2: approximately **140GB** (the default in the :ref:`installation <installation-guide>`)
 - one of the eight metallicities in DR2: approximately **20GB**
+- DR1: approximately **40GB**
 
 This is crucial for downloading the lite MESA simulation library, interpolation objects, and other auxiliary files used by the code.
 
@@ -39,17 +44,13 @@ Memory:
 - Minimum: 8GB RAM
 - Recommended: 16GB RAM
 
-(Note: Adjust memory requirements based on your knowledge of POSYDON's demands.)
+The amount of memory a population run needs per CPU, and the related
+``dump_rate`` setting, are covered in the installation guide and the
+population-synthesis examples.
 
 CPU:
 
-- Multi-core processor recommended for optimal performance, e.g. HPC cluster.
-
-(Note: Include more specific CPU details if necessary.)
-
-Network:
-
-- A stable internet connection for downloading necessary libraries and datasets.
+- A multi-core processor is recommended for optimal performance (e.g. an HPC cluster), since a run is parallelized across CPUs (one process per CPU).
 
 Installation Steps
 ~~~~~~~~~~~~~~~~~~

--- a/docs/_source/index.rst
+++ b/docs/_source/index.rst
@@ -20,34 +20,21 @@ POSYDON is a next-generation single- and binary-star population synthesis tool. 
 
 To stay up-to-date with the latest news about POSYDON, check out our `official website <https://www.posydon.org>`_ for more details.
 
-How is this Documentation Structured?
--------------------------------------
 
-- **Introductions** Discover what POSYDON is, its objectives, and its science scope.
-- **Getting Started:** A quick guide to get POSYDON up and running on your machine.
-- **User Guides:** Detailed guides on using various features.
-- **Tutorials and Examples:** Step-by-step walk-throughs of typical use-cases.
-- **POSYDON School Materials:** Access resources from the POSYDON school.
-- **In-Depth Components Overview:** Delve deep into the core components of POSYDON.
-- **API Reference:** A comprehensive reference for developers.
-- **Troubleshooting and FAQs:** Answers to common questions and problems.
-- **Contributing to POSYDON:** Join our community and help us grow!
-- **Release Notes and Changelog:** Stay updated with our version history.
-- **Contact and Support:** Reach out to us with your queries or feedback.
+Using this Documentation
+------------------------
 
-.. - **POSYDON Workflow:** Learn about how to conduct simulations from start to finish.
+We've tried to group the documentation into four distinct sections to help you navigate easily:
+
+- **Tutorials:** Step-by-step guides to help you get started and explore POSYDON's capabilities.
+- **User Guides:** In-depth explanations of POSYDON's features and functionalities.
+- **Reference:** For developers and advanced users, detailing the classes, methods, and functions available in POSYDON.
+- **Explanation:** Background and conceptual material on the POSYDON framework.
+
 
 .. toctree::
    :maxdepth: 1
-   :caption: Introduction
-
-   introduction-acknowledgements/intro
-   Collaborative Team <https://posydon.org/team.html>
-   Publications <https://ui.adsabs.harvard.edu/public-libraries/ZZsD9bzLTzWnLV3hwyJxbA>
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Getting Started
+   :caption: How-to (Getting Started)
 
    getting-started/prerequisites
    getting-started/installation-guide
@@ -56,8 +43,7 @@ How is this Documentation Structured?
 
 .. toctree::
    :maxdepth: 1
-   :titlesonly:
-   :caption: Tutorials and Examples
+   :caption: Tutorials
 
    tutorials-examples/population-synthesis/binary-pop-syn
    tutorials-examples/generating-datasets/generating-datasets
@@ -70,36 +56,38 @@ How is this Documentation Structured?
 
    POSYDON School 2025 <https://github.com/POSYDON-code/POSYDON-2025-School-Labs>
 
+
+
 .. toctree::
    :maxdepth: 1
    :titlesonly:
-   :caption: In-Depth Components Overview
+   :caption: Explanation
 
-   components-overview/mesa-grids
+   explanations/grid-types
+   explanations/data-releases
    components-overview/processing-pipeline
    components-overview/machine-learning-components
    components-overview/stellar-binary-simulation
+   components-overview/population-synthesis
 
 .. toctree::
    :maxdepth: 1
    :caption: API Reference
 
+   components-overview/mesa-grids
    api_reference/posydon
    api_reference/bin
 
 
 .. toctree::
    :maxdepth: 1
-   :caption: Releases and Datasets
+   :caption: Additional Information
 
+   introduction-acknowledgements/intro
+   Collaborative Team <https://posydon.org/team.html>
+   Publications <https://ui.adsabs.harvard.edu/public-libraries/ZZsD9bzLTzWnLV3hwyJxbA>
    Releases <https://github.com/POSYDON-code/POSYDON/releases>
    Datasets <https://zenodo.org/communities/posydon/>
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Support and Contact
-
    contact-support/contact-information
    troubleshooting-faqs/installation-issues
    troubleshooting-faqs/code-questions

--- a/docs/_source/introduction-acknowledgements/intro.rst
+++ b/docs/_source/introduction-acknowledgements/intro.rst
@@ -27,26 +27,50 @@ If you use POSYDON for your research and it contributes to a publication, we kin
 
 .. code-block::
 
-        @ARTICLE{2023ApJS..264...45F,
-            author = {{Fragos}, Tassos and {Andrews}, Jeff J. and {Bavera}, Simone S. and {Berry}, Christopher P.~L. and {Coughlin}, Scott and {Dotter}, Aaron and {Giri}, Prabin and {Kalogera}, Vicky and {Katsaggelos}, Aggelos and {Kovlakas}, Konstantinos and {Lalvani}, Shamal and {Misra}, Devina and {Srivastava}, Philipp M. and {Qin}, Ying and {Rocha}, Kyle A. and {Rom{\'a}n-Garza}, Jaime and {Serra}, Juan Gabriel and {Stahle}, Petter and {Sun}, Meng and {Teng}, Xu and {Trajcevski}, Goce and {Tran}, Nam Hai and {Xing}, Zepei and {Zapartas}, Emmanouil and {Zevin}, Michael},
-            title = "{POSYDON: A General-purpose Population Synthesis Code with Detailed Binary-evolution Simulations}",
-            journal = {\apjs},
-            keywords = {Binary stars, Close binary stars, Compact binary stars, Interacting binary stars, X-ray binary stars, Compact objects, Stellar remnants, Black holes, Neutron stars, Gravitational wave sources, Stellar evolutionary models, Stellar populations, 154, 254, 283, 801, 1811, 288, 1627, 162, 1108, 677, 2046, 1622, Astrophysics - Solar and Stellar Astrophysics},
-            year = 2023,
-            month = feb,
-            volume = {264},
-            number = {2},
-            eid = {45},
-            pages = {45},
-            doi = {10.3847/1538-4365/ac90c1},
-            archivePrefix = {arXiv},
-            eprint = {2202.05892},
-            primaryClass = {astro-ph.SR},
-            adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJS..264...45F},
-            adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-        }
+    @ARTICLE{2023ApJS..264...45F,
+        author = {{Fragos}, Tassos and {Andrews}, Jeff J. and {Bavera}, Simone S. and {Berry}, Christopher P.~L. and {Coughlin}, Scott and {Dotter}, Aaron and {Giri}, Prabin and {Kalogera}, Vicky and {Katsaggelos}, Aggelos and {Kovlakas}, Konstantinos and {Lalvani}, Shamal and {Misra}, Devina and {Srivastava}, Philipp M. and {Qin}, Ying and {Rocha}, Kyle A. and {Rom{\'a}n-Garza}, Jaime and {Serra}, Juan Gabriel and {Stahle}, Petter and {Sun}, Meng and {Teng}, Xu and {Trajcevski}, Goce and {Tran}, Nam Hai and {Xing}, Zepei and {Zapartas}, Emmanouil and {Zevin}, Michael},
+        title = "{POSYDON: A General-purpose Population Synthesis Code with Detailed Binary-evolution Simulations}",
+        journal = {\apjs},
+        keywords = {Binary stars, Close binary stars, Compact binary stars, Interacting binary stars, X-ray binary stars, Compact objects, Stellar remnants, Black holes, Neutron stars, Gravitational wave sources, Stellar evolutionary models, Stellar populations, 154, 254, 283, 801, 1811, 288, 1627, 162, 1108, 677, 2046, 1622, Astrophysics - Solar and Stellar Astrophysics},
+        year = 2023,
+        month = feb,
+        volume = {264},
+        number = {2},
+        eid = {45},
+        pages = {45},
+        doi = {10.3847/1538-4365/ac90c1},
+        archivePrefix = {arXiv},
+        eprint = {2202.05892},
+        primaryClass = {astro-ph.SR},
+        adsurl = {https://ui.adsabs.harvard.edu/abs/2023ApJS..264...45F},
+        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }
 
 
-- POSYDON Version 2:  Population Synthesis across Metallicities with Detailed Binary-Evolution Simulation, Andrews et al. (in prep.)
+- `POSYDON version 2: population synthesis with detailed binary-evolution simulations across a cosmological range of metallicities <https://ui.adsabs.harvard.edu/abs/2025ApJS..281....3A>`_, **Andrews et al. (2025)**
+
+.. code-block::
+
+    @ARTICLE{2025ApJS..281....3A,
+        author = {{Andrews}, Jeff J. and {Bavera}, Simone S. and {Briel}, Max and {Chattaraj}, Abhishek and {Dotter}, Aaron and {Fragos}, Tassos and {Gallegos-Garcia}, Monica and {Gossage}, Seth and {Kalogera}, Vicky and {Kasdagli}, Eirini and {Katsaggelos}, Aggelos and {Kimball}, Chase and {Kovlakas}, Konstantinos and {Kruckow}, Matthias U. and {Liotine}, Camille and {Misra}, Devina and {Rocha}, Kyle A. and {Souropanis}, Dimitris and {Srivastava}, Philipp M. and {Sun}, Meng and {Teng}, Elizabeth and {Xing}, Zepei and {Zapartas}, Emmanouil and {Zevin}, Michael},
+        title = "{POSYDON Version 2: Population Synthesis with Detailed Binary-evolution Simulations across a Cosmological Range of Metallicities}",
+        journal = {\apjs},
+        keywords = {Binary stars, Stellar populations, Massive stars, High mass x-ray binary stars, Stellar evolutionary models, 154, 1622, 732, 733, 2046, Astrophysics of Galaxies, Solar and Stellar Astrophysics},
+        year = 2025,
+        month = nov,
+        volume = {281},
+        number = {1},
+        eid = {3},
+        pages = {3},
+        doi = {10.3847/1538-4365/adfb78},
+        archivePrefix = {arXiv},
+        eprint = {2411.02376},
+        primaryClass = {astro-ph.GA},
+        adsurl = {https://ui.adsabs.harvard.edu/abs/2025ApJS..281....3A},
+        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
+
+
 
 Acknowledging these works ensures that the development team receives proper credit and supports the continued advancement and maintenance of the POSYDON software.

--- a/docs/_source/tutorials-examples/MESA-grids/running-grids.rst
+++ b/docs/_source/tutorials-examples/MESA-grids/running-grids.rst
@@ -62,7 +62,9 @@ The following tutorial will show you how to run a grid of MESA simulations using
 
     running_a_grid
 
-Now that you have run your first grid, you can process, visualize and explore the results using the POSYDON post-processing pipeline API. TODO: link
+Now that you have run your first grid, you can process, visualize and explore
+the results using the POSYDON :ref:`post-processing pipeline
+<processing-pipeline>`.
 
 III. Running single stars with POSYDON
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,7 +75,9 @@ This tutorials shows how to run a grid of single star simulations using POSYDON.
 
    running_single_hms
 
-We show how to export EEPs and make a PSyGrid object in this tutorial TODO: link the advanced tutorial of step 2.
+We show how to export EEPs and make a PSyGrid object in this tutorial
+(see the :ref:`PSyGrid <psygrid>` and :ref:`post-processing pipeline
+<processing-pipeline>` pages for how the extracted data is organized).
 
 Advanced Tutorials
 ------------------
@@ -106,4 +110,6 @@ Provided a sparse, rectilinearly sampled MESA grid, POSYDON allows to dynamicall
 Support & Feedback
 ------------------
 
-Encountered obstacles or have questions? Ensure you consult our [FAQ](link-to-FAQ) or drop by the [contact-information.rst](contact-information.rst) page.
+Encountered obstacles or have questions? Ensure you consult our
+:ref:`code usage FAQ <code-usage>` or drop by the
+:ref:`contact information <contact_info>` page.

--- a/docs/_source/tutorials-examples/population-synthesis/binary-pop-syn.rst
+++ b/docs/_source/tutorials-examples/population-synthesis/binary-pop-syn.rst
@@ -69,11 +69,6 @@ In this tutorial, you will learn how to change the assumption of star-formation 
 
     one_met_pop_syn
 
-X-ray binaries: computing the X-ray luminosity function 🩻
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-TODO: bring v1 tutorial to v2 leveraging the SyntheticPopulation class
-
 
 Evolving Single Binaries 🐞
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,17 +102,5 @@ Dive deeper into POSYDON's visualization capabilities. This tutorial explores th
 
     Van den Heuvel Diagrams <VHD>
 
-
-Deep Dive: Behind the Scenes Customizations
--------------------------------------------
-
-Dive into the nitty-gritty of POSYDON's inner workings. Customize, extend, and tweak the system to fit your unique requirements:
-
-Customizing the Population Synthesis Class 🛠️
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   - Understand the foundational class driving our binary-star population synthesis. Learn to modify and adapt it to your needs.
-   - 🔗 [Delve into class customizations](link-to-customization-notebook1)
-
-(Add other in-depth customization tutorials here...)
 
 Remember, mastering POSYDON is a journey, not a destination. As you progress through these tutorials, you'll uncover layers of capabilities and functionalities. Keep exploring and happy simulating!


### PR DESCRIPTION
This PR reorganises some of the tutorials and documentation (does not contain PR 878!!! PR https://github.com/POSYDON-code/POSYDON/pull/878)

The following changes are implemented:

- [x] re-order the index.html page
- [x] Adds an explanations folder with two pages describing the data-releases and grid-type
- [x]  Add a supernova_models page describing the supernova models (CCSN and PISN) that are pre-trained and those available without the pre-training.
- [x] Add a page about reweighting
- [x] Adds the automatic installation script to the installation instructions.