### PR TITLE
[enhancement] Add check for already downloaded data

### DIFF
--- a/posydon/unit_tests/utils/test_data_download.py
+++ b/posydon/unit_tests/utils/test_data_download.py
@@ -12,13 +12,14 @@ import posydon.utils.data_download as totest
 # aliases
 os = totest.os
 
-from contextlib import chdir
-from inspect import isclass, isroutine
-from shutil import rmtree
-from unittest.mock import patch
-
 # import other needed code for the tests, which is not already imported in the
 # module you like to test
+import hashlib
+from contextlib import chdir
+from inspect import isclass, isroutine
+from shutil import copyfile, rmtree
+from unittest.mock import patch
+
 from pytest import approx, fixture, raises, warns
 
 from posydon.utils.posydonwarning import ReplaceValueWarning
@@ -32,10 +33,12 @@ class TestElements:
                     'Pwarn', 'ZENODO_COLLECTION', '__authors__',\
                     '__builtins__', '__cached__', '__doc__', '__file__',\
                     '__loader__', '__name__', '__package__', '__spec__',\
+                    '_GRID_DIRS', '_INTERP_GRID_DIRS', '_INTERP_METHODS',\
+                    '_dataset_installed', '_expected_paths', '_md5_of_file',\
                     '_get_posydon_data', '_parse_commandline', 'argparse',\
-                    'data_download', 'download_one_dataset', 'hashlib',\
-                    'list_datasets', 'os', 'progressbar', 'tarfile',\
-                    'textwrap', 'tqdm', 'urllib'}
+                    'convert_metallicity_to_string', 'data_download',\
+                    'download_one_dataset', 'hashlib', 'list_datasets', 'os',\
+                    'progressbar', 'tarfile', 'textwrap', 'tqdm', 'urllib'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\
@@ -59,6 +62,15 @@ class TestElements:
 
     def test_instance_list_datasets(self):
         assert isroutine(totest.list_datasets)
+
+    def test_instance_expected_paths(self):
+        assert isroutine(totest._expected_paths)
+
+    def test_instance_dataset_installed(self):
+        assert isroutine(totest._dataset_installed)
+
+    def test_instance_md5_of_file(self):
+        assert isroutine(totest._md5_of_file)
 
     def test_instance_download_one_dataset(self):
         assert isroutine(totest.download_one_dataset)
@@ -108,13 +120,13 @@ class TestFunctions:
             mp.setattr(totest.argparse.ArgumentParser, "error", mock_error)
             # bad input
             self.commandline_args = totest.argparse.Namespace(dataset='Test',\
-             listedsets=None, nomd5check=False, verbose=False)
+             listedsets=None, nomd5check=False, force=False, verbose=False)
             with raises(totest.argparse.ArgumentError,\
                         match="unknown dataset, use -l to show defined sets"):
                 totest._parse_commandline()
             # example
             self.commandline_args = totest.argparse.Namespace(dataset='DR1',\
-             listedsets=None, nomd5check=False, verbose=False)
+             listedsets=None, nomd5check=False, force=False, verbose=False)
             assert totest._parse_commandline() == self.commandline_args
 
     def test_list_datasets(self, capsys):
@@ -132,10 +144,80 @@ class TestFunctions:
             if v:
                 assert "more information at" in captured_output.out
 
