### PR TITLE
Say what file triggered `data_download` when a file is missing

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -302,7 +302,7 @@ class MesaGridStep:
             Pwarn(f"While loading interpolators, unable to find {self.grid_name}."
                    "Attempting to download the data from Zenodo.",
                    "MissingFilesWarning")
-            data_download()
+            data_download(confirm=True)
 
         if self.verbose:
             print("loading psyTrackInterp: {}".format(self.grid_name))
@@ -321,7 +321,7 @@ class MesaGridStep:
             Pwarn(f"While loading interpolators, unable to find {filename}."
                    "Attempting to download the data from Zenodo.",
                    "MissingFilesWarning")
-            data_download()
+            data_download(confirm=True)
 
         # Load interpolator
         self._Interp = IFInterpolator()

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -318,6 +318,9 @@ class MesaGridStep:
 
         # Check if interpolation files exist
         if not os.path.exists(filename):
+            Pwarn(f"While loading interpolators, unable to find {filename}."
+                   "Attempting to download the data from Zenodo.",
+                   "MissingFilesWarning")
             data_download()
 
         # Load interpolator

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -370,6 +370,9 @@ class StepSN(object):
                     filename = os.path.join(self.path_to_Patton_datasets,
                                             file_name)
                     if not os.path.exists(filename):
+                        Pwarn(f"While loading auxiliary data, unable to find {filename}."
+                               "Attempting to download the data from Zenodo.",
+                               "MissingFilesWarning")
                         data_download(set_name='auxiliary')
 
                     # Reading the dataset
@@ -2615,6 +2618,9 @@ class Sukhbold16_corecollapse(object):
             filename = os.path.join(path_engine_dataset,
                                     "results_" + self.engine + "_table.csv")
             if not os.path.exists(filename):
+                Pwarn(f"While loading auxiliary data, unable to find {filename}."
+                       "Attempting to download the data from Zenodo.",
+                       "MissingFilesWarning")
                 data_download(set_name='auxiliary')
 
             Engine_data = read_csv(filename)
@@ -2808,6 +2814,9 @@ class Couch20_corecollapse(object):
             # Check if interpolation files exist
             filename = os.path.join(path_to_Couch_datasets, 'explDatsSTIR2.json')
             if not os.path.exists(filename):
+                Pwarn(f"While loading auxiliary data, unable to find {filename}."
+                       "Attempting to download the data from Zenodo.",
+                       "MissingFilesWarning")
                 data_download(set_name='auxiliary')
 
             Couch_data_file = open(filename)

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -373,7 +373,7 @@ class StepSN(object):
                         Pwarn(f"While loading auxiliary data, unable to find {filename}."
                                "Attempting to download the data from Zenodo.",
                                "MissingFilesWarning")
-                        data_download(set_name='auxiliary')
+                        data_download(set_name='auxiliary', confirm=True)
 
                     # Reading the dataset
                     data = np.loadtxt(filename, skiprows=6, dtype='str')
@@ -2621,7 +2621,7 @@ class Sukhbold16_corecollapse(object):
                 Pwarn(f"While loading auxiliary data, unable to find {filename}."
                        "Attempting to download the data from Zenodo.",
                        "MissingFilesWarning")
-                data_download(set_name='auxiliary')
+                data_download(set_name='auxiliary', confirm=True)
 
             Engine_data = read_csv(filename)
 
@@ -2817,7 +2817,7 @@ class Couch20_corecollapse(object):
                 Pwarn(f"While loading auxiliary data, unable to find {filename}."
                        "Attempting to download the data from Zenodo.",
                        "MissingFilesWarning")
-                data_download(set_name='auxiliary')
+                data_download(set_name='auxiliary', confirm=True)
 
             Couch_data_file = open(filename)
             Couch_data = json.load(Couch_data_file)

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -200,7 +200,7 @@ def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
             print('Removed downloaded tar file.')
         os.remove(filepath)
 
