### PR TITLE
[fix] add check against scalars + comment on redundant code

### DIFF
--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -918,11 +918,14 @@ class BinaryStar:
             setattr(binary, 'orbital_period', list(period)[-1])
 
         # set the binary, star1, star2 parameters to last history value in df
+        # TODO: remove code? The binary = cls() line already implements
+        # the setting of the right parameters. We don't need to set them here again.
         for params, pointer in zip(
                 [star1_params,  star2_params,  binary_params],
                 [binary.star_1, binary.star_2, binary]):
             for key, val in params.items():
-                setattr(pointer, key.split('_history')[0], val[-1])
+                final_val = val[-1] if isinstance(val, (list, np.ndarray)) else val
+                setattr(pointer, key.split('_history')[0], final_val)
 
         # make BINARYPROPERTIES, history columns same length if not given
         already_included_cols = [name.split('_history')[0]


### PR DESCRIPTION
This fixes a bug when creating a binary from a previous run, it would fail. 

This was due to the natal_kicks being set as scalars in v2.3. This makes it that if the value is not a list (a history), the value is used instead of the last element.

Previously (before the change to the natal_kick_array treatment), we incorrectly set the last element of the natal_kick_array as the "natal_kick_array" value. 

I did notice that in SingleStar and BinaryStar, we're correctly setting the parameters already. This code is setting it again, and is thus not useful. But requires more testing to be removed, so not done here.