+    def test_expected_paths(self):
+        # grid data sets contain the grids and their pre-trained interpolators
+        for suffix, z_str in [('2', '2e+00'), ('0.45', '4.5e-01'),
+                              ('1e-3', '1e-03')]:
+            expected_paths = totest._expected_paths(
+                'DR2_grids_'+suffix+'Zsun')
+            assert len(expected_paths)\
+                   == (len(totest._GRID_DIRS)
+                       +(len(totest._INTERP_GRID_DIRS)
+                         *len(totest._INTERP_METHODS)))
+            for grid_dir in totest._GRID_DIRS:
+                assert os.path.join(grid_dir, z_str+"_Zsun.h5")\
+                       in expected_paths
+            for grid_dir in totest._INTERP_GRID_DIRS:
+                for interp_method in totest._INTERP_METHODS:
+                    assert os.path.join(grid_dir, "interpolators",
+                                        interp_method,
+                                        z_str+"_Zsun.pkl")\
+                           in expected_paths
+        # unsupported metallicities cannot be verified
+        assert totest._expected_paths('DR2_grids_bogusZsun') is None
+        assert totest._expected_paths('DR2_grids_5Zsun') is None
+        assert totest._expected_paths('DR2_grids_Zsun') is None
+        # other known data sets
+        assert totest._expected_paths('auxiliary') is not None
+        assert totest._expected_paths('DR1_for_v2.0.0-pre1') is not None
+        assert totest._expected_paths('DR1-super_Eddington') is not None
+        assert len(totest._expected_paths('DR1-super_Eddington')) == 3
+        # unknown data sets cannot be verified
+        assert totest._expected_paths('DR2') is None
+        assert totest._expected_paths('v2_tutorial_populations') is None
+
+    def test_dataset_installed(self, monkeypatch, test_path):
+        with monkeypatch.context() as mp:
+            mp.setattr(totest, "PATH_TO_POSYDON_DATA", test_path)
+            # data sets with unknown content cannot be verified
+            assert totest._dataset_installed('Test') == False
+            assert totest._dataset_installed('v2_tutorial_populations')\
+                   == False
+            # partially extracted data sets are not installed
+            auxiliary_paths = totest._expected_paths('auxiliary')
+            for path in auxiliary_paths[:-1]:
+                os.makedirs(os.path.join(test_path, os.path.dirname(path)),
+                            exist_ok=True)
+                with open(os.path.join(test_path, path), "a"):
+                    pass
+            assert totest._dataset_installed('auxiliary') == False
+            # fully extracted data sets are installed
+            with open(os.path.join(test_path, auxiliary_paths[-1]), "a"):
+                pass
+            assert totest._dataset_installed('auxiliary') == True
+
+    def test_md5_of_file(self, tmp_path):
+        content = b"Unit Test\n"
+        test_file_path = os.path.join(tmp_path, "unit_test.txt")
+        with open(test_file_path, "wb") as test_file:
+            test_file.write(content)
+        assert totest._md5_of_file(test_file_path)\
+               == hashlib.md5(content).hexdigest()
+
     def test_download_one_dataset(self, capsys, monkeypatch, test_path,\
                                   download_statement, failed_MD5_statement,\
                                   extraction_statement, removal_statement):
-        def mock_urlretrieve(url, filename=None, reporthook=None, data=None):
+        # mocks
+        def failing_urlretrieve(url, filename=None, reporthook=None,\
+                                data=None):
+            # raise an error, if a download should not happen
+            raise RuntimeError("The dataset should not be downloaded.")
+        def mock_urlretrieve_empty(url, filename=None, reporthook=None,\
+                                   data=None):
+            # simulate a download by creating an empty file
+            if isinstance(filename, str):
+                with open(filename, "wb"):
+                    pass
             return None
         class mock_TarFile:
             def getmembers(self):
@@ -151,24 +233,40 @@ class TestFunctions:
                 return mock_TarFile()
             def __exit__(self, exc_type, exc_value, exc_traceback):
                 return False
-        def mock_urlretrieve2(url, filename=None, reporthook=None, data=None):
-            os.mkdir(test_path)
-            if (isinstance(filename, str) and (len(filename)>=8)):
-                test_ID = filename[-8]
-            else:
-                test_ID = ""
-            with open(os.path.join(test_path, "test"+test_ID+".txt"), "w")\
+
+        # helpers
+        directory = os.path.dirname(test_path)
+        filepath = os.path.join(directory, "POSYDON_data.tar.gz")
+        partpath = filepath+".part"
+        pristine_archive = os.path.join(directory,
+                                        "POSYDON_data_pristine.tar.gz")
+
+        def mock_urlretrieve_archive(url, filename=None, reporthook=None,\
+                                     data=None):
+            # simulate a download by providing the correct archive
+            copyfile(pristine_archive, filename)
+            return None
+
+        def build_archive():
+            # create a small tar.gz archive at filepath
+            os.makedirs(test_path, exist_ok=True)
+            with open(os.path.join(test_path, "test.txt"), "w")\
                  as test_file:
                 test_file.write("Unit Test\n")
-            with chdir(os.path.join(test_path,"..")):
-                try:
-                    os.system("tar -czf POSYDON_data"+test_ID\
-                              +".tar.gz POSYDON_data")
-                except:
+            with chdir(directory):
+                if os.system("tar -czf POSYDON_data.tar.gz POSYDON_data")\
+                   != 0:
                     raise RuntimeError("Please check that you have `tar` "\
                                        +"installed and up to date.")
             rmtree(test_path)