-def data_download(set_name='DR2', MD5_check=True, verbose=False):
+def data_download(set_name='DR2', MD5_check=True, confirm=False, verbose=False):
     """Download data files from Zenodo if they do not exist.
 
         Parameters
@@ -209,25 +209,40 @@ def data_download(set_name='DR2', MD5_check=True, verbose=False):
             Name of the data set to be in COMPLETE_SETS or ZENODO_COLLECTION.
         MD5_check : boolean (default: True)
             Use the MD5 check to make sure data is not corrupted.
+        confirm : boolean (default: False)
+            If True, then prompt user for confirmation to proceed with download.
         verbose : boolean (default: False)
             Enables verbose output.
 
     """
     if not isinstance(set_name, str):
         raise TypeError("'set_name' should be a string.")
+
     # Check whether the set is in the complete sets or just a single dataset.
     if set_name in COMPLETE_SETS:
-        for dataset in COMPLETE_SETS[set_name]:
-            download_one_dataset(dataset=dataset, MD5_check=MD5_check,
-                                 verbose=verbose)
+        datasets = COMPLETE_SETS[set_name]
     elif set_name in ZENODO_COLLECTION:
         if verbose:
             print("You are downloading a single data set, which might not "
                   "contain all the data needed.")
-        download_one_dataset(dataset=set_name, MD5_check=MD5_check,
-                             verbose=verbose)
+        datasets = [set_name]
     else:
         raise KeyError(f"The dataset '{set_name}' is not defined.")
+
+    # Ask for confirmation before downloading.
+    print(f"About to download POSYDON data set '{set_name}' from Zenodo.")
+    response = input("Continue? [y/N] ").strip().lower()
+
+    if response not in ('y', 'yes'):
+        print("Download cancelled.")
+        return
+
+    for dataset in datasets:
+        download_one_dataset(
+            dataset=dataset,
+            MD5_check=MD5_check,
+            verbose=verbose
+        )
 
 def _get_posydon_data():
     """Run the data download or list the datasets

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -233,7 +233,7 @@ def data_download(set_name='DR2', MD5_check=True, confirm=False, verbose=False):
     print(f"About to download POSYDON data set '{set_name}' from Zenodo.")
     response = input("Continue? [y/N] ").strip().lower()
 
-    if response not in ('y', 'yes'):
+    if response not in ('y', 'yes'): # pragma: no cover
         print("Download cancelled.")
         return
 

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -233,8 +233,8 @@ def data_download(set_name='DR2', MD5_check=True, confirm=False, verbose=False):
     if confirm: # pragma: no cover
         print(f"About to download POSYDON data set '{set_name}' from Zenodo.")
         response = input("Continue? [y/N] ").strip().lower()
-    
-        if response not in ('y', 'yes'): 
+
+        if response not in ('y', 'yes'):
             print("Download cancelled.")
             return
 

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -230,12 +230,13 @@ def data_download(set_name='DR2', MD5_check=True, confirm=False, verbose=False):
         raise KeyError(f"The dataset '{set_name}' is not defined.")
 
     # Ask for confirmation before downloading.
-    print(f"About to download POSYDON data set '{set_name}' from Zenodo.")
-    response = input("Continue? [y/N] ").strip().lower()
-
-    if response not in ('y', 'yes'): # pragma: no cover
-        print("Download cancelled.")
-        return
+    if confirm: # pragma: no cover
+        print(f"About to download POSYDON data set '{set_name}' from Zenodo.")
+        response = input("Continue? [y/N] ").strip().lower()
+    
+        if response not in ('y', 'yes'): 
+            print("Download cancelled.")
+            return
 
     for dataset in datasets:
         download_one_dataset(


### PR DESCRIPTION
When a file is missing in `PATH_TO_POSYDON_DATA`, a `data_download` is triggered, but it doesn't say which file triggered it.

`Pwarn` messages have been added to now say which missing file caused the `data_download` call.

Maybe this would be better folded into a function, or into `data_download` itself?

Also add a prompt to confirm whether or not to proceed with the data download when a missing file triggers it.