-            return None
+
+        def clean_up():
+            # remove leftovers of previous test scenarios
+            for leftover in [filepath, partpath]:
+                if os.path.exists(leftover):
+                    os.remove(leftover)
+            if os.path.exists(test_path):
+                rmtree(test_path)
 
         # bad input
         with raises(TypeError, match="'dataset' should be a string."):
@@ -192,37 +290,46 @@ class TestFunctions:
                                                   +"not refer to a valid "\
                                                   +"directory."):
                 totest.download_one_dataset(dataset='DR1_for_v2.0.0-pre1')
-        # bad input
+
+        # installed data sets get skipped
         with monkeypatch.context() as mp:
-            mock_ZENODO_COLLECTION = {'Test': {'data' : "./", 'md5': "Unit"}}
-            mp.setattr(totest, "ZENODO_COLLECTION", mock_ZENODO_COLLECTION)
-            with raises(FileExistsError, match="POSYDON data already exists "\
-                                               +"at"):
-                totest.download_one_dataset(dataset='Test')
-        # skip real download: do nothing instead
+            mp.setattr(totest, "PATH_TO_POSYDON_DATA", test_path)
+            mp.setattr(totest, "ZENODO_COLLECTION",
+                       {'auxiliary': totest.ZENODO_COLLECTION['auxiliary']})
+            mp.setattr(totest.urllib.request, "urlretrieve",
+                       failing_urlretrieve)
+            for path in totest._expected_paths('auxiliary'):
+                os.makedirs(os.path.join(test_path, os.path.dirname(path)),
+                            exist_ok=True)
+                with open(os.path.join(test_path, path), "a"):
+                    pass
+            totest.download_one_dataset(dataset='auxiliary')
+            captured_output = capsys.readouterr()
+            assert "POSYDON data 'auxiliary' is already present, skipping."\
+                   in captured_output.out
+            clean_up()
+            # forced downloads happen anyway
+            mp.setattr(totest.urllib.request, "urlretrieve",
+                       mock_urlretrieve_empty)
+            mp.setattr(totest.tarfile, "open", mock_open)
+            totest.download_one_dataset(dataset='auxiliary', MD5_check=False,
+                                        force=True)
+            captured_output = capsys.readouterr()
+            assert download_statement.format('auxiliary')\
+                   in captured_output.out
+            assert extraction_statement.format('auxiliary')\
+                   in captured_output.out
+            clean_up()
+
+        # downloads without an available MD5 checksum cannot be verified
         with monkeypatch.context() as mp:
             mp.setattr(totest, "PATH_TO_POSYDON_DATA", test_path)
             mock_ZENODO_COLLECTION = {'Test': {'data': "POSYDON_data.tar.gz",
-                                               'md5': "Unit"}}
+                                               'md5': None}}
             mp.setattr(totest, "ZENODO_COLLECTION", mock_ZENODO_COLLECTION)
-            mp.setattr(totest.urllib.request, "urlretrieve", mock_urlretrieve)
+            mp.setattr(totest.urllib.request, "urlretrieve",
+                       mock_urlretrieve_empty)
             mp.setattr(totest.tarfile, "open", mock_open)
-            # mocked download: fails MD5check, no tar file to remove
-            totest.download_one_dataset(dataset='Test', verbose=True)
-            captured_output = capsys.readouterr()
-            assert download_statement.format('Test') in captured_output.out
-            assert failed_MD5_statement in captured_output.out
-            assert extraction_statement.format('Test') in captured_output.out
-            assert removal_statement not in captured_output.out
-            # without MD5 check
-            totest.download_one_dataset(dataset='Test', MD5_check=False)
-            captured_output = capsys.readouterr()
-            assert download_statement.format('Test') in captured_output.out
-            assert failed_MD5_statement not in captured_output.out
-            assert extraction_statement.format('Test') in captured_output.out
-            assert removal_statement not in captured_output.out
-            # without MD5 check
-            mock_ZENODO_COLLECTION['Test']['md5'] = None
             with warns(ReplaceValueWarning, match="MD5 undefined, skip MD5 "\
                                                   +"check."):
                 totest.download_one_dataset(dataset='Test')
@@ -231,53 +338,96 @@ class TestFunctions:
             assert failed_MD5_statement not in captured_output.out
             assert extraction_statement.format('Test') in captured_output.out
             assert removal_statement not in captured_output.out
-        # skip real download: create mock file instead
+            clean_up()
+            # incomplete leftover downloads get removed and restarted
+            with open(partpath, "wb"):
+                pass
+            totest.download_one_dataset(dataset='Test', verbose=True)
+            captured_output = capsys.readouterr()
+            assert "Removing incomplete download 'POSYDON_data.tar.gz"\
+                   +".part'" in captured_output.out
+            assert download_statement.format('Test') in captured_output.out
+            assert extraction_statement.format('Test') in captured_output.out
+            clean_up()
+
+        # corrupted fresh downloads get removed and raise an error
         with monkeypatch.context() as mp:
             mp.setattr(totest, "PATH_TO_POSYDON_DATA", test_path)
-            mock_ZENODO_COLLECTION = {'Test0': {'data': "POSYDON_data0.tar.gz",
-                                                'md5': "Unit"},
-                                      'Test1': {'data': "POSYDON_data1.tar.gz",
-                                                'md5': "Unit"},
-                                      'Test2': {'data': "POSYDON_data2.tar.gz",
-                                                'md5': "Unit"}}
+            mock_ZENODO_COLLECTION = {'Test': {'data': "POSYDON_data.tar.gz",
+                                               'md5': "Unit"}}
             mp.setattr(totest, "ZENODO_COLLECTION", mock_ZENODO_COLLECTION)
-            mp.setattr(totest.urllib.request, "urlretrieve", mock_urlretrieve2)
-            # mocked download: fails MD5check, which removes tar file and
-            #                  causes a FileNotFoundError
-            with raises(FileNotFoundError, match="No such file or directory:"):
-                totest.download_one_dataset(dataset='Test0', verbose=True)
+            mp.setattr(totest.urllib.request, "urlretrieve",
+                       mock_urlretrieve_empty)
+            mp.setattr(totest.tarfile, "open", mock_open)
+            with raises(ValueError, match="MD5 verification failed!."):
+                totest.download_one_dataset(dataset='Test')
             captured_output = capsys.readouterr()
-            assert download_statement.format('Test0') in captured_output.out
+            assert download_statement.format('Test') in captured_output.out
+            assert extraction_statement.format('Test') not in\
+                captured_output.out
+            assert failed_MD5_statement not in captured_output.out
+            assert not os.path.exists(filepath)
+            clean_up()
+            # unreadable files cannot be verified, but continue anyway;
+            # here, the archive vanishes before its removal
+            def failing_md5(unused_filepath):
+                os.remove(filepath)
+                raise OSError("unreadable file")
+            mp.setattr(totest, "_md5_of_file", failing_md5)
+            totest.download_one_dataset(dataset='Test')
+            captured_output = capsys.readouterr()
             assert failed_MD5_statement in captured_output.out
-            assert extraction_statement.format('Test0') in captured_output.out
+            assert extraction_statement.format('Test') in captured_output.out
             assert removal_statement not in captured_output.out
-            # return expected hash for testfile
-            with patch("hashlib.md5") as p_md5:
-                p_md5.return_value.hexdigest.return_value\
-                 = mock_ZENODO_COLLECTION['Test1']['md5']
-                totest.download_one_dataset(dataset='Test1')
-                captured_output = capsys.readouterr()
-                assert download_statement.format('Test1')\
-                       in captured_output.out
-                assert failed_MD5_statement not in captured_output.out
-                assert extraction_statement.format('Test1')\
-                       in captured_output.out
-                assert removal_statement not in captured_output.out
-                assert os.path.exists(test_path)
-                assert os.path.exists(os.path.join(test_path, "test1.txt"))
-                rmtree(test_path) # removed extracted data for next test
-                # with verification output
-                totest.download_one_dataset(dataset='Test2', verbose=True)
-                captured_output = capsys.readouterr()
-                assert download_statement.format('Test2')\
-                       in captured_output.out
-                assert "MD5 verified" in captured_output.out
-                assert extraction_statement.format('Test2')\
-                       in captured_output.out
-                assert removal_statement in captured_output.out
-                assert os.path.exists(test_path)
-                assert os.path.exists(os.path.join(test_path, "test2.txt"))
-#                rmtree(test_path) # removed extracted data for next test
+            clean_up()
+
+        # existing complete archives are verified and extracted instead of
+        # being downloaded again
+        build_archive()
+        copyfile(filepath, pristine_archive)
+        original_md5 = totest._md5_of_file(filepath)
+        with monkeypatch.context() as mp:
+            mp.setattr(totest, "PATH_TO_POSYDON_DATA", test_path)
+            mock_ZENODO_COLLECTION = {'Test': {'data': "POSYDON_data.tar.gz",
+                                               'md5': original_md5}}
+            mp.setattr(totest, "ZENODO_COLLECTION", mock_ZENODO_COLLECTION)
+            mp.setattr(totest.urllib.request, "urlretrieve",
+                       failing_urlretrieve)
+            # correct checksum: reuse the existing archive
+            totest.download_one_dataset(dataset='Test', verbose=True)
+            captured_output = capsys.readouterr()
+            assert "Verifying existing archive 'POSYDON_data.tar.gz'"\
+                   in captured_output.out
+            assert "MD5 verified." in captured_output.out
+            assert download_statement.format('Test') not in\
+                captured_output.out
+            assert extraction_statement.format('Test') in captured_output.out
+            assert removal_statement in captured_output.out
+            assert os.path.exists(os.path.join(test_path, "test.txt"))
+            clean_up()
+            # without verbose output
+            build_archive()
+            totest.download_one_dataset(dataset='Test')
+            captured_output = capsys.readouterr()
+            assert "Verifying existing archive" not in captured_output.out
+            clean_up()
+            # wrong checksum: replace the existing archive by a fresh download
+            build_archive()
+            with open(filepath, "ab") as corrupted_archive:
+                corrupted_archive.write(b"corrupted\n")
+            mp.setattr(totest.urllib.request, "urlretrieve",
+                       mock_urlretrieve_archive)
+            totest.download_one_dataset(dataset='Test', verbose=True)
+            captured_output = capsys.readouterr()
+            assert "The existing archive did not pass the MD5 verification,"\
+                   in captured_output.out
+            assert download_statement.format('Test') in captured_output.out
+            assert "MD5 verified." in captured_output.out
+            assert extraction_statement.format('Test') in captured_output.out
+            assert removal_statement in captured_output.out
+            assert os.path.exists(os.path.join(test_path, "test.txt"))
+            clean_up()
+        os.remove(pristine_archive)
 
     def test_data_download(self, capsys, monkeypatch):
         def mock_download_one_dataset(**kwargs):
@@ -301,10 +451,18 @@ class TestFunctions:
                 assert self.kwargs['dataset'] == 'Test'
                 assert self.kwargs['MD5_check'] == True
                 assert self.kwargs['verbose'] == v
+                assert self.kwargs['force'] == False
                 if v:
                     assert "You are downloading a single data set, which "\
                            + "might not contain all the data needed.\n"\
                            == capsys.readouterr().out
+            # test forced download of a single dataset
+            self.kwargs = None
+            totest.data_download(set_name='Test', force=True)
+            assert self.kwargs['dataset'] == 'Test'
+            assert self.kwargs['MD5_check'] == True
+            assert self.kwargs['verbose'] == False
+            assert self.kwargs['force'] == True
             # test complete set
             mock_COMPLETE_SETS = {'Unit': ['Test', 'Test2']}
             mp.setattr(totest, "COMPLETE_SETS", mock_COMPLETE_SETS)
@@ -313,6 +471,7 @@ class TestFunctions:
             assert self.kwargs['dataset'] == 'Test2'
             assert self.kwargs['MD5_check'] == True
             assert self.kwargs['verbose'] == False
+            assert self.kwargs['force'] == False
 
     def test_get_posydon_data(self, monkeypatch):
         def mock_parse_commandline():
@@ -330,22 +489,26 @@ class TestFunctions:
                 for v in [True, False]:
                     self.list_printed = None
                     self.commandline_args = totest.argparse.Namespace(\
-                     dataset='DR1', listedsets=l, nomd5check=False, verbose=v)
+                     dataset='DR1', listedsets=l, nomd5check=False,
+                     force=False, verbose=v)
                     totest._get_posydon_data()
                     assert self.list_printed['individual_sets']\
                            == (l == 'individual')
                     assert self.list_printed['verbose'] == v
             # examples
             for n in [True, False]:
-                for v in [True, False]:
-                    for d in ['DR1', 'DR2']:
-                        self.downloaded = None
-                        self.commandline_args = totest.argparse.Namespace(\
-                         dataset=d, listedsets=None, nomd5check=n, verbose=v)
-                        totest._get_posydon_data()
-                        assert self.downloaded['set_name'] == d
-                        assert self.downloaded['MD5_check'] == (not n)
-                        assert self.downloaded['verbose'] == v
+                for f in [True, False]:
+                    for v in [True, False]:
+                        for d in ['DR1', 'DR2']:
+                            self.downloaded = None
+                            self.commandline_args = totest.argparse.Namespace(\
+                             dataset=d, listedsets=None, nomd5check=n,
+                             force=f, verbose=v)
+                            totest._get_posydon_data()
+                            assert self.downloaded['set_name'] == d
+                            assert self.downloaded['MD5_check'] == (not n)
+                            assert self.downloaded['verbose'] == v
+                            assert self.downloaded['force'] == f
 
 
 class TestProgressBar:

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -19,8 +19,19 @@ import progressbar
 from tqdm import tqdm
 
 from posydon.config import PATH_TO_POSYDON_DATA
+from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.datasets import COMPLETE_SETS, ZENODO_COLLECTION
 from posydon.utils.posydonwarning import Pwarn
+
+# grid directories below PATH_TO_POSYDON_DATA, in which the *_Zsun.h5 files
+# of the grid data sets are expected (see simulationproperties.py)
+_GRID_DIRS = ['single_HMS', 'single_HeMS', 'HMS-HMS', 'HMS-HMS_RLO',
+              'CO-HMS_RLO', 'CO-HeMS', 'CO-HeMS_RLO']
+# binary grid directories, which contain pre-trained interpolators, and the
+# interpolation methods, whose interpolators are distributed with the grids
+_INTERP_GRID_DIRS = ['HMS-HMS', 'HMS-HMS_RLO', 'CO-HMS_RLO', 'CO-HeMS',
+                     'CO-HeMS_RLO']
+_INTERP_METHODS = ['1NN_1NN', 'linear3c_kNN']
 
 
 def _parse_commandline():
@@ -49,6 +60,11 @@ def _parse_commandline():
                         choices=['complete', 'individual'])
     parser.add_argument('-n', '--nomd5check',
                         help="do not confirm md5 checksum (default: False)",
+                        default=False,
+                        action='store_true')
+    parser.add_argument('-f', '--force',
+                        help="download the data even if they seem to be "
+                             "already installed (default: False)",
                         default=False,
                         action='store_true')
     parser.add_argument('-v', '--verbose',
@@ -118,14 +134,104 @@ def list_datasets(individual_sets=False, verbose=False):
                                                subsequent_indent=indent)
                 print(wrapper.fill(ZENODO_COLLECTION[dataset]['title']))
                 if verbose:
-                    wrapper = textwrap.TextWrapper(initial_indent=indent, width=80,
+                    wrapper = textwrap.TextWrapper(initial_indent=indent,
+                                                   width=80,
                                                    subsequent_indent=indent)
-                    print(wrapper.fill(ZENODO_COLLECTION[dataset]['description']))
+                    print(wrapper.fill(
+                        ZENODO_COLLECTION[dataset]['description']))
                     print(wrapper.fill("more information at "
                                        +ZENODO_COLLECTION[dataset]['url']))
 
-def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
-    """Download a data set from Zenodo if they do not exist.
+def _expected_paths(dataset):
+    """Get the paths, relative to PATH_TO_POSYDON_DATA, whose presence
+    indicates that a data set is installed.
+
+        Parameters
+        ----------
+        dataset : string
+            Name of the data set in ZENODO_COLLECTION.
+
+        Returns
+        -------
+        list of strings or None
+            Relative paths created by extracting the data set. None, if
+            they cannot be determined.
+
+    """
+    if dataset.startswith('DR2_grids_') and dataset.endswith('Zsun'):
+        suffix = dataset[len('DR2_grids_'):-len('Zsun')]
+        try:
+            z_str = convert_metallicity_to_string(float(suffix))
+        except ValueError:
+            return None
+        return [os.path.join(grid_dir, z_str + "_Zsun.h5")
+                for grid_dir in _GRID_DIRS] \
+               + [os.path.join(grid_dir, "interpolators", interp_method,
+                               z_str + "_Zsun.pkl")
+                  for grid_dir in _INTERP_GRID_DIRS
+                  for interp_method in _INTERP_METHODS]
+    elif dataset == 'auxiliary':
+        return ["SFR/IllustrisTNG.npz", "SFR/Zavala+21.txt",
+                "selection_effects/pdet_grid.hdf5", "Sukhbold+16",
+                "Patton+Sukhbold20", "Couch+2020"]
+    elif dataset == 'DR1_for_v2.0.0-pre1':
+        z_str = convert_metallicity_to_string(1.)
+        return [os.path.join(grid_dir, z_str + "_Zsun.h5")
+                for grid_dir in _GRID_DIRS] \
+               + ["Sukhbold+16", "Patton+Sukhbold20", "Couch+2020"]
+    elif dataset == 'DR1-super_Eddington':
+        # NOTE: it replaces the solar metallicity CO-* grids of
+        #       'DR1_for_v2.0.0-pre1', hence these two data sets cannot be
+        #       distinguished by their extracted files: use 'force' to
+        #       switch between them.
+        z_str = convert_metallicity_to_string(1.)
+        return [os.path.join(grid_dir, z_str + "_Zsun.h5")
+                for grid_dir in ['CO-HMS_RLO', 'CO-HeMS', 'CO-HeMS_RLO']]
+    return None
+
+def _dataset_installed(dataset):
+    """Check whether a data set seems to be already installed.
+
+        Parameters
+        ----------
+        dataset : string
+            Name of the data set in ZENODO_COLLECTION.
+
+        Returns
+        -------
+        boolean
+            True, if all expected paths of the data set exist.
+
+    """
+    expected_paths = _expected_paths(dataset)
+    if not expected_paths:
+        return False
+    return all(os.path.exists(os.path.join(PATH_TO_POSYDON_DATA, path))
+               for path in expected_paths)
+
+def _md5_of_file(filepath):
+    """Calculate the MD5 checksum of a file without loading it into memory.
+
+        Parameters
+        ----------
+        filepath : string
+            Path to the file.
+
+        Returns
+        -------
+        string
+            The hexadecimal MD5 checksum of the file.
+
+    """
+    md5 = hashlib.md5()
+    with open(filepath, "rb") as file_to_check:
+        for chunk in iter(lambda: file_to_check.read(65536), b""):
+            md5.update(chunk)
+    return md5.hexdigest()
+
+def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False,
+                         force=False):
+    """Download a data set from Zenodo if it is not installed yet.
 
         Parameters
         ----------
@@ -135,6 +241,8 @@ def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
             Use the MD5 check to make sure data is not corrupted.
         verbose : boolean (default: False)
             Enables verbose output.
+        force : boolean (default: False)
+            Download the data even if they seem to be already installed.
 
     """
     if not isinstance(dataset, str):
@@ -142,7 +250,12 @@ def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
     if dataset not in ZENODO_COLLECTION:
         raise KeyError(f"The dataset '{dataset}' is not defined.")
 
-    # First, generate filename and make sure the path does not exist
+    # skip data sets, which seem to be installed already
+    if not force and _dataset_installed(dataset):
+        print(f"POSYDON data '{dataset}' is already present, skipping.")
+        return
+
+    # First, generate filename and make sure the path exists
     data_url = ZENODO_COLLECTION[dataset]['data']
     if data_url is None:
         raise ValueError(f"The dataset '{dataset}' has no publication yet.")
@@ -153,39 +266,53 @@ def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
     filename = os.path.basename(data_url)
     directory = os.path.dirname(PATH_TO_POSYDON_DATA)
     filepath = os.path.join(directory, filename)
+    partpath = filepath + ".part"
     if not os.path.isdir(os.path.dirname(filepath)):
         raise NotADirectoryError("PATH_TO_POSYDON_DATA does not refer to a "
                                  "valid directory.")
-    if os.path.exists(filepath):
-        raise FileExistsError(f"POSYDON data already exists at {filepath}.")
 
-    # Download the data
-    print(f"Downloading POSYDON data '{dataset}' from Zenodo to {directory}")
-    urllib.request.urlretrieve(data_url, filepath, ProgressBar())
+    # handle leftovers of previous interrupted downloads: an incomplete
+    # download gets removed and restarted, whereas a complete archive is
+    # verified below and extracted instead of being downloaded again
+    use_existing_archive = os.path.exists(filepath)
+    if os.path.exists(partpath):
+        print(f"Removing incomplete download '{filename}.part'...")
+        os.remove(partpath)
 
-    # Compare original MD5 with freshly calculated
-    if MD5_check:
-        try:
-            with open(filepath, "rb") as file_to_check:
-                # read contents of the file
-                data = file_to_check.read()
+    # download the data (unless a complete archive exists already) and
+    # verify its integrity; a corrupted leftover archive gets replaced by a
+    # fresh download instead of aborting
+    verified = not MD5_check
+    while True:
+        if use_existing_archive:
+            if verbose:
+                print(f"Verifying existing archive '{filename}'...")
+        else:
+            print(f"Downloading POSYDON data '{dataset}' from Zenodo to "
+                  +directory)
+            urllib.request.urlretrieve(data_url, partpath, ProgressBar())
+            os.replace(partpath, filepath)
 
-            # pipe contents of the file through
-            md5_returned = hashlib.md5(data).hexdigest()
-
-            if original_md5 == md5_returned:
-                if verbose:
+        # Compare original MD5 with freshly calculated
+        if MD5_check:
+            try:
+                verified = (_md5_of_file(filepath) == original_md5)
+                if verified and verbose:
                     print("MD5 verified.")
-            else:
-                # Delete file - we cannot rely upon that data
-                os.remove(filepath)
-
-                # Raise value error
-                raise ValueError("MD5 verification failed!.")
-        except:
-            print('Failed to read the tar.gz file for MD5 verification, '
-                  'cannot guarantee file integrity (this error seems to '
-                  'happen only on macOS).')
+            except OSError:
+                verified = True
+                print('Failed to read the tar.gz file for MD5 verification, '
+                      'cannot guarantee file integrity (this error seems to '
+                      'happen only on macOS).')
+        if verified:
+            break
+        os.remove(filepath)
+        if use_existing_archive:
+            use_existing_archive = False
+            print("The existing archive did not pass the MD5 verification, "
+                  "downloading it again.")
+        else:
+            raise ValueError("MD5 verification failed!.")
 
     # extract each file
     print(f"Extracting POSYDON data '{dataset}' from tar file...")
@@ -200,8 +327,8 @@ def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
             print('Removed downloaded tar file.')
         os.remove(filepath)
 
-def data_download(set_name='DR2', MD5_check=True, verbose=False):
-    """Download data files from Zenodo if they do not exist.
+def data_download(set_name='DR2', MD5_check=True, verbose=False, force=False):
+    """Download data files from Zenodo if they are not installed yet.
 
         Parameters
         ----------
@@ -211,6 +338,8 @@ def data_download(set_name='DR2', MD5_check=True, verbose=False):
             Use the MD5 check to make sure data is not corrupted.
         verbose : boolean (default: False)
             Enables verbose output.
+        force : boolean (default: False)
+            Download the data even if they seem to be already installed.
 
     """
     if not isinstance(set_name, str):
@@ -219,13 +348,13 @@ def data_download(set_name='DR2', MD5_check=True, verbose=False):
     if set_name in COMPLETE_SETS:
         for dataset in COMPLETE_SETS[set_name]:
             download_one_dataset(dataset=dataset, MD5_check=MD5_check,
-                                 verbose=verbose)
+                                 verbose=verbose, force=force)
     elif set_name in ZENODO_COLLECTION:
         if verbose:
             print("You are downloading a single data set, which might not "
                   "contain all the data needed.")
         download_one_dataset(dataset=set_name, MD5_check=MD5_check,
-                             verbose=verbose)
+                             verbose=verbose, force=force)
     else:
         raise KeyError(f"The dataset '{set_name}' is not defined.")
 
@@ -240,4 +369,4 @@ def _get_posydon_data():
         list_datasets(individual_sets=True, verbose=args.verbose)
     else:
         data_download(set_name=args.dataset, MD5_check=not args.nomd5check,
-                      verbose=args.verbose)
+                      verbose=args.verbose, force=args.force)


### PR DESCRIPTION
This checks if datasets are already downloaded to allow you to repeat the same command as before, e.g. 

```
get-posydon-data DR2
```
With the auxilliray data, 2Zsun, and 1Zsun already downloaded, gives: 

```
(posydon-debug) ➜  ~ get-posydon-data DR2
POSYDON data 'auxiliary' is already present, skipping.
POSYDON data 'DR2_grids_2Zsun' is already present, skipping.
POSYDON data 'DR2_grids_1Zsun' is already present, skipping.
Downloading POSYDON data 'DR2_grids_0.45Zsun' from Zenodo to /Users/max/Documents/POSYDON_popsynth_data/v2/v2.3.0
```

additional adds:
- downloads in progress are names <file>.tar.gz.part and are renamed on success. The leftover complete tarball is MD5-verified and extracted (similar to before). But if the file already exists, instead of raising a FileExistsError, a corrupt leftover is deleted and re-downloaded.
- a new `-f/--force` to re-download regardless of file existence is added.
